### PR TITLE
chore: add agent readiness — CLAUDE.md sections + templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Report a bug
+labels: bug
+---
+
+## Description
+
+## Steps to Reproduce
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+<!-- devnet / testnet / local -->
+
+## Logs / Error Messages

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Propose a new feature
+labels: enhancement
+---
+
+## Summary
+
+## Motivation
+
+## Proposed Solution
+
+## SPEC Reference
+<!-- If a SPEC exists: SPEC-{name}.md -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- What and why -->
+
+## SPEC Reference
+<!-- SPEC-{name}.md if applicable -->
+
+## Changes
+<!-- Key changes -->
+
+## Test Plan
+<!-- What was tested, how to verify -->
+
+## Cross-Repo Impact
+<!-- Which other repos are affected by this change -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,33 @@ Deployment metadata is tracked in `deployments/monti_spl.json`. Current deployme
 ### Solidity Version
 
 Target: `0.8.28`. Production profile enables optimizer with 200 runs.
+
+## Agent Execution Guide
+
+- All contracts consume precompile interfaces from `rome-solidity-sdk` (../rome-solidity-sdk/).
+- After modifying precompile addresses or ABIs, verify consumers compile: `npx hardhat compile`.
+- Test against local Rome-EVM node first: `npx hardhat test --network local`.
+- Test against devnet: `npx hardhat test --network montispl`.
+- Oracle Gateway V2 contracts depend on live Pyth/Switchboard feeds — test against montispl for oracle-related changes.
+- Never deploy contracts without running the full Hardhat test suite.
+- ERC-20 SPL wrappers interact with Solana precompiles at fixed addresses (0xFF...05-08) — verify precompile addresses match rome-evm-private if changed.
+
+## Change Impact Map
+
+| If you change... | Also check/update... |
+|-----------------|---------------------|
+| Precompile interface addresses | `rome-solidity-sdk/` interfaces must match `rome-evm-private/` precompile dispatch |
+| Contract ABIs | `rome-deposit-ui/` ABI imports, `tests/` Solidity test contracts |
+| Oracle adapter interfaces | Consuming contracts in this repo that use the adapters |
+| SPL token wrapper logic | `rome-uniswap-v2/` (uses SPL wrappers for trading pairs) |
+| Hardhat network config | `rome-solidity-sdk/` uses same network definitions |
+
+## Test Selection Guide
+
+| What Changed | Tests to Run |
+|-------------|-------------|
+| Any contract | `npx hardhat test` (full suite) |
+| Oracle contracts | `npx hardhat test` + `npx hardhat test --network montispl` (verify live feeds) |
+| Precompile wrappers | `npx hardhat test` + `tests/` opcode suite in integration repo |
+| ERC-20 SPL wrappers | `npx hardhat test` + `tests/` EVM suite |
+| Hardhat config only | `npx hardhat compile` (verify config is valid) |


### PR DESCRIPTION
## Summary
- Add Agent Execution Guide, Change Impact Map, and Test Selection Guide to CLAUDE.md
- Add PR template and issue templates (bug report, feature request)
- Part of Session 2: Per-Repo Agent Readiness (SPEC-session-2-repo-readiness.md)

## SPEC Reference
SPEC-session-2-repo-readiness.md

## Changes
- **CLAUDE.md**: 3 new sections for agent guidance (execution guide, change impact map, test selection)
- **`.github/pull_request_template.md`**: Standardized PR template
- **`.github/ISSUE_TEMPLATE/`**: Bug report and feature request templates

## Test Plan
- Verify agent reads and follows Agent Execution Guide in a Claude Code session
- Verify templates render correctly on GitHub

## Cross-Repo Impact
None — documentation and templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)