### PR TITLE
feat: RomeEvents.sol library + Hardhat integration for structured events

### DIFF
--- a/contracts/events/RomeEvents.sol
+++ b/contracts/events/RomeEvents.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// @title RomeEvents — structured events readable from Solana programs
+/// @notice Persists events to a ring-buffer PDA owned by rome-evm-private AND
+///         fires a standard EVM LOGn so ethers.js / eth_getLogs / Blockscout
+///         remain compatible. The ring PDA seed uses `msg.sender`, resolved
+///         program-side in the precompile — a contract can only write into
+///         its own ring.
+library RomeEvents {
+    address constant EVENT_LOG_PRECOMPILE =
+        address(0xff00000000000000000000000000000000000009);
+
+    bytes1 constant SEL_EMIT         = 0x01;
+    bytes1 constant SEL_INIT_RING    = 0x02;
+    bytes1 constant SEL_RING_HEADER  = 0x03;
+
+    error EmitFailed();
+    error InitRingFailed();
+    error RingHeaderFailed();
+    error TooManyTopics();
+    error DataTooLarge();
+
+    /// Emit a structured event. Fires a standard LOGn AND appends to the ring PDA.
+    /// `topics` excludes topic0 and holds up to 3 entries.
+    /// `data` up to 65,535 bytes (will be truncated to the ring's data_cap if larger).
+    function emitEvent(
+        bytes32 topic0,
+        bytes32[] memory topics,
+        bytes memory data
+    ) internal {
+        if (topics.length > 3) revert TooManyTopics();
+        if (data.length > type(uint16).max) revert DataTooLarge();
+
+        bytes memory buf = abi.encodePacked(
+            SEL_EMIT,
+            topic0,
+            uint8(topics.length)
+        );
+        for (uint256 i = 0; i < topics.length; i++) {
+            buf = abi.encodePacked(buf, topics[i]);
+        }
+        buf = abi.encodePacked(buf, _u16LE(uint16(data.length)), data);
+
+        (bool ok, ) = EVENT_LOG_PRECOMPILE.call(buf);
+        if (!ok) revert EmitFailed();
+    }
+
+    /// Initialize the ring PDA with custom capacity / data_cap.
+    /// Must be called BEFORE the first emitEvent from this contract.
+    function initRing(uint32 capacity, uint16 dataCap) internal {
+        bytes memory buf = abi.encodePacked(
+            SEL_INIT_RING,
+            _u32LE(capacity),
+            _u16LE(dataCap)
+        );
+        (bool ok, ) = EVENT_LOG_PRECOMPILE.call(buf);
+        if (!ok) revert InitRingFailed();
+    }
+
+    /// Read the current ring header for a given emitter. View-only.
+    function ringHeader(address emitter)
+        internal view
+        returns (uint32 capacity, uint16 dataCap, uint32 head, uint64 count)
+    {
+        bytes memory buf = abi.encodePacked(SEL_RING_HEADER, bytes20(emitter));
+        (bool ok, bytes memory ret) = EVENT_LOG_PRECOMPILE.staticcall(buf);
+        if (!ok || ret.length < 18) revert RingHeaderFailed();
+        capacity = _u32LEFromBytes(ret, 0);
+        dataCap  = _u16LEFromBytes(ret, 4);
+        head     = _u32LEFromBytes(ret, 6);
+        count    = _u64LEFromBytes(ret, 10);
+    }
+
+    // ---- LE helpers (little-endian for Solana-side byte layouts) ----
+
+    function _u16LE(uint16 v) private pure returns (bytes memory) {
+        bytes memory b = new bytes(2);
+        b[0] = bytes1(uint8(v));
+        b[1] = bytes1(uint8(v >> 8));
+        return b;
+    }
+
+    function _u32LE(uint32 v) private pure returns (bytes memory) {
+        bytes memory b = new bytes(4);
+        b[0] = bytes1(uint8(v));
+        b[1] = bytes1(uint8(v >> 8));
+        b[2] = bytes1(uint8(v >> 16));
+        b[3] = bytes1(uint8(v >> 24));
+        return b;
+    }
+
+    function _u16LEFromBytes(bytes memory b, uint256 off) private pure returns (uint16) {
+        return uint16(uint8(b[off])) | (uint16(uint8(b[off + 1])) << 8);
+    }
+
+    function _u32LEFromBytes(bytes memory b, uint256 off) private pure returns (uint32) {
+        return uint32(uint8(b[off]))
+            | (uint32(uint8(b[off + 1])) << 8)
+            | (uint32(uint8(b[off + 2])) << 16)
+            | (uint32(uint8(b[off + 3])) << 24);
+    }
+
+    function _u64LEFromBytes(bytes memory b, uint256 off) private pure returns (uint64) {
+        uint64 r;
+        for (uint256 i = 0; i < 8; i++) {
+            r |= uint64(uint8(b[off + i])) << uint64(8 * i);
+        }
+        return r;
+    }
+}

--- a/contracts/events/test/EventEmitter.sol
+++ b/contracts/events/test/EventEmitter.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {RomeEvents} from "../RomeEvents.sol";
+
+/// @title EventEmitter — minimal test contract for Hardhat integration tests.
+/// @notice Calls RomeEvents.emitEvent (writes to ring PDA via precompile) and also
+///         emits a native Solidity event so both the PDA and standard LOG are verifiable.
+contract EventEmitter {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function fireTransfer(address to, uint256 value) external {
+        bytes32 sig = keccak256("Transfer(address,address,uint256)");
+        bytes32[] memory topics = new bytes32[](2);
+        topics[0] = bytes32(uint256(uint160(msg.sender)));
+        topics[1] = bytes32(uint256(uint160(to)));
+        RomeEvents.emitEvent(sig, topics, abi.encode(value));
+
+        // Native Solidity event — preserved alongside the PDA write.
+        emit Transfer(msg.sender, to, value);
+    }
+}

--- a/tests/event-pda.integration.ts
+++ b/tests/event-pda.integration.ts
@@ -35,14 +35,18 @@ describe("RomeEvents", () => {
     { skip: !INTEGRATION ? "requires RUN_EVENT_PDA_INTEGRATION=1 and local Rome stack" : false },
     async () => {
       const { viem } = await hardhat.network.connect();
-      const [, recipient] = await viem.getWalletClients();
+      // Local Rome chain only provides one signer (LOCAL_PRIVATE_KEY).
+      // Use a stable dummy address as the transfer recipient.
+      const recipientAddr = "0x000000000000000000000000000000000000dEaD" as `0x${string}`;
 
-      const emitter = await viem.deployContract("EventEmitter", []);
+      // Local Rome chain rejects very low gas prices; force 1 gwei.
+      const gasPrice = 1_000_000_000n;
+      const emitter = await viem.deployContract("EventEmitter", [], { gasPrice });
 
-      const txHash = await emitter.write.fireTransfer([
-        recipient.account.address,
-        12345n,
-      ]);
+      const txHash = await emitter.write.fireTransfer(
+        [recipientAddr, 12345n],
+        { gasPrice },
+      );
 
       const publicClient = await viem.getPublicClient();
       const rcpt = await publicClient.waitForTransactionReceipt({ hash: txHash });
@@ -77,15 +81,19 @@ describe("RomeEvents", () => {
       if (!env) return;
 
       const { viem } = await hardhat.network.connect();
-      const [, recipient] = await viem.getWalletClients();
+      // Local Rome chain only provides one signer (LOCAL_PRIVATE_KEY).
+      // Use a stable dummy address as the transfer recipient.
+      const recipientAddr = "0x000000000000000000000000000000000000dEaD" as `0x${string}`;
 
-      const emitter = await viem.deployContract("EventEmitter", []);
+      // Local Rome chain rejects very low gas prices; force 1 gwei.
+      const gasPrice = 1_000_000_000n;
+      const emitter = await viem.deployContract("EventEmitter", [], { gasPrice });
       const contractAddr = emitter.address;
 
-      const txHash = await emitter.write.fireTransfer([
-        recipient.account.address,
-        12345n,
-      ]);
+      const txHash = await emitter.write.fireTransfer(
+        [recipientAddr, 12345n],
+        { gasPrice },
+      );
       const publicClient = await viem.getPublicClient();
       await publicClient.waitForTransactionReceipt({ hash: txHash });
 

--- a/tests/event-pda.integration.ts
+++ b/tests/event-pda.integration.ts
@@ -14,12 +14,12 @@
  *   npx hardhat test tests/event-pda.integration.ts --network local
  */
 
-import { describe, it, before } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import hardhat from "hardhat";
-import { keccak256, encodeAbiParameters, parseAbiParameters } from "viem";
+import { keccak256 } from "viem";
 import { getSolanaEnv, getSolanaConnection } from "./helpers/solana.js";
-import { deriveEventRingPda, parseRingHeader, parseEntry, hexToBytes } from "./helpers/eventRing.js";
+import { deriveEventRingPda, parseRingHeader, parseEntry } from "./helpers/eventRing.js";
 
 const INTEGRATION = process.env["RUN_EVENT_PDA_INTEGRATION"] === "1";
 
@@ -97,8 +97,9 @@ describe("RomeEvents", () => {
       );
 
       const conn = await getSolanaConnection(env);
+      // @ts-ignore — @solana/web3.js is an integration-only dep; not in package.json by design
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { PublicKey } = await import("@solana/web3.js") as any;
+      const { PublicKey } = (await import("@solana/web3.js")) as any;
       const info = await conn.getAccountInfo(new PublicKey(pubkey), "confirmed");
 
       assert.ok(info !== null, `ring PDA ${pubkey} must exist after first emit`);
@@ -122,19 +123,12 @@ describe("RomeEvents", () => {
       // topic[1] = msg.sender (deployer), topic[2] = recipient — 3 topics total
       assert.equal(entry!.topics.length, 3, "must have 3 topics: sig + 2 indexed");
 
-      // data must ABI-decode to 12345n
-      const [decodedValue] = encodeAbiParameters
-        ? (() => {
-            // decode: just read it as uint256 LE from the 32-byte ABI word
-            const word = entry!.data;
-            let v = 0n;
-            // ABI-encoded uint256 is big-endian 32 bytes
-            for (let i = 0; i < 32 && i < word.length; i++) {
-              v = (v << 8n) | BigInt(word[i]);
-            }
-            return [v];
-          })()
-        : [0n];
+      // data must ABI-decode to 12345n (uint256 is big-endian 32 bytes).
+      const word = entry!.data;
+      let decodedValue = 0n;
+      for (let i = 0; i < 32 && i < word.length; i++) {
+        decodedValue = (decodedValue << 8n) | BigInt(word[i]);
+      }
       assert.equal(decodedValue, 12345n, "ABI-encoded value must decode to 12345");
     },
   );

--- a/tests/event-pda.integration.ts
+++ b/tests/event-pda.integration.ts
@@ -1,0 +1,141 @@
+/**
+ * event-pda.integration.ts — Hardhat integration tests for RomeEvents + ring PDA.
+ *
+ * ALL tests in this file require RUN_EVENT_PDA_INTEGRATION=1 because fireTransfer
+ * calls the EventLog precompile at 0xFF...09, which does not exist in the stock
+ * Hardhat EDR simulator and will revert. The tests are skipped automatically when
+ * the env var is absent — `npx hardhat test` passes without a local Rome stack.
+ *
+ * To run the full suite against a local Rome stack:
+ *   RUN_EVENT_PDA_INTEGRATION=1 \
+ *   SOLANA_RPC_URL=http://localhost:8899 \
+ *   ROME_EVM_PROGRAM_ID=<base58> \
+ *   ROME_CHAIN_ID=1001 \
+ *   npx hardhat test tests/event-pda.integration.ts --network local
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { keccak256, encodeAbiParameters, parseAbiParameters } from "viem";
+import { getSolanaEnv, getSolanaConnection } from "./helpers/solana.js";
+import { deriveEventRingPda, parseRingHeader, parseEntry, hexToBytes } from "./helpers/eventRing.js";
+
+const INTEGRATION = process.env["RUN_EVENT_PDA_INTEGRATION"] === "1";
+
+describe("RomeEvents", () => {
+  /**
+   * Test 1: emits a native LOG.
+   *
+   * Skipped when RUN_EVENT_PDA_INTEGRATION=1 is not set because fireTransfer
+   * calls the EventLog precompile which reverts on stock Hardhat EDR.
+   */
+  it(
+    "emits a native Transfer LOG (integration — RUN_EVENT_PDA_INTEGRATION=1 required)",
+    { skip: !INTEGRATION ? "requires RUN_EVENT_PDA_INTEGRATION=1 and local Rome stack" : false },
+    async () => {
+      const { viem } = await hardhat.network.connect();
+      const [, recipient] = await viem.getWalletClients();
+
+      const emitter = await viem.deployContract("EventEmitter", []);
+
+      const txHash = await emitter.write.fireTransfer([
+        recipient.account.address,
+        12345n,
+      ]);
+
+      const publicClient = await viem.getPublicClient();
+      const rcpt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      const transferSig = keccak256(
+        new TextEncoder().encode("Transfer(address,address,uint256)"),
+      ) as `0x${string}`;
+
+      const transferLogs = (rcpt.logs ?? []).filter(
+        (l) => l.topics[0] === transferSig,
+      );
+
+      assert.ok(
+        transferLogs.length > 0,
+        `expected at least one Transfer LOG, got ${transferLogs.length}`,
+      );
+    },
+  );
+
+  /**
+   * Test 2: ring PDA check.
+   *
+   * Deploys EventEmitter, calls fireTransfer, then fetches the Solana ring PDA
+   * and asserts the first entry matches the Transfer event.
+   */
+  it(
+    "writes to the ring PDA [integration — RUN_EVENT_PDA_INTEGRATION=1 required]",
+    { skip: !INTEGRATION ? "requires RUN_EVENT_PDA_INTEGRATION=1 and local Rome stack" : false },
+    async () => {
+      const env = await getSolanaEnv();
+      // Should not reach here if INTEGRATION=false, but guard anyway.
+      if (!env) return;
+
+      const { viem } = await hardhat.network.connect();
+      const [, recipient] = await viem.getWalletClients();
+
+      const emitter = await viem.deployContract("EventEmitter", []);
+      const contractAddr = emitter.address;
+
+      const txHash = await emitter.write.fireTransfer([
+        recipient.account.address,
+        12345n,
+      ]);
+      const publicClient = await viem.getPublicClient();
+      await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      // Derive the ring PDA for the deployed contract address.
+      const { pubkey } = await deriveEventRingPda(
+        env.programId,
+        env.chainId,
+        contractAddr,
+      );
+
+      const conn = await getSolanaConnection(env);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { PublicKey } = await import("@solana/web3.js") as any;
+      const info = await conn.getAccountInfo(new PublicKey(pubkey), "confirmed");
+
+      assert.ok(info !== null, `ring PDA ${pubkey} must exist after first emit`);
+
+      const accountData = new Uint8Array(info.data);
+      const hdr = parseRingHeader(accountData);
+      assert.ok(hdr !== null, "ring header must parse");
+      assert.equal(hdr!.count, 1n, "ring must contain exactly 1 entry after one emit");
+      assert.equal(hdr!.head, 1, "ring head must advance to 1");
+
+      const entry = parseEntry(accountData, hdr!, 0);
+      assert.ok(entry !== null, "entry at index 0 must parse");
+
+      // topic[0] must equal keccak256("Transfer(address,address,uint256)")
+      const expectedTopic0 = keccak256(
+        new TextEncoder().encode("Transfer(address,address,uint256)"),
+      ) as `0x${string}`;
+      const actualTopic0 = "0x" + Buffer.from(entry!.topics[0]).toString("hex");
+      assert.equal(actualTopic0, expectedTopic0, "topic[0] must be Transfer event signature");
+
+      // topic[1] = msg.sender (deployer), topic[2] = recipient — 3 topics total
+      assert.equal(entry!.topics.length, 3, "must have 3 topics: sig + 2 indexed");
+
+      // data must ABI-decode to 12345n
+      const [decodedValue] = encodeAbiParameters
+        ? (() => {
+            // decode: just read it as uint256 LE from the 32-byte ABI word
+            const word = entry!.data;
+            let v = 0n;
+            // ABI-encoded uint256 is big-endian 32 bytes
+            for (let i = 0; i < 32 && i < word.length; i++) {
+              v = (v << 8n) | BigInt(word[i]);
+            }
+            return [v];
+          })()
+        : [0n];
+      assert.equal(decodedValue, 12345n, "ABI-encoded value must decode to 12345");
+    },
+  );
+});

--- a/tests/helpers/eventRing.ts
+++ b/tests/helpers/eventRing.ts
@@ -156,8 +156,9 @@ export async function deriveEventRingPda(
   chainId: bigint,
   emitterHex: string,
 ): Promise<{ pubkey: string; bump: number }> {
+  // @ts-ignore — @solana/web3.js is an integration-only dep; not in package.json by design
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { PublicKey } = await import("@solana/web3.js") as any;
+  const { PublicKey } = (await import("@solana/web3.js")) as any;
   const emitterBytes = hexToBytes(emitterHex);
   const chainIdBytes = new Uint8Array(8);
   writeU64LE(chainIdBytes, 0, chainId);

--- a/tests/helpers/eventRing.ts
+++ b/tests/helpers/eventRing.ts
@@ -1,0 +1,180 @@
+/**
+ * eventRing.ts — TypeScript port of the byte layout + PDA seed helpers from
+ * rome-solana/src/events/layout.rs (T15).
+ *
+ * Pure byte-layout helpers: no runtime Solana dependency in this module itself.
+ * deriveEventRingPda() dynamically imports @solana/web3.js — call it only inside
+ * integration-gated code paths (RUN_EVENT_PDA_INTEGRATION=1).
+ */
+
+export const RING_HEADER_SIZE = 36;
+export const ENTRY_FIXED_SIZE = 205;
+export const EVENT_RING_SEED = new TextEncoder().encode("event_log");
+
+/**
+ * Ring-buffer header — first 36 bytes of the PDA account.
+ *
+ * Layout (all LE):
+ *   ver       u8       offset 0
+ *   bump      u8       offset 1
+ *   capacity  u32 LE   offset 2
+ *   data_cap  u16 LE   offset 6
+ *   head      u32 LE   offset 8
+ *   count     u64 LE   offset 12
+ *   init_slot u64 LE   offset 20
+ *   _reserved [u8;8]   offset 28  (8 bytes, total = 36)
+ */
+export interface EventRingHeader {
+  ver: number;
+  bump: number;
+  capacity: number;
+  dataCap: number;
+  head: number;
+  count: bigint;
+  initSlot: bigint;
+}
+
+/**
+ * A single persisted event entry, decoded from the ring buffer.
+ *
+ * Entry prefix (205 bytes fixed):
+ *   seq         u64 LE   offset 0
+ *   slot        u64 LE   offset 8
+ *   tx_hash     [32]     offset 16
+ *   emitter     [20]     offset 48
+ *   topic_count u8       offset 68
+ *   topics      [[32];4] offset 69  (128 bytes, 4 × 32)
+ *   data_len    u16 LE   offset 197
+ *   truncated   u8       offset 199
+ *   _pad        [5]      offset 200  (5 bytes, total = 205)
+ *
+ * Entry trailing: data [data_cap bytes]
+ * Entry stride = 205 + data_cap
+ */
+export interface PersistedEvent {
+  seq: bigint;
+  slot: bigint;
+  txHash: Uint8Array;    // 32 bytes
+  emitter: Uint8Array;   // 20 bytes
+  topics: Uint8Array[];  // 1..=4 × 32 bytes each
+  data: Uint8Array;
+  truncated: boolean;
+}
+
+export function entryStride(dataCap: number): number {
+  return ENTRY_FIXED_SIZE + dataCap;
+}
+
+export function readU16LE(b: Uint8Array, off: number): number {
+  return b[off] | (b[off + 1] << 8);
+}
+
+export function readU32LE(b: Uint8Array, off: number): number {
+  return (b[off] | (b[off + 1] << 8) | (b[off + 2] << 16) | (b[off + 3] << 24)) >>> 0;
+}
+
+export function readU64LE(b: Uint8Array, off: number): bigint {
+  let r = 0n;
+  for (let i = 0; i < 8; i++) r |= BigInt(b[off + i]) << BigInt(8 * i);
+  return r;
+}
+
+export function writeU64LE(out: Uint8Array, off: number, v: bigint): void {
+  for (let i = 0; i < 8; i++) out[off + i] = Number((v >> BigInt(8 * i)) & 0xffn);
+}
+
+export function parseRingHeader(data: Uint8Array): EventRingHeader | null {
+  if (data.length < RING_HEADER_SIZE) return null;
+  return {
+    ver:      data[0],
+    bump:     data[1],
+    capacity: readU32LE(data, 2),
+    dataCap:  readU16LE(data, 6),
+    head:     readU32LE(data, 8),
+    count:    readU64LE(data, 12),
+    initSlot: readU64LE(data, 20),
+  };
+}
+
+export function parseEntry(
+  data: Uint8Array,
+  hdr: EventRingHeader,
+  idx: number,
+): PersistedEvent | null {
+  if (idx >= hdr.capacity) return null;
+  const stride = entryStride(hdr.dataCap);
+  const off = RING_HEADER_SIZE + idx * stride;
+  if (data.length < off + stride) return null;
+  const e = data.subarray(off, off + stride);
+
+  const seq = readU64LE(e, 0);
+  const slot = readU64LE(e, 8);
+  const txHash = e.subarray(16, 48);
+  const emitter = e.subarray(48, 68);
+  const topicCount = e[68];
+  if (topicCount > 4) return null;
+  const topics: Uint8Array[] = [];
+  for (let i = 0; i < topicCount; i++) {
+    const o = 69 + i * 32;
+    topics.push(new Uint8Array(e.subarray(o, o + 32)));
+  }
+  // data_len at fixed offset 197 (= 69 + 4*32)
+  const dataLenOff = 197;
+  const dataLen = readU16LE(e, dataLenOff);
+  const truncated = e[dataLenOff + 2] !== 0;
+  // data starts at offset 205 (= 197 + 2 + 1 + 5)
+  const dataOff = 205;
+  const dataBytes = e.subarray(dataOff, dataOff + dataLen);
+
+  return {
+    seq,
+    slot,
+    txHash: new Uint8Array(txHash),
+    emitter: new Uint8Array(emitter),
+    topics,
+    data: new Uint8Array(dataBytes),
+    truncated,
+  };
+}
+
+/**
+ * Derives the event-ring PDA for a given emitter address.
+ *
+ * Seed: [chain_id u64 LE (8 bytes) | "event_log" (9 bytes) | emitter_addr (20 bytes)]
+ *
+ * NOTE: Dynamically imports @solana/web3.js at call time. Only call this inside
+ * integration-gated paths (RUN_EVENT_PDA_INTEGRATION=1). The package is not listed
+ * in package.json — the dynamic import will throw if it is absent, which is the
+ * intended behaviour (tests skip before reaching this path).
+ *
+ * @param programId  base58 pubkey string of the rome-evm program
+ * @param chainId    chain id as bigint
+ * @param emitterHex 0x-prefixed 20-byte hex EVM address
+ */
+export async function deriveEventRingPda(
+  programId: string,
+  chainId: bigint,
+  emitterHex: string,
+): Promise<{ pubkey: string; bump: number }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { PublicKey } = await import("@solana/web3.js") as any;
+  const emitterBytes = hexToBytes(emitterHex);
+  const chainIdBytes = new Uint8Array(8);
+  writeU64LE(chainIdBytes, 0, chainId);
+  const [pda, bump] = PublicKey.findProgramAddressSync(
+    [chainIdBytes, EVENT_RING_SEED, emitterBytes],
+    new PublicKey(programId),
+  );
+  return { pubkey: pda.toBase58(), bump };
+}
+
+/**
+ * Converts a 0x-prefixed 20-byte hex string to a Uint8Array.
+ */
+export function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (h.length !== 40) throw new Error(`expected 20-byte hex address, got ${h.length / 2} bytes`);
+  const out = new Uint8Array(20);
+  for (let i = 0; i < 20; i++) out[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}

--- a/tests/helpers/solana.ts
+++ b/tests/helpers/solana.ts
@@ -51,7 +51,8 @@ export async function getSolanaEnv(): Promise<SolanaEnv | null> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function getSolanaConnection(env: SolanaEnv): Promise<any> {
+  // @ts-ignore — @solana/web3.js is an integration-only dep; not in package.json by design
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { Connection } = await import("@solana/web3.js") as any;
+  const { Connection } = (await import("@solana/web3.js")) as any;
   return new Connection(env.rpcUrl, "confirmed");
 }

--- a/tests/helpers/solana.ts
+++ b/tests/helpers/solana.ts
@@ -1,0 +1,57 @@
+/**
+ * solana.ts — lazy Solana connection helper for integration tests.
+ *
+ * Returns env config and a Connection if:
+ *   - RUN_EVENT_PDA_INTEGRATION=1 is set, AND
+ *   - SOLANA_RPC_URL, ROME_EVM_PROGRAM_ID, ROME_CHAIN_ID are all set.
+ *
+ * Returns null otherwise — callers should skip the PDA check.
+ *
+ * @solana/web3.js is NOT listed in package.json. getSolanaConnection() uses a
+ * dynamic import so that the module loads (and tests compile) without the package
+ * installed. Tests that call getSolanaConnection() are only reached when
+ * RUN_EVENT_PDA_INTEGRATION=1, at which point the Solana package must be available.
+ */
+
+export interface SolanaEnv {
+  rpcUrl: string;
+  programId: string;
+  chainId: bigint;
+}
+
+/**
+ * Returns the Solana env config if all required env vars are set and
+ * RUN_EVENT_PDA_INTEGRATION=1 is active; null otherwise.
+ */
+export async function getSolanaEnv(): Promise<SolanaEnv | null> {
+  if (process.env["RUN_EVENT_PDA_INTEGRATION"] !== "1") return null;
+
+  const rpcUrl    = process.env["SOLANA_RPC_URL"];
+  const programId = process.env["ROME_EVM_PROGRAM_ID"];
+  const chainIdStr = process.env["ROME_CHAIN_ID"];
+
+  if (!rpcUrl || !programId || !chainIdStr) {
+    console.warn(
+      "[T14] integration env incomplete — skipping ring-PDA verification.",
+      { rpcUrl: !!rpcUrl, programId: !!programId, chainId: !!chainIdStr },
+    );
+    return null;
+  }
+
+  return { rpcUrl, programId, chainId: BigInt(chainIdStr) };
+}
+
+/**
+ * Returns a Solana Connection for the given env config.
+ *
+ * Dynamically imports @solana/web3.js — only call this inside integration-gated
+ * code paths where the package is guaranteed to be installed.
+ *
+ * @returns any — typed as any to avoid needing @solana/web3.js types at compile time.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getSolanaConnection(env: SolanaEnv): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { Connection } = await import("@solana/web3.js") as any;
+  return new Connection(env.rpcUrl, "confirmed");
+}


### PR DESCRIPTION
## Summary

Solidity-side of the **Structured Event PDA Standard**. Contracts call `RomeEvents.emitEvent(topic0, topics, data)`, which wraps the new Rome EVM precompile at `0xFF…09`. The library fires a standard EVM `LOG` alongside the ring-PDA write, so ethers.js / Blockscout / `eth_getLogs` stay compatible.

- `contracts/events/RomeEvents.sol` — library with `emitEvent`, `initRing`, `ringHeader` helpers. Follows repo conventions (solc 0.8.28, precompile constant address, LE helpers matching `Convert`).
- `contracts/events/test/EventEmitter.sol` — minimal test contract that fires a `Transfer(from, to, value)` event through the library.
- `tests/event-pda.integration.ts` — Hardhat integration tests (skipped unless `RUN_EVENT_PDA_INTEGRATION=1 + SOLANA_RPC_URL + ROME_EVM_PROGRAM_ID + ROME_CHAIN_ID` are set). Pins explicit 1 gwei gas price and a dummy recipient since local Rome chains ship with a single funded signer.
- `tests/helpers/eventRing.ts` + `tests/helpers/solana.ts` — pure TS byte-layout + PDA-seed helpers mirroring `rome-sdk/rome-solana/src/events/layout.rs`. `@solana/web3.js` is imported dynamically so the default `npx hardhat test` run (without the env flag) does not require the Solana SDK.

## Test plan

- [x] `npx hardhat compile` — clean (`Compiled 1 Solidity file with solc 0.8.28`).
- [x] `npx hardhat test` without env flag — `2 skipped (2 nodejs)`, no failures, no imports for `@solana/web3.js`.
- [x] `RUN_EVENT_PDA_INTEGRATION=1 … npx hardhat test … --network local` against a locally-running Rome stack with the rome-evm-private PR deployed: **Test 1 passes** — native Transfer LOG present in receipt. Test 2 gated on installing `@solana/web3.js` at merge time; reader-side verification is already covered by the rome-sdk integration test.

## Depends on
- rome-evm-private: https://github.com/rome-protocol/rome-evm-private/pull/245 — precompile + on-chain ring PDA.

## Related
- rome-sdk: https://github.com/rome-protocol/rome-sdk/pulls?q=is%3Apr+head%3Afeat-event-pda-standard — Rust reader + integration tests.

🤖 _This response was generated by Claude Code._