### PR TITLE
Add Solana Oracle Gateway: Pyth price feed adapters

### DIFF
--- a/contracts/oracle/IAggregatorV3Interface.sol
+++ b/contracts/oracle/IAggregatorV3Interface.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Chainlink AggregatorV3Interface
+/// @notice Standard Chainlink interface for price feed consumers
+interface IAggregatorV3Interface {
+    function decimals() external view returns (uint8);
+    function description() external view returns (string memory);
+    function version() external view returns (uint256);
+
+    function getRoundData(uint80 _roundId) external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+}

--- a/contracts/oracle/PythAggregatorFactory.sol
+++ b/contracts/oracle/PythAggregatorFactory.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./PythAggregatorV3.sol";
+import "../interface.sol";
+
+/// @title PythAggregatorFactory
+/// @notice Deploys per-feed PythAggregatorV3 adapters and maintains an
+///         on-chain registry. Validates that the target account is owned
+///         by the Pyth program at deploy time.
+/// @dev Permissionless — anyone can create a feed, but the account must
+///      be owned by the configured Pyth program ID.
+contract PythAggregatorFactory {
+    bytes32 public immutable pythProgramId;
+
+    // On-chain registry
+    mapping(bytes32 => address) public feedAdapters; // pythPubkey => adapter
+    address[] public allAdapters;
+
+    event FeedCreated(
+        address indexed adapter,
+        bytes32 indexed pythAccount,
+        string description
+    );
+
+    /// @param _pythProgramId Pyth program ID for the target environment
+    ///        (devnet/testnet/mainnet). Immutable after deploy.
+    constructor(bytes32 _pythProgramId) {
+        pythProgramId = _pythProgramId;
+    }
+
+    /// @notice Deploy a new PythAggregatorV3 adapter for a Pyth price feed
+    /// @param pythAccountPubkey The Solana pubkey of the Pyth PriceAccount
+    /// @param desc Human-readable description (e.g. "BTC/USD")
+    /// @return The address of the deployed adapter contract
+    function createFeed(
+        bytes32 pythAccountPubkey,
+        string calldata desc
+    ) external returns (address) {
+        require(feedAdapters[pythAccountPubkey] == address(0), "Feed exists");
+
+        // Validate: account must be owned by Pyth program
+        (uint64 lamports, bytes32 owner,,,,) =
+            CpiProgram.account_info(pythAccountPubkey);
+        require(owner == pythProgramId, "Not a Pyth account");
+        require(lamports > 0, "Account does not exist");
+
+        // Deploy full adapter contract (no proxy — zero overhead per read)
+        PythAggregatorV3 adapter = new PythAggregatorV3(
+            pythAccountPubkey,
+            desc
+        );
+
+        feedAdapters[pythAccountPubkey] = address(adapter);
+        allAdapters.push(address(adapter));
+
+        emit FeedCreated(address(adapter), pythAccountPubkey, desc);
+        return address(adapter);
+    }
+
+    /// @notice Total number of deployed feed adapters
+    function totalFeeds() external view returns (uint256) {
+        return allAdapters.length;
+    }
+}

--- a/contracts/oracle/PythAggregatorV3.sol
+++ b/contracts/oracle/PythAggregatorV3.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IAggregatorV3Interface.sol";
+import "./PythParser.sol";
+import "../interface.sol";
+
+/// @title PythAggregatorV3
+/// @notice Per-feed adapter that reads a Pyth PriceAccount via Rome's CPI
+///         precompile and exposes it through the Chainlink AggregatorV3Interface.
+/// @dev Deployed by PythAggregatorFactory. One instance per Pyth price feed.
+contract PythAggregatorV3 is IAggregatorV3Interface {
+    bytes32 public immutable pythAccount;
+    string private _description;
+
+    constructor(bytes32 _pythAccount, string memory desc) {
+        pythAccount = _pythAccount;
+        _description = desc;
+    }
+
+    /// @notice Always 8 — prices are normalized to 10^-8
+    function decimals() external pure returns (uint8) {
+        return 8;
+    }
+
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+
+    /// @notice Returns the latest Pyth price normalized to 8 decimals
+    /// @dev Reads raw Pyth account data via CPI precompile, parses with
+    ///      PythParser, normalizes exponent, and maps to Chainlink fields.
+    ///      Reverts if the price is <= 0.
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        // Read raw Pyth account data via CPI precompile
+        (,,,,, bytes memory data) = CpiProgram.account_info(pythAccount);
+
+        // Parse with version-aware parser
+        (int64 price, , int32 expo, uint64 publishTime) = PythParser.parse(data);
+
+        // Revert on non-positive price
+        require(price > 0, "Negative price");
+
+        // Normalize to 8 decimals
+        answer = _normalize(price, expo);
+
+        // Map Pyth fields to Chainlink interface
+        // Pyth has no round concept; fixed value satisfies roundId != 0 checks
+        roundId = 1;
+        startedAt = uint256(publishTime);
+        updatedAt = uint256(publishTime);
+        answeredInRound = 1;
+    }
+
+    /// @notice Historical rounds are not supported by Pyth
+    function getRoundData(uint80) external pure returns (
+        uint80, int256, uint256, uint256, uint80
+    ) {
+        revert("Historical rounds not supported");
+    }
+
+    /// @notice Convenience: returns just the latest price
+    function latestAnswer() external view returns (int256) {
+        (, int256 answer,,,) = this.latestRoundData();
+        return answer;
+    }
+
+    /// @notice Convenience: returns just the latest timestamp
+    function latestTimestamp() external view returns (uint256) {
+        (,,, uint256 updatedAt,) = this.latestRoundData();
+        return updatedAt;
+    }
+
+    /// @notice Convenience: returns the latest round (always 1)
+    function latestRound() external pure returns (uint256) {
+        return 1;
+    }
+
+    /// @dev Normalize Pyth price (int64 * 10^expo) to 8 decimals (10^-8).
+    ///      answer = price * 10^(expo - targetExpo)
+    ///      Uses Solidity 0.8.x checked arithmetic for overflow safety.
+    function _normalize(int64 price, int32 expo) internal pure returns (int256) {
+        int256 scaledPrice = int256(price);
+        int32 targetExpo = -8;
+        int32 diff = expo - targetExpo; // e.g., expo=-5 → diff=3 → multiply
+
+        if (diff > 0) {
+            // Fewer decimals than target: multiply to add precision
+            scaledPrice = scaledPrice * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            // More decimals than target: divide (lossy truncation)
+            scaledPrice = scaledPrice / int256(10 ** uint32(-diff));
+        }
+        // diff == 0: already at 8 decimals
+
+        return scaledPrice;
+    }
+}

--- a/contracts/oracle/PythParser.sol
+++ b/contracts/oracle/PythParser.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../convert.sol";
+
+/// @title PythParser
+/// @notice Version-aware Borsh parser for Pyth PriceAccount data
+/// @dev Reuses Convert library for little-endian unsigned reads;
+///      adds signed readers for Pyth-specific fields.
+library PythParser {
+    uint32 constant PYTH_MAGIC = 0xa1b2c3d4;
+
+    error UnsupportedPythVersion(uint32 version);
+    error InvalidPythAccount();
+
+    /// @notice Parse Pyth PriceAccount data, version-aware
+    /// @param data Raw account data from account_info
+    /// @return price The aggregate price (int64)
+    /// @return conf The confidence interval (uint64)
+    /// @return expo The exponent (int32)
+    /// @return publishTime The publish timestamp (uint64)
+    function parse(bytes memory data) internal pure returns (
+        int64 price,
+        uint64 conf,
+        int32 expo,
+        uint64 publishTime
+    ) {
+        require(data.length >= 48, "Data too short");
+
+        // Read magic number (bytes 0-3, little-endian)
+        (uint32 magic,) = Convert.read_u32le(data, 0);
+        if (magic != PYTH_MAGIC) revert InvalidPythAccount();
+
+        // Read version (bytes 4-7, little-endian)
+        (uint32 ver,) = Convert.read_u32le(data, 4);
+
+        if (ver == 2) {
+            return parseV2(data);
+        } else {
+            revert UnsupportedPythVersion(ver);
+        }
+    }
+
+    /// @notice Parse Pyth V2 PriceAccount layout
+    /// @dev Layout (little-endian):
+    ///   [0..4]     magic (0xa1b2c3d4)
+    ///   [4..8]     version (2)
+    ///   [8..12]    account_type
+    ///   [12..16]   size
+    ///   [16..20]   price_type
+    ///   [20..24]   exponent (int32)
+    ///   [24..28]   num_component_prices
+    ///   [28..32]   num_quoters
+    ///   [32..40]   last_slot
+    ///   [40..48]   valid_slot
+    ///   ...
+    ///   [208..216] aggregate price (int64)
+    ///   [216..224] aggregate conf (uint64)
+    ///   [224..228] aggregate status (uint32)
+    ///   ...
+    ///   [232..240] publish_time (int64, treated as uint64)
+    ///
+    /// NOTE: Offsets are based on the Pyth V2 specification and MUST be
+    /// validated against a live Pyth account during deployment.
+    function parseV2(bytes memory data) private pure returns (
+        int64 price,
+        uint64 conf,
+        int32 expo,
+        uint64 publishTime
+    ) {
+        require(data.length >= 240, "V2 data too short");
+
+        // Exponent at offset 20 (int32, little-endian)
+        expo = _readInt32LE(data, 20);
+
+        // Aggregate price at offset 208 (int64, little-endian)
+        price = _readInt64LE(data, 208);
+
+        // Aggregate confidence at offset 216 (uint64, little-endian)
+        (conf,) = Convert.read_u64le(data, 216);
+
+        // Publish time at offset 232 (int64 as uint64, little-endian)
+        publishTime = uint64(_readInt64LE(data, 232));
+    }
+
+    // --- Signed little-endian readers ---
+    // Reuse Convert's unsigned LE reads and reinterpret as signed.
+
+    function _readInt32LE(bytes memory data, uint256 offset) private pure returns (int32) {
+        (uint32 val,) = Convert.read_u32le(data, offset);
+        return int32(val);
+    }
+
+    function _readInt64LE(bytes memory data, uint256 offset) private pure returns (int64) {
+        (uint64 val,) = Convert.read_u64le(data, offset);
+        return int64(val);
+    }
+}

--- a/contracts/oracle/examples/SampleLendingOracle.sol
+++ b/contracts/oracle/examples/SampleLendingOracle.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../IAggregatorV3Interface.sol";
+
+/// @title SampleLendingOracle
+/// @notice Example consumer demonstrating standard Chainlink-style usage
+///         of PythAggregatorV3 adapters for a lending protocol.
+contract SampleLendingOracle {
+    uint256 public constant MAX_STALENESS = 60; // 60 seconds
+
+    mapping(address => IAggregatorV3Interface) public priceFeeds;
+
+    function setPriceFeed(address token, address aggregator) external {
+        priceFeeds[token] = IAggregatorV3Interface(aggregator);
+    }
+
+    function getPrice(address token) public view returns (int256) {
+        IAggregatorV3Interface feed = priceFeeds[token];
+        require(address(feed) != address(0), "Feed not set");
+
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        // Standard Chainlink consumer checks
+        require(roundId > 0, "Invalid round");
+        require(answer > 0, "Invalid price");
+        require(updatedAt > 0, "Stale price");
+        require(answeredInRound >= roundId, "Stale round");
+        require(block.timestamp - updatedAt <= MAX_STALENESS, "Price too old");
+
+        return answer;
+    }
+
+    /// @notice Check if a position is liquidatable
+    function isLiquidatable(
+        address collateralToken,
+        address debtToken,
+        uint256 collateralAmount,
+        uint256 debtAmount,
+        uint256 liquidationThreshold // e.g., 8000 = 80%
+    ) external view returns (bool) {
+        int256 collateralPrice = getPrice(collateralToken);
+        int256 debtPrice = getPrice(debtToken);
+
+        // Both prices are 8 decimals
+        uint256 collateralValue = collateralAmount * uint256(collateralPrice);
+        uint256 debtValue = debtAmount * uint256(debtPrice);
+
+        return collateralValue * liquidationThreshold / 10000 < debtValue;
+    }
+}

--- a/contracts/oracle/test/NormalizerHarness.sol
+++ b/contracts/oracle/test/NormalizerHarness.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title NormalizerHarness
+/// @notice Exposes PythAggregatorV3's internal _normalize logic for unit testing.
+contract NormalizerHarness {
+    /// @dev Same logic as PythAggregatorV3._normalize
+    function normalize(int64 price, int32 expo) external pure returns (int256) {
+        int256 scaledPrice = int256(price);
+        int32 targetExpo = -8;
+        int32 diff = expo - targetExpo;
+
+        if (diff > 0) {
+            scaledPrice = scaledPrice * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            scaledPrice = scaledPrice / int256(10 ** uint32(-diff));
+        }
+
+        return scaledPrice;
+    }
+}

--- a/contracts/oracle/test/PythParserHarness.sol
+++ b/contracts/oracle/test/PythParserHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PythParser.sol";
+
+/// @title PythParserHarness
+/// @notice Test wrapper that exposes PythParser's internal library functions
+///         as external calls for unit testing.
+contract PythParserHarness {
+    function parse(bytes memory data) external pure returns (
+        int64 price,
+        uint64 conf,
+        int32 expo,
+        uint64 publishTime
+    ) {
+        return PythParser.parse(data);
+    }
+}

--- a/deployments/monti_spl.json
+++ b/deployments/monti_spl.json
@@ -15,5 +15,25 @@
       "txHash": "0xd0259a0ba944b6d2e459fec27ec618f03fb8b8cbafd8cb0ee4cd6d0cb45b2b24",
       "blockNumber": "1550"
     }
+  ],
+  "PythAggregatorFactory": {
+    "address": "0x05382ec336f797fcbeddcb0fef8288fb4f26e072"
+  },
+  "PythAggregatorFeeds": [
+    {
+      "pair": "SOL/USD",
+      "pythAccountBase58": "J83w4HKfqxwcq3BEMMkPFSppX3gqekLyLJBexebFVkix",
+      "adapter": "0x170dDC928429FC1A55Dc31c7f5793fc1b2Afea08"
+    },
+    {
+      "pair": "BTC/USD",
+      "pythAccount": "0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b",
+      "adapter": "0xaF9b0a1F94FAa8d36F67a6057cd9aC0Aa16BCa07"
+    },
+    {
+      "pair": "ETH/USD",
+      "pythAccount": "0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6",
+      "adapter": "0x8a67386F90b5422D3B61e9a5e4BD1986A216D98D"
+    }
   ]
 }

--- a/scripts/oracle/deploy-and-test.ts
+++ b/scripts/oracle/deploy-and-test.ts
@@ -1,0 +1,176 @@
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import { toHex } from "viem";
+
+/**
+ * Deploy PythAggregatorFactory to monti_spl and create a feed adapter
+ * for a real Pyth devnet price account.
+ */
+
+async function main() {
+    const { viem, networkName } = await hardhat.network.connect();
+    const [deployer] = await viem.getWalletClients();
+    if (!deployer?.account) {
+        throw new Error("No deployer wallet. Set MONTI_SPL_PRIVATE_KEY.");
+    }
+
+    const publicClient = await viem.getPublicClient();
+    const balance = await publicClient.getBalance({ address: deployer.account.address });
+    console.log("Deployer:", deployer.account.address);
+    console.log("Balance:", balance.toString());
+
+    // ─── Step 1: Convert Pyth devnet program ID to bytes32 ───
+    // gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s
+    // We use the SystemProgram precompile to convert base58 → bytes32
+    const systemProgram = await viem.getContractAt(
+        "ISystemProgram",
+        "0xfF00000000000000000000000000000000000007",
+    );
+
+    const pythProgramId = await systemProgram.read.base58_to_bytes32([
+        toHex(Buffer.from("gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s")),
+    ]);
+    console.log("Pyth Program ID (bytes32):", pythProgramId);
+
+    // ─── Step 2: Deploy PythAggregatorFactory ───
+    console.log("\nDeploying PythAggregatorFactory...");
+    const factory = await viem.deployContract("PythAggregatorFactory", [pythProgramId]);
+    console.log("Factory deployed to:", factory.address);
+
+    // Verify factory state
+    const storedProgramId = await factory.read.pythProgramId();
+    console.log("Factory pythProgramId:", storedProgramId);
+    console.log("Matches:", storedProgramId === pythProgramId);
+
+    const totalBefore = await factory.read.totalFeeds();
+    console.log("Total feeds before:", totalBefore.toString());
+
+    // ─── Step 3: Find a Pyth devnet price feed ───
+    // Pyth devnet BTC/USD price account: GVXRSBjFk6e6J3NbVPXbvDBth43bQuVBMi5Bia4aDwXF
+    // Pyth devnet SOL/USD price account: J83w4HKfqxwcq3BEMMkPFSppX3gqekLyLJBexebFVkix
+    // Let's use SOL/USD since it's commonly active on devnet
+    const solUsdFeedBase58 = "J83w4HKfqxwcq3BEMMkPFSppX3gqekLyLJBexebFVkix";
+    const solUsdPubkey = await systemProgram.read.base58_to_bytes32([
+        toHex(Buffer.from(solUsdFeedBase58)),
+    ]);
+    console.log("\nSOL/USD Pyth pubkey (bytes32):", solUsdPubkey);
+
+    // ─── Step 4: Create feed adapter ───
+    console.log("\nCreating SOL/USD feed adapter...");
+    const txHash = await factory.write.createFeed([solUsdPubkey, "SOL/USD"]);
+    console.log("createFeed tx:", txHash);
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    console.log("Status:", receipt.status);
+
+    const adapterAddress = await factory.read.feedAdapters([solUsdPubkey]);
+    console.log("SOL/USD adapter deployed to:", adapterAddress);
+
+    const totalAfter = await factory.read.totalFeeds();
+    console.log("Total feeds after:", totalAfter.toString());
+
+    // ─── Step 5: Read price via the adapter ───
+    const adapter = await viem.getContractAt(
+        "PythAggregatorV3",
+        adapterAddress as `0x${string}`,
+    );
+
+    console.log("\n=== SOL/USD Adapter ===");
+    console.log("Description:", await adapter.read.description());
+    console.log("Decimals:", await adapter.read.decimals());
+    console.log("Version:", (await adapter.read.version()).toString());
+
+    const [roundId, answer, startedAt, updatedAt, answeredInRound] =
+        await adapter.read.latestRoundData();
+
+    console.log("\nlatestRoundData():");
+    console.log("  roundId:", roundId.toString());
+    console.log("  answer:", answer.toString(), `($${Number(answer) / 1e8})`);
+    console.log("  startedAt:", startedAt.toString(), `(${new Date(Number(startedAt) * 1000).toISOString()})`);
+    console.log("  updatedAt:", updatedAt.toString(), `(${new Date(Number(updatedAt) * 1000).toISOString()})`);
+    console.log("  answeredInRound:", answeredInRound.toString());
+
+    const latestAnswer = await adapter.read.latestAnswer();
+    console.log("\nlatestAnswer():", latestAnswer.toString(), `($${Number(latestAnswer) / 1e8})`);
+
+    const latestTs = await adapter.read.latestTimestamp();
+    console.log("latestTimestamp():", latestTs.toString());
+
+    const latestRound = await adapter.read.latestRound();
+    console.log("latestRound():", latestRound.toString());
+
+    // ─── Step 6: Try BTC/USD too ───
+    const btcUsdFeedBase58 = "HovQMDrbAgAYPCmHVSrezcSmkMtXSSUsLDFANExrZh2J";
+    const btcUsdPubkey = await systemProgram.read.base58_to_bytes32([
+        toHex(Buffer.from(btcUsdFeedBase58)),
+    ]);
+    console.log("\n\nCreating BTC/USD feed adapter...");
+    const btcTxHash = await factory.write.createFeed([btcUsdPubkey, "BTC/USD"]);
+    const btcReceipt = await publicClient.waitForTransactionReceipt({ hash: btcTxHash });
+    console.log("Status:", btcReceipt.status);
+
+    const btcAdapterAddress = await factory.read.feedAdapters([btcUsdPubkey]);
+    const btcAdapter = await viem.getContractAt(
+        "PythAggregatorV3",
+        btcAdapterAddress as `0x${string}`,
+    );
+
+    console.log("\n=== BTC/USD Adapter ===");
+    console.log("Description:", await btcAdapter.read.description());
+
+    const [, btcAnswer, , btcUpdatedAt] = await btcAdapter.read.latestRoundData();
+    console.log("Price:", btcAnswer.toString(), `($${Number(btcAnswer) / 1e8})`);
+    console.log("Updated:", new Date(Number(btcUpdatedAt) * 1000).toISOString());
+
+    // ─── Step 7: Verify duplicate prevention ───
+    console.log("\n\nVerifying duplicate feed prevention...");
+    try {
+        await factory.write.createFeed([solUsdPubkey, "SOL/USD duplicate"]);
+        console.log("ERROR: Should have reverted!");
+    } catch (e: any) {
+        console.log("Correctly reverted on duplicate:", e.message?.slice(0, 80));
+    }
+
+    // ─── Step 8: Verify getRoundData reverts ───
+    console.log("\nVerifying getRoundData reverts...");
+    try {
+        await adapter.read.getRoundData([1]);
+        console.log("ERROR: Should have reverted!");
+    } catch (e: any) {
+        console.log("Correctly reverted:", e.message?.slice(0, 80));
+    }
+
+    // ─── Save deployment ───
+    const deploymentsDir = path.resolve(process.cwd(), "deployments");
+    const filePath = path.resolve(deploymentsDir, `${networkName}.json`);
+    let content: any = {};
+    if (fs.existsSync(filePath)) {
+        content = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    }
+
+    content.PythAggregatorFactory = {
+        address: factory.address,
+        pythProgramId: pythProgramId,
+    };
+    content.PythAggregatorFeeds = [
+        {
+            pair: "SOL/USD",
+            pythAccount: solUsdPubkey,
+            adapter: adapterAddress,
+        },
+        {
+            pair: "BTC/USD",
+            pythAccount: btcUsdPubkey,
+            adapter: btcAdapterAddress,
+        },
+    ];
+
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");
+    console.log("\nDeployment saved to:", filePath);
+    console.log("\n✓ All done!");
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/oracle/deploy-factory.ts
+++ b/scripts/oracle/deploy-factory.ts
@@ -1,0 +1,57 @@
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+
+async function main() {
+    const pythProgramId = process.env.PYTH_PROGRAM_ID;
+    if (!pythProgramId) {
+        throw new Error(
+            "PYTH_PROGRAM_ID env var required (bytes32 hex of Pyth program pubkey)",
+        );
+    }
+
+    const { viem, networkName } = await hardhat.network.connect();
+    const [deployer] = await viem.getWalletClients();
+    if (!deployer?.account) {
+        throw new Error(
+            "No deployer wallet found. Configure a funded account for this network.",
+        );
+    }
+
+    const publicClient = await viem.getPublicClient();
+
+    console.log("Deploying PythAggregatorFactory with account:", deployer.account.address);
+    console.log(
+        "Account balance:",
+        (await publicClient.getBalance({ address: deployer.account.address })).toString(),
+    );
+    console.log("Pyth Program ID:", pythProgramId);
+
+    const factory = await viem.deployContract("PythAggregatorFactory", [
+        pythProgramId as `0x${string}`,
+    ]);
+    console.log("PythAggregatorFactory deployed to:", factory.address);
+
+    // Save deployment
+    const deploymentsDir = path.resolve(process.cwd(), "deployments");
+    fs.mkdirSync(deploymentsDir, { recursive: true });
+
+    const filePath = path.resolve(deploymentsDir, `${networkName}.json`);
+    let content: any = {};
+    if (fs.existsSync(filePath)) {
+        content = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    }
+
+    content.PythAggregatorFactory = {
+        address: factory.address,
+        pythProgramId,
+    };
+
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");
+    console.log("Saved deployment to:", filePath);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/oracle/test-feeds.ts
+++ b/scripts/oracle/test-feeds.ts
@@ -1,0 +1,182 @@
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import { toHex } from "viem";
+
+/**
+ * Test oracle feeds on monti_spl. Uses existing factory deployment
+ * or deploys a new one. Creates BTC/USD and ETH/USD feed adapters
+ * and runs full verification.
+ */
+
+const FACTORY_ADDRESS = "0x05382ec336f797fcbeddcb0fef8288fb4f26e072";
+const SOL_ADAPTER_ADDRESS = "0x170dDC928429FC1A55Dc31c7f5793fc1b2Afea08";
+
+// Pyth devnet v1 price accounts (owned by gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s)
+const FEEDS = {
+    "BTC/USD": "HovQMDrbAgAYPCmHVSrezcSmkMtXSSUsLDFANExrZh2J",
+    "ETH/USD": "EdVCmQ9FSPcVe5YySXDPCRmc8aDQLKJ9xvYBMZPie1Vw",
+};
+
+async function main() {
+    const { viem, networkName } = await hardhat.network.connect();
+    const publicClient = await viem.getPublicClient();
+
+    const systemProgram = await viem.getContractAt(
+        "ISystemProgram",
+        "0xfF00000000000000000000000000000000000007",
+    );
+
+    const factory = await viem.getContractAt(
+        "PythAggregatorFactory",
+        FACTORY_ADDRESS,
+    );
+
+    console.log("Factory:", FACTORY_ADDRESS);
+    console.log("Total feeds:", (await factory.read.totalFeeds()).toString());
+
+    // ─── Test existing SOL/USD adapter ───
+    console.log("\n=== SOL/USD (existing) ===");
+    const solAdapter = await viem.getContractAt("PythAggregatorV3", SOL_ADAPTER_ADDRESS);
+    await printAdapterState(solAdapter);
+
+    // ─── Create new feeds ───
+    const deployedFeeds: { pair: string; pubkey: string; adapter: string }[] = [];
+
+    for (const [pair, base58] of Object.entries(FEEDS)) {
+        console.log(`\n=== Creating ${pair} ===`);
+        const pubkey = await systemProgram.read.base58_to_bytes32([
+            toHex(Buffer.from(base58)),
+        ]);
+        console.log("Pubkey (bytes32):", pubkey);
+
+        // Check if already exists
+        const existing = await factory.read.feedAdapters([pubkey]);
+        if (existing !== "0x0000000000000000000000000000000000000000") {
+            console.log("Already deployed at:", existing);
+            const adapter = await viem.getContractAt("PythAggregatorV3", existing);
+            await printAdapterState(adapter);
+            deployedFeeds.push({ pair, pubkey, adapter: existing });
+            continue;
+        }
+
+        const txHash = await factory.write.createFeed([pubkey, pair]);
+        console.log("Tx:", txHash);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        console.log("Status:", receipt.status);
+
+        const adapterAddr = await factory.read.feedAdapters([pubkey]);
+        console.log("Adapter:", adapterAddr);
+
+        const adapter = await viem.getContractAt("PythAggregatorV3", adapterAddr as `0x${string}`);
+        await printAdapterState(adapter);
+        deployedFeeds.push({ pair, pubkey, adapter: adapterAddr as string });
+    }
+
+    console.log("\nTotal feeds:", (await factory.read.totalFeeds()).toString());
+
+    // ─── Verification tests ───
+    console.log("\n=== Verification Tests ===");
+
+    // Test 1: Duplicate prevention
+    console.log("\n1. Duplicate feed prevention:");
+    const solPubkey = await systemProgram.read.base58_to_bytes32([
+        toHex(Buffer.from("J83w4HKfqxwcq3BEMMkPFSppX3gqekLyLJBexebFVkix")),
+    ]);
+    try {
+        await factory.write.createFeed([solPubkey, "SOL/USD dup"]);
+        console.log("   FAIL: should have reverted");
+    } catch (e: any) {
+        console.log("   PASS: reverted with:", e.cause?.reason ?? e.message?.slice(0, 60));
+    }
+
+    // Test 2: getRoundData reverts
+    console.log("\n2. getRoundData reverts:");
+    const solAdapter2 = await viem.getContractAt("PythAggregatorV3", SOL_ADAPTER_ADDRESS);
+    try {
+        await solAdapter2.read.getRoundData([1]);
+        console.log("   FAIL: should have reverted");
+    } catch (e: any) {
+        console.log("   PASS: reverted with:", e.cause?.reason ?? e.message?.slice(0, 60));
+    }
+
+    // Test 3: Non-Pyth account rejection
+    console.log("\n3. Non-Pyth account rejection:");
+    // Use a random system account that isn't owned by Pyth
+    const fakePubkey = "0x0000000000000000000000000000000000000000000000000000000000000001" as `0x${string}`;
+    try {
+        await factory.write.createFeed([fakePubkey, "FAKE"]);
+        console.log("   FAIL: should have reverted");
+    } catch (e: any) {
+        console.log("   PASS: reverted with:", e.cause?.reason ?? e.message?.slice(0, 60));
+    }
+
+    // Test 4: Interface compliance — all Chainlink fields present
+    console.log("\n4. Chainlink interface compliance:");
+    const [roundId, answer, startedAt, updatedAt, answeredInRound] =
+        await solAdapter2.read.latestRoundData();
+    const checks = [
+        ["roundId > 0", roundId > 0],
+        ["answer > 0", answer > 0n],
+        ["updatedAt > 0", updatedAt > 0n],
+        ["answeredInRound >= roundId", answeredInRound >= roundId],
+        ["decimals == 8", (await solAdapter2.read.decimals()) === 8],
+        ["version == 1", (await solAdapter2.read.version()) === 1n],
+        ["description non-empty", (await solAdapter2.read.description()).length > 0],
+        ["latestRound == 1", (await solAdapter2.read.latestRound()) === 1n],
+    ];
+    for (const [name, ok] of checks) {
+        console.log(`   ${ok ? "PASS" : "FAIL"}: ${name}`);
+    }
+
+    // Test 5: latestAnswer matches latestRoundData
+    console.log("\n5. Consistency check:");
+    const la = await solAdapter2.read.latestAnswer();
+    const lt = await solAdapter2.read.latestTimestamp();
+    console.log(`   latestAnswer: ${la} === answer: ${answer} → ${la === answer ? "PASS" : "FAIL"}`);
+    console.log(`   latestTimestamp: ${lt} === updatedAt: ${updatedAt} → ${lt === updatedAt ? "PASS" : "FAIL"}`);
+
+    // ─── Save deployments ───
+    const deploymentsDir = path.resolve(process.cwd(), "deployments");
+    const filePath = path.resolve(deploymentsDir, `${networkName}.json`);
+    let content: any = {};
+    if (fs.existsSync(filePath)) {
+        content = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    }
+
+    content.PythAggregatorFactory = { address: FACTORY_ADDRESS };
+    content.PythAggregatorFeeds = [
+        {
+            pair: "SOL/USD",
+            pythAccountBase58: "J83w4HKfqxwcq3BEMMkPFSppX3gqekLyLJBexebFVkix",
+            adapter: SOL_ADAPTER_ADDRESS,
+        },
+        ...deployedFeeds.map((f) => ({
+            pair: f.pair,
+            pythAccount: f.pubkey,
+            adapter: f.adapter,
+        })),
+    ];
+
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");
+    console.log("\nDeployments saved to:", filePath);
+    console.log("\nDone.");
+}
+
+async function printAdapterState(adapter: any) {
+    const desc = await adapter.read.description();
+    const decimals = await adapter.read.decimals();
+
+    const [roundId, answer, , updatedAt, answeredInRound] =
+        await adapter.read.latestRoundData();
+
+    console.log(`  ${desc} | decimals=${decimals}`);
+    console.log(`  price: $${Number(answer) / 1e8} (raw: ${answer})`);
+    console.log(`  roundId=${roundId} answeredInRound=${answeredInRound}`);
+    console.log(`  updatedAt: ${updatedAt} (${new Date(Number(updatedAt) * 1000).toISOString()})`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/oracle/Normalizer.test.ts
+++ b/tests/oracle/Normalizer.test.ts
@@ -1,0 +1,104 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+describe("PythAggregatorV3 _normalize", function () {
+    let normalizer: any;
+
+    before(async function () {
+        const { viem } = await hardhat.network.connect();
+        normalizer = await viem.deployContract("NormalizerHarness", []);
+    });
+
+    // ──────────────────────────────────────────────
+    // Same exponent (no scaling)
+    // ──────────────────────────────────────────────
+
+    it("no-op when expo is already -8", async function () {
+        // price=6543210000000 at expo=-8 → 6543210000000 (unchanged)
+        const result = await normalizer.read.normalize([
+            6543210000000n,
+            -8,
+        ]);
+        assert.equal(result, 6543210000000n);
+    });
+
+    // ──────────────────────────────────────────────
+    // Scale up (multiply — fewer decimals → more)
+    // ──────────────────────────────────────────────
+
+    it("scales up from expo=-5 to -8 (multiply by 1000)", async function () {
+        // price=123456 at expo=-5 → 123456 * 10^3 = 123456000
+        const result = await normalizer.read.normalize([123456n, -5]);
+        assert.equal(result, 123456000n);
+    });
+
+    it("scales up from expo=-2 to -8 (multiply by 10^6)", async function () {
+        // price=100 at expo=-2 → 100 * 10^6 = 100000000
+        // This represents $1.00 → 100000000 in 8 decimals
+        const result = await normalizer.read.normalize([100n, -2]);
+        assert.equal(result, 100000000n);
+    });
+
+    it("scales up from expo=0 to -8 (multiply by 10^8)", async function () {
+        // price=42 at expo=0 → 42 * 10^8 = 4200000000
+        const result = await normalizer.read.normalize([42n, 0]);
+        assert.equal(result, 4200000000n);
+    });
+
+    it("scales up from expo=2 to -8 (multiply by 10^10)", async function () {
+        // price=1 at expo=2 → 1 * 10^10 = 10000000000
+        const result = await normalizer.read.normalize([1n, 2]);
+        assert.equal(result, 10000000000n);
+    });
+
+    // ──────────────────────────────────────────────
+    // Scale down (divide — more decimals → fewer, lossy)
+    // ──────────────────────────────────────────────
+
+    it("scales down from expo=-10 to -8 (divide by 100)", async function () {
+        // price=12345678900 at expo=-10 → 12345678900 / 100 = 123456789
+        const result = await normalizer.read.normalize([
+            12345678900n,
+            -10,
+        ]);
+        assert.equal(result, 123456789n);
+    });
+
+    it("scales down from expo=-12 to -8 (divide by 10^4)", async function () {
+        // price=5000000000000 at expo=-12 → 5000000000000 / 10000 = 500000000
+        const result = await normalizer.read.normalize([
+            5000000000000n,
+            -12,
+        ]);
+        assert.equal(result, 500000000n);
+    });
+
+    it("lossy division truncates toward zero", async function () {
+        // price=999 at expo=-10 → 999 / 100 = 9 (truncated from 9.99)
+        const result = await normalizer.read.normalize([999n, -10]);
+        assert.equal(result, 9n);
+    });
+
+    // ──────────────────────────────────────────────
+    // Edge cases
+    // ──────────────────────────────────────────────
+
+    it("handles price=1 at various exponents", async function () {
+        // 1 at expo=-8 = 1 (0.00000001 in 8 decimals)
+        assert.equal(
+            await normalizer.read.normalize([1n, -8]),
+            1n,
+        );
+        // 1 at expo=0 = 100000000 ($1 in 8 decimals)
+        assert.equal(
+            await normalizer.read.normalize([1n, 0]),
+            100000000n,
+        );
+    });
+
+    it("handles negative price (parser allows, adapter would revert)", async function () {
+        const result = await normalizer.read.normalize([-500n, -5]);
+        assert.equal(result, -500000n);
+    });
+});

--- a/tests/oracle/PythParser.test.ts
+++ b/tests/oracle/PythParser.test.ts
@@ -1,0 +1,250 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythV2Account } from "./helpers/mockPyth.js";
+
+describe("PythParser", function () {
+    let parser: any;
+
+    before(async function () {
+        const { viem } = await hardhat.network.connect();
+        parser = await viem.deployContract("PythParserHarness", []);
+    });
+
+    // ──────────────────────────────────────────────
+    // Happy-path V2 parsing
+    // ──────────────────────────────────────────────
+
+    it("parses V2 BTC/USD correctly (expo=-8)", async function () {
+        const mockData = buildPythV2Account({
+            price: 6543210000000n, // $65,432.10 at expo=-8
+            conf: 1500000n,
+            expo: -8,
+            publishTime: 1711900800,
+        });
+
+        const [price, conf, expo, publishTime] = await parser.read.parse([
+            mockData,
+        ]);
+
+        assert.equal(price, 6543210000000n);
+        assert.equal(conf, 1500000n);
+        assert.equal(expo, -8);
+        assert.equal(publishTime, 1711900800n);
+    });
+
+    it("parses V2 ETH/USD correctly (expo=-8)", async function () {
+        const mockData = buildPythV2Account({
+            price: 300000000000n, // $3,000.00 at expo=-8
+            conf: 50000000n,
+            expo: -8,
+            publishTime: 1711900900,
+        });
+
+        const [price, conf, expo, publishTime] = await parser.read.parse([
+            mockData,
+        ]);
+
+        assert.equal(price, 300000000000n);
+        assert.equal(conf, 50000000n);
+        assert.equal(expo, -8);
+        assert.equal(publishTime, 1711900900n);
+    });
+
+    it("parses feed with non-8 exponent (expo=-5)", async function () {
+        const mockData = buildPythV2Account({
+            price: 123456n, // 1.23456 at expo=-5
+            conf: 100n,
+            expo: -5,
+            publishTime: 1711901000,
+        });
+
+        const [price, , expo] = await parser.read.parse([mockData]);
+
+        assert.equal(price, 123456n);
+        assert.equal(expo, -5);
+    });
+
+    it("parses feed with positive exponent (expo=2)", async function () {
+        const mockData = buildPythV2Account({
+            price: 42n, // 4200 at expo=2
+            conf: 1n,
+            expo: 2,
+            publishTime: 1711901100,
+        });
+
+        const [price, , expo] = await parser.read.parse([mockData]);
+
+        assert.equal(price, 42n);
+        assert.equal(expo, 2);
+    });
+
+    it("handles negative price (parser returns it; adapter would revert)", async function () {
+        const mockData = buildPythV2Account({
+            price: -500n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711901200,
+        });
+
+        const [price] = await parser.read.parse([mockData]);
+        assert.equal(price, -500n);
+    });
+
+    it("handles zero price", async function () {
+        const mockData = buildPythV2Account({
+            price: 0n,
+            conf: 0n,
+            expo: -8,
+            publishTime: 1711901300,
+        });
+
+        const [price] = await parser.read.parse([mockData]);
+        assert.equal(price, 0n);
+    });
+
+    it("handles large price values near int64 max", async function () {
+        const int64Max = (1n << 63n) - 1n; // 9223372036854775807
+        const mockData = buildPythV2Account({
+            price: int64Max,
+            conf: 0n,
+            expo: -8,
+            publishTime: 1711901400,
+        });
+
+        const [price] = await parser.read.parse([mockData]);
+        assert.equal(price, int64Max);
+    });
+
+    it("handles large confidence values", async function () {
+        const largeConf = (1n << 63n) - 1n;
+        const mockData = buildPythV2Account({
+            price: 100n,
+            conf: largeConf,
+            expo: -8,
+            publishTime: 1711901500,
+        });
+
+        const [, conf] = await parser.read.parse([mockData]);
+        assert.equal(conf, largeConf);
+    });
+
+    // ──────────────────────────────────────────────
+    // Error cases
+    // ──────────────────────────────────────────────
+
+    it("reverts on unknown version (version=3)", async function () {
+        const mockData = buildPythV2Account({
+            version: 3,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711901600,
+        });
+
+        await assert.rejects(
+            async () => parser.read.parse([mockData]),
+            (err: any) => {
+                // Check for UnsupportedPythVersion custom error
+                assert.ok(
+                    err.message.includes("UnsupportedPythVersion") ||
+                        err.message.includes("revert"),
+                    `Expected UnsupportedPythVersion, got: ${err.message}`,
+                );
+                return true;
+            },
+        );
+    });
+
+    it("reverts on invalid magic number", async function () {
+        const mockData = buildPythV2Account({
+            magic: 0xdeadbeef,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711901700,
+        });
+
+        await assert.rejects(
+            async () => parser.read.parse([mockData]),
+            (err: any) => {
+                assert.ok(
+                    err.message.includes("InvalidPythAccount") ||
+                        err.message.includes("revert"),
+                    `Expected InvalidPythAccount, got: ${err.message}`,
+                );
+                return true;
+            },
+        );
+    });
+
+    it("reverts on data too short (< 48 bytes)", async function () {
+        const shortData = "0x" + "00".repeat(32);
+
+        await assert.rejects(
+            async () => parser.read.parse([shortData as `0x${string}`]),
+            (err: any) => {
+                assert.ok(
+                    err.message.includes("Data too short") ||
+                        err.message.includes("revert"),
+                    `Expected Data too short, got: ${err.message}`,
+                );
+                return true;
+            },
+        );
+    });
+
+    it("reverts on V2 data too short (>= 48 but < 240 bytes)", async function () {
+        // Valid magic and version but not enough bytes for V2 fields
+        const buf = new Uint8Array(100);
+        // Write magic LE
+        buf[0] = 0xd4;
+        buf[1] = 0xc3;
+        buf[2] = 0xb2;
+        buf[3] = 0xa1;
+        // Write version 2 LE
+        buf[4] = 0x02;
+
+        const hex =
+            "0x" +
+            Array.from(buf)
+                .map((b) => b.toString(16).padStart(2, "0"))
+                .join("");
+
+        await assert.rejects(
+            async () => parser.read.parse([hex as `0x${string}`]),
+            (err: any) => {
+                assert.ok(
+                    err.message.includes("V2 data too short") ||
+                        err.message.includes("revert"),
+                    `Expected V2 data too short, got: ${err.message}`,
+                );
+                return true;
+            },
+        );
+    });
+
+    it("reverts on version 0", async function () {
+        const mockData = buildPythV2Account({
+            version: 0,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711901800,
+        });
+
+        await assert.rejects(async () => parser.read.parse([mockData]));
+    });
+
+    it("reverts on version 1", async function () {
+        const mockData = buildPythV2Account({
+            version: 1,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711901900,
+        });
+
+        await assert.rejects(async () => parser.read.parse([mockData]));
+    });
+});

--- a/tests/oracle/helpers/mockPyth.ts
+++ b/tests/oracle/helpers/mockPyth.ts
@@ -1,0 +1,78 @@
+/**
+ * Mock Pyth V2 PriceAccount builder for testing PythParser.
+ *
+ * Constructs byte arrays matching the Pyth V2 PriceAccount layout:
+ *   [0..4]     magic (0xa1b2c3d4, LE)
+ *   [4..8]     version (2, LE)
+ *   [20..24]   exponent (int32, LE)
+ *   [208..216] aggregate price (int64, LE)
+ *   [216..224] aggregate confidence (uint64, LE)
+ *   [232..240] publish_time (int64, LE)
+ */
+
+export interface PythV2AccountParams {
+    magic?: number;
+    version?: number;
+    price: bigint;
+    conf: bigint;
+    expo: number;
+    publishTime: number;
+}
+
+function writeUint32LE(buf: Uint8Array, offset: number, value: number): void {
+    buf[offset] = value & 0xff;
+    buf[offset + 1] = (value >>> 8) & 0xff;
+    buf[offset + 2] = (value >>> 16) & 0xff;
+    buf[offset + 3] = (value >>> 24) & 0xff;
+}
+
+function writeInt32LE(buf: Uint8Array, offset: number, value: number): void {
+    // Convert signed to unsigned 32-bit representation
+    writeUint32LE(buf, offset, value < 0 ? value + 0x100000000 : value);
+}
+
+function writeInt64LE(buf: Uint8Array, offset: number, value: bigint): void {
+    // Convert signed to unsigned 64-bit representation
+    const unsigned = value < 0n ? value + (1n << 64n) : value;
+    for (let i = 0; i < 8; i++) {
+        buf[offset + i] = Number((unsigned >> BigInt(i * 8)) & 0xffn);
+    }
+}
+
+function writeUint64LE(buf: Uint8Array, offset: number, value: bigint): void {
+    for (let i = 0; i < 8; i++) {
+        buf[offset + i] = Number((value >> BigInt(i * 8)) & 0xffn);
+    }
+}
+
+/**
+ * Build a mock Pyth V2 PriceAccount byte array.
+ * Returns a hex string prefixed with 0x, suitable for passing to Solidity.
+ */
+export function buildPythV2Account(params: PythV2AccountParams): `0x${string}` {
+    const buf = new Uint8Array(240); // Minimum size for V2
+
+    // Magic at offset 0
+    writeUint32LE(buf, 0, params.magic ?? 0xa1b2c3d4);
+
+    // Version at offset 4
+    writeUint32LE(buf, 4, params.version ?? 2);
+
+    // Exponent at offset 20 (int32)
+    writeInt32LE(buf, 20, params.expo);
+
+    // Aggregate price at offset 208 (int64)
+    writeInt64LE(buf, 208, params.price);
+
+    // Aggregate confidence at offset 216 (uint64)
+    writeUint64LE(buf, 216, params.conf);
+
+    // Publish time at offset 232 (int64)
+    writeInt64LE(buf, 232, BigInt(params.publishTime));
+
+    // Convert to hex string
+    const hex = Array.from(buf)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+    return `0x${hex}`;
+}


### PR DESCRIPTION
## Summary

- Implements Chainlink-compatible `AggregatorV3Interface` adapters that read Pyth price feeds from Solana via Rome's CPI precompile (`0xFF...08`)
- Permissionless `PythAggregatorFactory` with on-chain registry and Pyth program ownership validation at deploy time
- Version-aware Borsh parser (`PythParser`) reusing existing `Convert` library for little-endian reads
- 24 unit tests passing (PythParser + normalization), plus full integration verification on monti_spl devnet

## Contracts

| Contract | Role |
|----------|------|
| `PythAggregatorFactory` | Deploys per-feed adapters, validates Pyth ownership, maintains registry |
| `PythAggregatorV3` | Per-feed adapter: `latestRoundData()` with 8-decimal normalization |
| `PythParser` | Version-aware Borsh parser for Pyth V2 PriceAccount data |
| `IAggregatorV3Interface` | Standard Chainlink interface |
| `SampleLendingOracle` | Example consumer with staleness checks |

## Devnet Deployment (monti_spl)

| Feed | Adapter Address | Live Price |
|------|----------------|------------|
| SOL/USD | `0x170dDC928429FC1A55Dc31c7f5793fc1b2Afea08` | $139.82 |
| BTC/USD | `0xaF9b0a1F94FAa8d36F67a6057cd9aC0Aa16BCa07` | $59,553.48 |
| ETH/USD | `0x8a67386F90b5422D3B61e9a5e4BD1986A216D98D` | $2,529.67 |

Factory: `0x05382ec336f797fcbeddcb0fef8288fb4f26e072`

## Spec deviation

Fixed `_normalize` sign error in the spec: `diff = expo - targetExpo` (not `targetExpo - expo`), which was inverting multiply/divide. Caught by unit tests.

## Test plan

- [x] 14 PythParser unit tests (V2 parsing, edge cases, reverts on bad magic/version/length)
- [x] 10 Normalizer unit tests (scale up/down/no-op, lossy truncation, negative prices)
- [x] Deploy factory to monti_spl devnet
- [x] Create SOL/USD, BTC/USD, ETH/USD feed adapters with live Pyth data
- [x] Verify duplicate prevention, getRoundData revert, non-Pyth account rejection
- [x] Verify Chainlink interface compliance (all field checks pass)
- [ ] Verify Pyth V2 byte offsets against dumped live account (open item from spec)
- [ ] Gas profiling on local stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)