### PR TITLE
fix: resolve invoke_swap overload compilation error

### DIFF
--- a/contracts/meteora/damm_v1_pool.sol
+++ b/contracts/meteora/damm_v1_pool.sol
@@ -480,6 +480,6 @@ contract DAMMv1Pool {
             in_token
         );
 
-        this.invoke_swap(a, in_amount, minimum_out_amount);
+        invoke_swap(a, in_amount, minimum_out_amount);
     }
 }


### PR DESCRIPTION
## Summary
- `this.invoke_swap(a, in_amount, minimum_out_amount)` in `DAMMv1Pool` forced an external call, resolving to the 6-arg `external` overload instead of the 3-arg `internal` one — causing a `TypeError: Wrong argument count` compilation failure.
- Removed `this.` prefix so the call resolves to the correct internal overload.

## Test plan
- [x] `npx hardhat compile` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)