### PR TITLE
Oracle Gateway V2: Pyth Pull + Switchboard V2 + EIP-1167 factory

### DIFF
--- a/contracts/oracle/SwitchboardParser.sol
+++ b/contracts/oracle/SwitchboardParser.sol
@@ -4,31 +4,43 @@ pragma solidity ^0.8.20;
 import "../convert.sol";
 
 /// @title SwitchboardParser
-/// @notice Parses AggregatorAccountData from Switchboard V3.
+/// @notice Parses AggregatorAccountData from Switchboard V2 on Solana.
 /// @dev Switchboard stores results as SwitchboardDecimal:
 ///   - mantissa: i128 (16 bytes, little-endian)
 ///   - scale: u32 (4 bytes, little-endian)
 ///   - actual_value = mantissa / 10^scale
 ///
-/// The latest_confirmed_round contains result, round_open_slot, round_open_timestamp.
+/// Validated layout (from live SOL/USD aggregator GvDMxP... on monti_spl):
+///   Offset  Size  Field
+///   0       8     Anchor discriminator (0xd9e64165c9a21b7d)
+///   8       32    name
+///   ...           (many config fields)
+///   350     8     latest_confirmed_round.round_open_slot (u64)
+///   358     8     latest_confirmed_round.round_open_timestamp (i64)
+///   366     16    latest_confirmed_round.result.mantissa (i128)
+///   382     4     latest_confirmed_round.result.scale (u32)
 ///
-/// IMPORTANT: The exact byte offset of latest_confirmed_round.result must be
-/// confirmed by reading a live Switchboard aggregator on devnet.
-/// Run validate-switchboard-offsets.ts before deployment.
+/// IMPORTANT: These offsets are empirically validated against the live account.
+/// Run validate-switchboard-offsets.ts to re-confirm before redeployment.
 library SwitchboardParser {
     error InvalidSwitchboardAccount();
     error SwitchboardDataTooShort();
 
     /// @notice Anchor discriminator for AggregatorAccountData
-    /// Must be validated against live account before deployment
+    /// sha256("account:AggregatorAccountData")[0..8]
     bytes8 constant DISCRIMINATOR = 0xd9e64165c9a21b7d;
 
-    /// @notice Byte offset of latest_confirmed_round.result in AggregatorAccountData
-    /// This is a large struct — offset must be validated empirically
-    uint256 constant LATEST_RESULT_OFFSET = 176;
+    /// @notice Byte offset of latest_confirmed_round.round_open_slot
+    uint256 constant ROUND_SLOT_OFFSET = 350;
+    /// @notice Byte offset of latest_confirmed_round.round_open_timestamp
+    uint256 constant ROUND_TIMESTAMP_OFFSET = 358;
+    /// @notice Byte offset of latest_confirmed_round.result.mantissa
+    uint256 constant RESULT_MANTISSA_OFFSET = 366;
+    /// @notice Byte offset of latest_confirmed_round.result.scale
+    uint256 constant RESULT_SCALE_OFFSET = 382;
 
-    /// @notice Minimum account data length
-    uint256 constant MIN_DATA_LENGTH = 224;
+    /// @notice Minimum account data length (must cover through scale field)
+    uint256 constant MIN_DATA_LENGTH = 386;
 
     struct SwitchboardPrice {
         int128 mantissa;
@@ -37,7 +49,7 @@ library SwitchboardParser {
         uint64 slot;
     }
 
-    /// @notice Parse a Switchboard V3 AggregatorAccountData
+    /// @notice Parse a Switchboard V2 AggregatorAccountData
     /// @param data Raw account data from CPI precompile
     /// @return parsed The parsed price data
     function parse(bytes memory data) internal pure returns (SwitchboardPrice memory parsed) {
@@ -50,16 +62,16 @@ library SwitchboardParser {
         }
         if (disc != DISCRIMINATOR) revert InvalidSwitchboardAccount();
 
-        // latest_confirmed_round.result.mantissa at LATEST_RESULT_OFFSET (i128, LE)
-        (parsed.mantissa,) = Convert.read_i128le(data, LATEST_RESULT_OFFSET);
+        // round_open_slot (u64, LE)
+        (parsed.slot,) = Convert.read_u64le(data, ROUND_SLOT_OFFSET);
 
-        // latest_confirmed_round.result.scale at LATEST_RESULT_OFFSET + 16 (u32, LE)
-        (parsed.scale,) = Convert.read_u32le(data, LATEST_RESULT_OFFSET + 16);
+        // round_open_timestamp (i64, LE)
+        (parsed.timestamp,) = Convert.read_i64le(data, ROUND_TIMESTAMP_OFFSET);
 
-        // round_open_slot at LATEST_RESULT_OFFSET + 20 (u64, LE)
-        (parsed.slot,) = Convert.read_u64le(data, LATEST_RESULT_OFFSET + 20);
+        // result.mantissa (i128, LE)
+        (parsed.mantissa,) = Convert.read_i128le(data, RESULT_MANTISSA_OFFSET);
 
-        // round_open_timestamp at LATEST_RESULT_OFFSET + 28 (i64, LE)
-        (parsed.timestamp,) = Convert.read_i64le(data, LATEST_RESULT_OFFSET + 28);
+        // result.scale (u32, LE)
+        (parsed.scale,) = Convert.read_u32le(data, RESULT_SCALE_OFFSET);
     }
 }

--- a/deployments/monti_spl.json
+++ b/deployments/monti_spl.json
@@ -38,38 +38,29 @@
   ],
   "OracleGatewayV2": {
     "PythPullAdapter": {
-      "address": "0x552f54edc06c7172c2748678af4c19600c0a6a8d",
+      "address": "0x4fd11aed44ee5f71df22fb804cfcbb4c50535db9",
       "type": "implementation"
     },
     "SwitchboardV3Adapter": {
-      "address": "0xa423d30c8d28a524f857423b6c776bc523dccafa",
+      "address": "0xb57e3589b880aa3f6b66ce2df6aa42cd9c36925e",
       "type": "implementation"
     },
     "OracleAdapterFactory": {
-      "address": "0x242e8a18c69ad68368ea08d49fa1333594276a9a",
+      "address": "0xa4647955a16b72d15f13b51b5277036755d297be",
       "pythPriceFeedProgramId": "0x0cb7fabb52f7a648bb5b317d9a018b9057cb024774fafe01e6c4df98cc385881",
       "switchboardProgramId": "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90",
       "defaultMaxStaleness": 60
     },
     "BatchReader": {
-      "address": "0x2b26b7e5d74980882468348f7a07617c9f97c8cf"
+      "address": "0x70da375e5680f84032f5b15d35ba0e6f9871d3fd"
     },
-    "deployedAt": "2026-04-01T23:39:27.183Z",
-    "feeds": [
+    "deployedAt": "2026-04-02T00:02:18.942Z",
+    "switchboardFeeds": [
       {
-        "pair": "SOL / USD",
-        "pythAccountBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243",
-        "adapter": "0xF408E6F07Fdd927A877e71586e74978FCe9ffB7e"
-      },
-      {
-        "pair": "BTC / USD",
-        "pythAccountBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de",
-        "adapter": "0x7EF3e28460cDb1C299E1a462AF69C815397c216a"
-      },
-      {
-        "pair": "ETH / USD",
-        "pythAccountBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb",
-        "adapter": "0xE4610114c3E43a394aC01ca25103f4bfD89B4C1C"
+        "pair": "SOL/USD",
+        "aggregator": "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
+        "aggregatorBytes32": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a",
+        "adapter": "0xF0864572019c295407CF2ed46e6FD3615e10E19d"
       }
     ]
   }

--- a/scripts/oracle/check-switchboard.ts
+++ b/scripts/oracle/check-switchboard.ts
@@ -1,0 +1,51 @@
+import hardhat from "hardhat";
+
+/**
+ * Check Switchboard accounts on Rome's fork.
+ */
+
+const ACCOUNTS: Record<string, `0x${string}`> = {
+    "SOL/USD (SB V2)": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a",
+    "BTC/USD (SB V2)": "0xabc6cd81621fa075cc40f28cce30cf33f34c7758b96ae21a100d81b1ec112db6",
+};
+
+const KNOWN_PROGRAMS: Record<string, string> = {
+    "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90": "SW1TCH (Switchboard V2)",
+    "0x0673bd46f2e47e04f12bd92fb731968ecd9d9757c274da87476f465c040c6573": "SBond (Switchboard On-Demand)",
+};
+
+async function main() {
+    const { viem } = await hardhat.network.connect();
+
+    const cpi = await viem.getContractAt(
+        "ICrossProgramInvocation",
+        "0xFF00000000000000000000000000000000000008",
+    );
+
+    for (const [name, pubkey] of Object.entries(ACCOUNTS)) {
+        try {
+            const [lamports, owner, , , , data] =
+                await cpi.read.account_info([pubkey]);
+            const ownerHex = owner.toLowerCase();
+            const program = KNOWN_PROGRAMS[ownerHex] ?? `UNKNOWN (${ownerHex})`;
+            const dataLen = (data.length - 2) / 2;
+            console.log(`${name}:`);
+            console.log(`  lamports: ${lamports}`);
+            console.log(`  owner: ${program}`);
+            console.log(`  data: ${dataLen} bytes`);
+            console.log(`  first 16 bytes: ${data.slice(0, 34)}`);
+
+            // Try to decode discriminator
+            const disc = data.slice(0, 18); // 0x + 8 bytes
+            console.log(`  discriminator: ${disc}`);
+        } catch (e: any) {
+            console.log(`${name}: ERROR — ${e.message?.slice(0, 100)}`);
+        }
+        console.log();
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/oracle/debug-switchboard.ts
+++ b/scripts/oracle/debug-switchboard.ts
@@ -1,0 +1,96 @@
+import hardhat from "hardhat";
+
+/**
+ * Debug Switchboard V2 account — brute-force find the latest_confirmed_round result.
+ *
+ * Switchboard V2 AggregatorAccountData struct layout (from switchboard-v2 crate):
+ *   - discriminator: 8 bytes
+ *   - name: 32 bytes [8..40]
+ *   - metadata: 128 bytes [40..168]
+ *   - ... many config fields ...
+ *   - latest_confirmed_round: AggregatorRound
+ *     - AggregatorRound has: num_success, num_error, is_closed, round_open_slot,
+ *       round_open_timestamp, result (SwitchboardDecimal), std_deviation, ...
+ *   - SwitchboardDecimal = { mantissa: i128 (16 bytes), scale: u32 (4 bytes) }
+ *
+ * Strategy: scan for any (i128 mantissa, u32 scale) pair where the resulting
+ * price is $50-$200 (SOL range), with scale 6-12.
+ */
+
+async function main() {
+    const { viem } = await hardhat.network.connect();
+
+    const cpi = await viem.getContractAt(
+        "ICrossProgramInvocation",
+        "0xFF00000000000000000000000000000000000008",
+    );
+
+    const solAgg = "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a" as const;
+    const [, , , , , data] = await cpi.read.account_info([solAgg]);
+    const hex = data.slice(2);
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    console.log(`Data length: ${bytes.length} bytes`);
+
+    // Name at [8..40]
+    const nameBytes = bytes.slice(8, 40);
+    const name = new TextDecoder().decode(nameBytes).replace(/\0/g, "");
+    console.log(`Name: "${name}"`);
+
+    // Search for (mantissa i128, scale u32) pairs where price is reasonable
+    console.log("\n--- Brute-force scanning for SwitchboardDecimal ---");
+
+    for (let offset = 100; offset < bytes.length - 20; offset++) {
+        // Read i128 LE
+        let mantissa = 0n;
+        for (let i = 0; i < 16; i++) {
+            mantissa |= BigInt(bytes[offset + i]) << BigInt(i * 8);
+        }
+        if (mantissa >= (1n << 127n)) mantissa -= (1n << 128n);
+
+        // Read u32 LE scale
+        let scale = 0;
+        for (let i = 0; i < 4; i++) {
+            scale |= bytes[offset + 16 + i] << (i * 8);
+        }
+
+        if (scale < 1 || scale > 18 || mantissa <= 0n) continue;
+
+        const price = Number(mantissa) / Math.pow(10, scale);
+        if (price < 10 || price > 500) continue;
+
+        // Check for timestamp nearby (before the result, round_open_timestamp is i64)
+        // In AggregatorRound: round_open_slot (u64) then round_open_timestamp (i64) come BEFORE result
+        // So check offset-24 and offset-16 for timestamp
+        for (const tsOff of [offset - 16, offset - 8, offset + 20, offset + 28]) {
+            if (tsOff < 0 || tsOff + 8 > bytes.length) continue;
+            let ts = 0n;
+            for (let i = 0; i < 8; i++) {
+                ts |= BigInt(bytes[tsOff + i]) << BigInt(i * 8);
+            }
+            if (ts >= 1700000000n && ts <= 1800000000n) {
+                console.log(`  MATCH offset=${offset}: mantissa=${mantissa}, scale=${scale}, price=$${price.toFixed(6)}`);
+                console.log(`    timestamp at offset ${tsOff}: ${ts} (${new Date(Number(ts) * 1000).toISOString()})`);
+
+                // Also show the slot
+                const slotOff = tsOff - 8;
+                if (slotOff >= 0) {
+                    let slot = 0n;
+                    for (let i = 0; i < 8; i++) {
+                        slot |= BigInt(bytes[slotOff + i]) << BigInt(i * 8);
+                    }
+                    if (slot > 100000000n && slot < 1000000000n) {
+                        console.log(`    slot at offset ${slotOff}: ${slot}`);
+                    }
+                }
+            }
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/oracle/test-switchboard.ts
+++ b/scripts/oracle/test-switchboard.ts
@@ -1,0 +1,145 @@
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Test Switchboard V2 SOL/USD feed on monti_spl.
+ *
+ * SOL/USD aggregator: GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR
+ *   bytes32: 0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a
+ *   owner: SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f
+ */
+
+const SB_SOL_USD = "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a" as const;
+
+async function main() {
+    const { viem, networkName } = await hardhat.network.connect();
+    const publicClient = await viem.getPublicClient();
+
+    const deploymentsDir = path.resolve(process.cwd(), "deployments");
+    const filePath = path.resolve(deploymentsDir, `${networkName}.json`);
+    const deployments = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const v2 = deployments.OracleGatewayV2;
+
+    console.log("=== Switchboard V2 Integration Test ===");
+    console.log("Factory:", v2.OracleAdapterFactory.address);
+    console.log();
+
+    const factory = await viem.getContractAt(
+        "OracleAdapterFactory",
+        v2.OracleAdapterFactory.address,
+    );
+
+    // ─── Create SOL/USD Switchboard feed ───
+    console.log("Creating Switchboard SOL/USD feed...");
+    console.log("  Account:", SB_SOL_USD);
+
+    const existing = await factory.read.switchboardAdapters([SB_SOL_USD]);
+    let adapterAddr: string;
+
+    if (existing !== "0x0000000000000000000000000000000000000000") {
+        console.log("  Already exists:", existing);
+        adapterAddr = existing;
+    } else {
+        try {
+            const txHash = await factory.write.createSwitchboardFeed([SB_SOL_USD, "SOL / USD (Switchboard)", 0n]);
+            console.log("  Tx:", txHash);
+            const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+            console.log("  Status:", receipt.status);
+
+            adapterAddr = await factory.read.switchboardAdapters([SB_SOL_USD]);
+            console.log("  Adapter:", adapterAddr);
+        } catch (e: any) {
+            console.error("  FAILED:", e.cause?.reason ?? e.message?.slice(0, 150));
+            return;
+        }
+    }
+
+    // ─── Read price ───
+    console.log("\n=== Read Switchboard price ===");
+    const adapter = await viem.getContractAt("SwitchboardV3Adapter", adapterAddr as `0x${string}`);
+
+    try {
+        const [roundId, answer, , updatedAt, answeredInRound] = await adapter.read.latestRoundData();
+        const desc = await adapter.read.description();
+        console.log(`${desc}:`);
+        console.log(`  price: $${(Number(answer) / 1e8).toFixed(4)} (raw: ${answer})`);
+        console.log(`  roundId=${roundId} answeredInRound=${answeredInRound}`);
+        console.log(`  updatedAt: ${updatedAt} (${new Date(Number(updatedAt) * 1000).toISOString()})`);
+        console.log(`  age: ${Math.floor(Date.now() / 1000) - Number(updatedAt)}s`);
+    } catch (e: any) {
+        console.log(`  latestRoundData REVERTED: ${e.cause?.reason ?? e.message?.slice(0, 100)}`);
+    }
+
+    // ─── Extended data ───
+    console.log("\n=== Extended data ===");
+    try {
+        const [price, conf, expo, publishTime] = await adapter.read.latestPriceData();
+        console.log(`  price=${price} conf=${conf} expo=${expo} publishTime=${publishTime}`);
+    } catch (e: any) {
+        console.log(`  latestPriceData: ${e.cause?.reason ?? e.message?.slice(0, 80)}`);
+    }
+
+    try {
+        await adapter.read.latestEMAData();
+        console.log("  FAIL: EMA should revert for Switchboard");
+    } catch {
+        console.log("  PASS: latestEMAData correctly reverts (EMANotSupported)");
+    }
+
+    console.log(`  oracleType: ${await adapter.read.oracleType()} (expected: 1 = SwitchboardV3)`);
+    console.log(`  version: ${await adapter.read.version()} (expected: 2)`);
+    console.log(`  decimals: ${await adapter.read.decimals()} (expected: 8)`);
+
+    // ─── Price status ───
+    console.log("\n=== Price status ===");
+    try {
+        const status = await adapter.read.priceStatus();
+        console.log(`  status: ${status} (0=Trading, 1=Stale, 2=Paused)`);
+    } catch (e: any) {
+        console.log(`  priceStatus: ${e.cause?.reason ?? e.message?.slice(0, 80)}`);
+    }
+
+    // ─── BatchReader with mixed Pyth + Switchboard ───
+    console.log("\n=== BatchReader (mixed Pyth + Switchboard) ===");
+    // Also create a Pyth feed if it doesn't exist
+    const pythSolPda = "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243" as const;
+    let pythAddr = await factory.read.pythAdapters([pythSolPda]);
+    if (pythAddr === "0x0000000000000000000000000000000000000000") {
+        try {
+            const tx = await factory.write.createPythFeed([pythSolPda, "SOL / USD (Pyth)", 0n]);
+            await publicClient.waitForTransactionReceipt({ hash: tx });
+            pythAddr = await factory.read.pythAdapters([pythSolPda]);
+            console.log("  Created Pyth SOL/USD:", pythAddr);
+        } catch (e: any) {
+            console.log("  Pyth feed creation failed:", e.cause?.reason ?? e.message?.slice(0, 80));
+        }
+    }
+
+    const batchReader = await viem.getContractAt("BatchReader", v2.BatchReader.address);
+    const adapters = [pythAddr, adapterAddr].filter(a => a !== "0x0000000000000000000000000000000000000000");
+    try {
+        const results = await batchReader.read.getLatestPrices([adapters as `0x${string}`[]]);
+        for (const r of results) {
+            console.log(`  ${r.adapter}: $${(Number(r.answer) / 1e8).toFixed(4)} success=${r.success}`);
+        }
+    } catch (e: any) {
+        console.log(`  BatchReader failed: ${e.cause?.reason ?? e.message?.slice(0, 80)}`);
+    }
+
+    // ─── Save ───
+    deployments.OracleGatewayV2.switchboardFeeds = [{
+        pair: "SOL/USD",
+        aggregator: "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
+        aggregatorBytes32: SB_SOL_USD,
+        adapter: adapterAddr,
+    }];
+    fs.writeFileSync(filePath, JSON.stringify(deployments, null, 2) + "\n", "utf8");
+
+    console.log("\n=== Done ===");
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/oracle/helpers/mockSwitchboard.ts
+++ b/tests/oracle/helpers/mockSwitchboard.ts
@@ -1,15 +1,16 @@
 /**
- * Mock Switchboard V3 AggregatorAccountData builder for testing SwitchboardParser.
+ * Mock Switchboard V2 AggregatorAccountData builder for testing SwitchboardParser.
  *
- * Key layout:
- *   [0..8]     Anchor discriminator
- *   ...
- *   [176..192] latest_confirmed_round.result.mantissa (i128, LE)
- *   [192..196] latest_confirmed_round.result.scale (u32, LE)
- *   [196..204] round_open_slot (u64, LE)
- *   [204..212] round_open_timestamp (i64, LE)
+ * Validated layout (from live SOL/USD aggregator on monti_spl):
+ *   [0..8]     Anchor discriminator (0xd9e64165c9a21b7d)
+ *   [8..40]    name
+ *   ...        (many config fields)
+ *   [350..358] round_open_slot (u64, LE)
+ *   [358..366] round_open_timestamp (i64, LE)
+ *   [366..382] result.mantissa (i128, LE)
+ *   [382..386] result.scale (u32, LE)
  *
- * Total minimum: 224 bytes
+ * Total minimum: 386 bytes
  */
 
 export interface SwitchboardAccountParams {
@@ -54,27 +55,27 @@ function writeInt64LE(buf: Uint8Array, offset: number, value: bigint): void {
 }
 
 /**
- * Build a mock Switchboard V3 AggregatorAccountData byte array.
+ * Build a mock Switchboard V2 AggregatorAccountData byte array.
  * Returns a hex string prefixed with 0x, suitable for passing to Solidity.
  */
 export function buildSwitchboardAccount(params: SwitchboardAccountParams): `0x${string}` {
-    const buf = new Uint8Array(224);
+    const buf = new Uint8Array(386);
 
     // Anchor discriminator at offset 0 (8 bytes, big-endian to match Solidity bytes8)
     const disc = params.discriminator ?? DEFAULT_DISCRIMINATOR;
     writeBytes8BE(buf, 0, disc);
 
-    // mantissa at offset 176 (i128, LE)
-    writeInt128LE(buf, 176, params.mantissa);
+    // round_open_slot at offset 350 (u64, LE)
+    writeUint64LE(buf, 350, params.slot ?? 0n);
 
-    // scale at offset 192 (u32, LE)
-    writeUint32LE(buf, 192, params.scale);
+    // round_open_timestamp at offset 358 (i64, LE)
+    writeInt64LE(buf, 358, BigInt(params.timestamp));
 
-    // round_open_slot at offset 196 (u64, LE)
-    writeUint64LE(buf, 196, params.slot ?? 0n);
+    // result.mantissa at offset 366 (i128, LE)
+    writeInt128LE(buf, 366, params.mantissa);
 
-    // round_open_timestamp at offset 204 (i64, LE)
-    writeInt64LE(buf, 204, BigInt(params.timestamp));
+    // result.scale at offset 382 (u32, LE)
+    writeUint32LE(buf, 382, params.scale);
 
     const hex = Array.from(buf)
         .map((b) => b.toString(16).padStart(2, "0"))


### PR DESCRIPTION
## Summary

- **Replace V1 oracle contracts** with V2: Pyth Pull model (PriceUpdateV2), Switchboard V2, staleness enforcement, pause mechanism, confidence/EMA data
- **PythPullParser** reads PriceUpdateV2 from Pyth Solana Receiver (`rec5EKM...`) via CPI precompile — offsets validated against live accounts
- **SwitchboardParser** reads AggregatorAccountData from Switchboard V2 (`SW1TCH...`) — offsets brute-force validated against live SOL/USD aggregator
- **PythPullAdapter + SwitchboardV3Adapter** implement `IAggregatorV3Interface` (Chainlink-compatible) with `maxStaleness` enforcement, factory pause checks, and opt-in `IExtendedOracleAdapter` for confidence/EMA
- **OracleAdapterFactory** deploys both adapter types via EIP-1167 minimal proxy clones, with registry, pause/unpause, and ownership controls
- **BatchReader** reads multiple feeds in one call with try/catch fault tolerance
- Adds `read_i64le()` and `read_i128le()` to `Convert.sol`
- Deletes V1 contracts (PythParser, PythAggregatorV3, PythAggregatorFactory)
- 18 unit tests passing, live integration tests on monti_spl

## Deployed to monti_spl

| Contract | Address |
|----------|---------|
| OracleAdapterFactory | `0xa4647955a16b72d15f13b51b5277036755d297be` |
| PythPullAdapter (impl) | `0x4fd11aed44ee5f71df22fb804cfcbb4c50535db9` |
| SwitchboardV3Adapter (impl) | `0xb57e3589b880aa3f6b66ce2df6aa42cd9c36925e` |
| BatchReader | `0x70da375e5680f84032f5b15d35ba0e6f9871d3fd` |

| Feed | Type | Adapter | Live Price |
|------|------|---------|-----------|
| SOL/USD | Pyth Pull | `0x718a7f...` | $81.15 |
| BTC/USD | Pyth Pull | — | $68,133.70 |
| ETH/USD | Pyth Pull | — | $2,141.19 |
| SOL/USD | Switchboard | `0xF086...` | Stale (Nov 2024 fork data) |

## Integration test results (monti_spl)

- [x] Pyth feed creation (3 feeds) + live price reads
- [x] Switchboard feed creation + correct stale detection
- [x] Chainlink compliance (7/7 checks)
- [x] Extended data: confidence, EMA, priceStatus, oracleType
- [x] Pause/unpause emergency controls
- [x] Duplicate feed prevention
- [x] BatchReader mixed Pyth+Switchboard with graceful failures
- [x] Staleness enforcement (StalePriceFeed revert)
- [x] EMA correctly reverts for Switchboard (EMANotSupported)
- [x] 18 unit tests (PythPullParser: 11, SwitchboardParser: 7)

## Test plan

- [x] Unit tests: `npx hardhat test tests/oracle/PythPullParser.test.ts tests/oracle/SwitchboardParser.test.ts`
- [x] Deploy to monti_spl: `npx hardhat run scripts/oracle/deploy.ts --network monti_spl`
- [x] Pyth integration: `npx hardhat run scripts/oracle/test-feeds-v2.ts --network monti_spl`
- [x] Switchboard integration: `npx hardhat run scripts/oracle/test-switchboard.ts --network monti_spl`
- [ ] Testnet promotion (requires explicit request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)