### PR TITLE
chore: gitignore local deployment artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /coverage
 
 .idea
+
+# Local deployment artifacts
+deployments/local.json


### PR DESCRIPTION
## Summary
- Add `deployments/local.json` to `.gitignore` to prevent committing local deployment artifacts generated by `scripts/setup-local.ts`

## Test plan
- [x] Verify `deployments/monti_spl.json` remains tracked
- [x] Verify `deployments/local.json` is now ignored

🤖 _This response was generated by Claude Code._