### PR TITLE
Update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-rome-solidity is a Solidity smart contract repo for SPL/EVM cross-program interaction within the Rome-EVM program stack. It provides ERC20 wrappers for SPL tokens and a Meteora DAMM v1 AMM integration, all running on Solana via Rome-EVM precompiles.
+rome-solidity is a Solidity smart contract repo for SPL/EVM cross-program interaction within the Rome-EVM program stack. It provides ERC20 wrappers for SPL tokens, a Meteora DAMM v1 AMM integration, and an Oracle Gateway for Pyth price feeds, all running on Solana via Rome-EVM precompiles.
 
 ## Build & Test Commands
 
@@ -14,6 +14,10 @@ npx hardhat compile        # compile all contracts (Solidity 0.8.28)
 
 # Run tests (requires local Rome-EVM node or monti_spl network)
 npx hardhat test tests/damm_v1_pool.integration.ts --network local
+
+# Run oracle tests (uses hardhat mainnet fork)
+npx hardhat test tests/pyth_parser.test.ts
+npx hardhat test tests/normalizer.test.ts
 
 # Deploy (requires env vars or hardhat keystore)
 npx hardhat run scripts/deploy_meteora_factory.ts --network monti_spl
@@ -44,6 +48,7 @@ Global constants (`SplToken`, `AssociatedSplToken`, `SystemProgram`, `CpiProgram
 - **`contracts/spl_token/`** — Low-level SPL token and associated token account libraries (`SplTokenLib`, `AssociatedSplTokenLib`). These use `CpiProgram.account_info()` to deserialize on-chain Solana account data (Borsh-encoded) from within Solidity.
 - **`contracts/erc20spl/`** — `SPL_ERC20` wraps an SPL mint as an ERC20 token. `ERC20SPLFactory` deploys these wrappers. Uses OpenZeppelin IERC20.
 - **`contracts/meteora/`** — `MeteoraDAMMv1Factory` and `DAMMv1Pool` implement a Uniswap-style factory/pool pattern that delegates swaps to Meteora's on-chain Solana program via CPI.
+- **`contracts/oracle/`** — Solana Oracle Gateway: Chainlink-compatible adapters for Pyth price feeds. `PythAggregatorFactory` permissionlessly deploys `PythAggregatorV3` adapters (one per Pyth feed). Each adapter reads Pyth account data from Solana via CPI, parses Borsh-encoded price data (`PythParser`), and normalizes to 8-decimal Chainlink format. Implements `IAggregatorV3Interface` so any EVM DeFi protocol can consume Pyth oracles without integration changes. Includes `examples/SampleLendingOracle.sol`.
 - **`contracts/rome_evm_account.sol`** — PDA derivation helpers for Rome-EVM user accounts (maps `address` → Solana `bytes32` pubkey).
 - **`contracts/borsch.sol`** — Borsh deserialization utilities for reading Solana account data.
 - **`contracts/wcross_program_invocation.sol`** — Example: calling an arbitrary Solana program from EVM via CPI.
@@ -60,6 +65,7 @@ Global constants (`SplToken`, `AssociatedSplToken`, `SystemProgram`, `CpiProgram
 - `local` — local Rome-EVM node at `http://localhost:9090`
 - `monti_spl` — Rome devnet at `https://montispl-i.devnet.romeprotocol.xyz/`
 - `sepolia` — Ethereum Sepolia testnet
+- `hardhatMainnet` — Hardhat mainnet fork (used for oracle unit tests)
 
 ### Solidity Version
 


### PR DESCRIPTION
Weekly automated update of CLAUDE.md to reflect current codebase state.

## Changes
- Added Oracle Gateway section documenting the new `contracts/oracle/` module (Pyth/Chainlink price feed adapters)
- Added oracle test commands (`pyth_parser.test.ts`, `normalizer.test.ts`)
- Added `hardhatMainnet` to networks list (used for oracle unit tests)
- Updated overview to mention Oracle Gateway