### PR TITLE
sec(oracle): fix audit findings C-1, C-2, H-1, H-3, H-4, M-1, M-5, M-6

### DIFF
--- a/contracts/oracle/IExtendedOracleAdapter.sol
+++ b/contracts/oracle/IExtendedOracleAdapter.sol
@@ -31,6 +31,8 @@ interface IExtendedOracleAdapter is IAggregatorV3Interface {
     function maxStaleness() external view returns (uint256);
 
     /// @notice The oracle source type
-    /// @return 0 = PythPull, 1 = SwitchboardV3
+    /// @return 0 = PythPull, 1 = Switchboard V2 (name retained as
+    ///         SwitchboardV3Adapter for legacy compat; see
+    ///         SwitchboardV3Adapter.sol for details)
     function oracleType() external view returns (uint8);
 }

--- a/contracts/oracle/OracleAdapterFactory.sol
+++ b/contracts/oracle/OracleAdapterFactory.sol
@@ -7,9 +7,10 @@ import "./SwitchboardV3Adapter.sol";
 import "../interface.sol";
 
 /// @title OracleAdapterFactory
-/// @notice Unified factory deploying both Pyth Pull and Switchboard V3 adapters
-///         via EIP-1167 minimal proxy clones. Maintains a registry and provides
-///         pause/unpause emergency controls.
+/// @notice Unified factory deploying both Pyth Pull and Switchboard V2 adapters
+///         (the latter is named `SwitchboardV3Adapter` for legacy reasons; see
+///         SwitchboardV3Adapter.sol) via EIP-1167 minimal proxy clones.
+///         Maintains a registry and provides pause/unpause emergency controls.
 contract OracleAdapterFactory {
     // --- State ---
     address public owner;
@@ -52,8 +53,10 @@ contract OracleAdapterFactory {
 
     /// @param _pythImpl Address of the PythPullAdapter logic contract
     /// @param _switchboardImpl Address of the SwitchboardV3Adapter logic contract
+    ///                         (name retained for legacy; targets Switchboard V2)
     /// @param _pythReceiverProgramId Pyth Solana Receiver program ID (rec5EKM...)
-    /// @param _switchboardProgramId Switchboard program ID (SW1TCH...)
+    /// @param _switchboardProgramId Switchboard V2 program ID
+    ///                              (SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f)
     /// @param _defaultMaxStaleness Default staleness threshold in seconds
     constructor(
         address _pythImpl,
@@ -109,7 +112,9 @@ contract OracleAdapterFactory {
         emit PythFeedCreated(adapter, pythAccountPubkey, desc);
     }
 
-    /// @notice Deploy a new Switchboard V3 adapter (permissionless)
+    /// @notice Deploy a new Switchboard V2 adapter (permissionless; contract
+    ///         name retains "V3" for legacy reasons — see
+    ///         SwitchboardV3Adapter.sol for details)
     /// @param sbAccountPubkey Switchboard aggregator account pubkey
     /// @param desc Human-readable description
     /// @param staleness Max staleness in seconds (0 = use defaultMaxStaleness)

--- a/contracts/oracle/OracleAdapterFactory.sol
+++ b/contracts/oracle/OracleAdapterFactory.sol
@@ -39,6 +39,7 @@ contract OracleAdapterFactory {
     error InvalidAccountOwner();
     error OnlyOwner();
     error StalenessOutOfRange(uint256 staleness);
+    error ZeroAddress();
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert OnlyOwner();
@@ -145,7 +146,11 @@ contract OracleAdapterFactory {
     }
 
     /// @notice Transfer ownership (owner only)
+    /// @dev Disallows the zero address to avoid permanently bricking the
+    ///      factory (no pause/unpause, no staleness updates, no further
+    ///      ownership transfer possible). Single-step typo protection.
     function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
         emit OwnershipTransferred(owner, newOwner);
         owner = newOwner;
     }

--- a/contracts/oracle/OracleAdapterFactory.sol
+++ b/contracts/oracle/OracleAdapterFactory.sol
@@ -25,6 +25,9 @@ contract OracleAdapterFactory {
     mapping(bytes32 => address) public switchboardAdapters;
     address[] public allAdapters;
     mapping(address => bool) public pausedAdapters;
+    /// @notice Reverse lookup so pause/unpause ops can reject arbitrary
+    ///         addresses. Populated in `createPythFeed` / `createSwitchboardFeed`.
+    mapping(address => bool) public isRegisteredAdapter;
 
     // --- Events ---
     event PythFeedCreated(address indexed adapter, bytes32 indexed pythAccount, string description);
@@ -40,6 +43,7 @@ contract OracleAdapterFactory {
     error OnlyOwner();
     error StalenessOutOfRange(uint256 staleness);
     error ZeroAddress();
+    error AdapterNotRegistered();
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert OnlyOwner();
@@ -94,6 +98,7 @@ contract OracleAdapterFactory {
         // Register
         pythAdapters[pythAccountPubkey] = adapter;
         allAdapters.push(adapter);
+        isRegisteredAdapter[adapter] = true;
 
         emit PythFeedCreated(adapter, pythAccountPubkey, desc);
     }
@@ -124,6 +129,7 @@ contract OracleAdapterFactory {
         // Register
         switchboardAdapters[sbAccountPubkey] = adapter;
         allAdapters.push(adapter);
+        isRegisteredAdapter[adapter] = true;
 
         emit SwitchboardFeedCreated(adapter, sbAccountPubkey, desc);
     }
@@ -134,13 +140,18 @@ contract OracleAdapterFactory {
     }
 
     /// @notice Pause an adapter (owner only)
+    /// @dev Only adapters registered via `createPythFeed` /
+    ///      `createSwitchboardFeed` are permitted targets — prevents typos
+    ///      from toggling paused-state on arbitrary addresses.
     function pauseAdapter(address adapter) external onlyOwner {
+        if (!isRegisteredAdapter[adapter]) revert AdapterNotRegistered();
         pausedAdapters[adapter] = true;
         emit AdapterPaused(adapter);
     }
 
     /// @notice Unpause an adapter (owner only)
     function unpauseAdapter(address adapter) external onlyOwner {
+        if (!isRegisteredAdapter[adapter]) revert AdapterNotRegistered();
         pausedAdapters[adapter] = false;
         emit AdapterUnpaused(adapter);
     }

--- a/contracts/oracle/OracleAdapterFactory.sol
+++ b/contracts/oracle/OracleAdapterFactory.sol
@@ -93,7 +93,13 @@ contract OracleAdapterFactory {
         // Initialize atomically (no front-running gap)
         uint256 maxStale = staleness > 0 ? staleness : defaultMaxStaleness;
         _requireStalenessInRange(maxStale);
-        PythPullAdapter(adapter).initialize(pythAccountPubkey, desc, maxStale, address(this));
+        PythPullAdapter(adapter).initialize(
+            pythAccountPubkey,
+            desc,
+            maxStale,
+            address(this),
+            pythReceiverProgramId
+        );
 
         // Register
         pythAdapters[pythAccountPubkey] = adapter;
@@ -124,7 +130,13 @@ contract OracleAdapterFactory {
         // Initialize atomically
         uint256 maxStale = staleness > 0 ? staleness : defaultMaxStaleness;
         _requireStalenessInRange(maxStale);
-        SwitchboardV3Adapter(adapter).initialize(sbAccountPubkey, desc, maxStale, address(this));
+        SwitchboardV3Adapter(adapter).initialize(
+            sbAccountPubkey,
+            desc,
+            maxStale,
+            address(this),
+            switchboardProgramId
+        );
 
         // Register
         switchboardAdapters[sbAccountPubkey] = adapter;

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -124,11 +124,16 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     }
 
     /// @notice Derived price status: 0 = Trading, 1 = Stale, 2 = Paused
+    /// @dev Clock skew (publishTime > block.timestamp) is treated as stale, not
+    ///      a panic — see _checkStaleness for the underflow guard rationale.
     function priceStatus() external view returns (uint8) {
         if (IAdapterFactory(factory).isPaused(address(this))) return 2;
 
         PythPullParser.PythPullPrice memory parsed = _readAndParse();
-        if (block.timestamp - parsed.publishTime > maxStaleness) return 1;
+        if (
+            parsed.publishTime > block.timestamp ||
+            block.timestamp - parsed.publishTime > maxStaleness
+        ) return 1;
         return 0;
     }
 
@@ -157,8 +162,16 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
         return PythPullParser.parse(data);
     }
 
+    /// @dev Guards against two failure modes:
+    ///      1. `publishTime > block.timestamp` — Solana clock runs a few seconds
+    ///         ahead of EVM on devnet. Without the explicit check, the subtraction
+    ///         would panic with 0x11 (arithmetic underflow), which is swallowed
+    ///         by BatchReader's `catch{}` and indistinguishable from other errors.
+    ///      2. `block.timestamp - publishTime > maxStaleness` — data too old.
     function _checkStaleness(uint64 publishTime) internal view {
-        if (block.timestamp - publishTime > maxStaleness) revert StalePriceFeed();
+        if (publishTime > block.timestamp || block.timestamp - publishTime > maxStaleness) {
+            revert StalePriceFeed();
+        }
     }
 
     function _checkPaused() internal view {

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -18,6 +18,10 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     address public factory;
     bool public initialized;
     uint64 public createdAt;
+    /// @notice Solana program that must own `pythAccount` on every read.
+    ///         Cannot be `immutable` because adapters are EIP-1167 clones
+    ///         (storage inherited from the implementation's init path).
+    bytes32 public expectedProgramId;
 
     error StalePriceFeed();
     error AdapterPaused();
@@ -27,6 +31,7 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     error OnlyFactory();
     error StalenessOutOfRange(uint256 staleness);
     error ConfidenceExceedsThreshold();
+    error AccountOwnerChanged();
 
     /// @notice Maximum permitted `conf / price` ratio, in basis points.
     /// @dev Pyth's canonical consumer guidance is to reject price updates
@@ -53,11 +58,15 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     /// @param desc Human-readable description (e.g., "SOL / USD")
     /// @param _maxStaleness Maximum acceptable age of price data in seconds
     /// @param _factory OracleAdapterFactory address
+    /// @param _expectedProgramId Solana program that must own `_pythAccount`
+    ///        on every read (validated at each `_readAndParse` to detect
+    ///        account ownership reassignment via `assign` — M-5).
     function initialize(
         bytes32 _pythAccount,
         string calldata desc,
         uint256 _maxStaleness,
-        address _factory
+        address _factory,
+        bytes32 _expectedProgramId
     ) external {
         if (initialized) revert AlreadyInitialized();
         if (_maxStaleness < 1 || _maxStaleness > 24 hours) revert StalenessOutOfRange(_maxStaleness);
@@ -67,6 +76,7 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
         _description = desc;
         maxStaleness = _maxStaleness;
         factory = _factory;
+        expectedProgramId = _expectedProgramId;
         createdAt = uint64(block.timestamp);
     }
 
@@ -170,8 +180,21 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
 
     // --- Internal helpers ---
 
+    /// @dev Fetches the current owner and data for `pythAccount`. Split out
+    ///      as `virtual` so test harnesses can override the CPI precompile
+    ///      call — the precompile is unavailable on hardhat's simulated
+    ///      network. Production code uses the real precompile.
+    function _fetchAccount() internal view virtual returns (bytes32 owner, bytes memory data) {
+        (, owner,,,, data) = CpiProgram.account_info(pythAccount);
+    }
+
     function _readAndParse() internal view returns (PythPullParser.PythPullPrice memory) {
-        (,,,,, bytes memory data) = CpiProgram.account_info(pythAccount);
+        (bytes32 owner, bytes memory data) = _fetchAccount();
+        // M-5: revalidate owner on every read. An attacker-controlled program
+        // could reassign the account via Solana's `assign` syscall and start
+        // producing bytes with the same discriminator + layout but arbitrary
+        // prices. The factory's one-time check at createPythFeed is not enough.
+        if (owner != expectedProgramId) revert AccountOwnerChanged();
         return PythPullParser.parse(data);
     }
 

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -214,12 +214,18 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
         if (IAdapterFactory(factory).isPaused(address(this))) revert AdapterPaused();
     }
 
-    /// @dev Reverts if `conf / price > MAX_CONF_BPS / 10_000`. Caller must
-    ///      ensure `price > 0` first so the cast to uint64 is safe. The
-    ///      multiplication uses uint256 to prevent overflow — conf is up to
-    ///      uint64 max (~1.8e19) and MAX_CONF_BPS is 200, so
-    ///      `conf * 10_000` fits comfortably in uint256.
+    /// @dev Reverts if `conf / price > MAX_CONF_BPS / 10_000`. Guards
+    ///      `price <= 0` up front so `uint64(price)` cannot silently wrap a
+    ///      negative signed value to a large unsigned one — a negative price
+    ///      is always a stale/invalid feed and must fail loudly regardless
+    ///      of whether the caller is `latestRoundData` (which does its own
+    ///      `NonPositivePrice` check) or a direct consumer of this primitive
+    ///      via the test harness / future callers. The uint256
+    ///      multiplication prevents overflow — conf is up to uint64 max
+    ///      (~1.8e19) and MAX_CONF_BPS is 200, so `conf * 10_000` fits
+    ///      comfortably in uint256.
     function _checkConfidence(int64 price, uint64 conf) internal pure {
+        if (price <= 0) revert NonPositivePrice();
         if (uint256(conf) * 10_000 > uint256(uint64(price)) * MAX_CONF_BPS) {
             revert ConfidenceExceedsThreshold();
         }

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -27,6 +27,15 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     error OnlyFactory();
     error StalenessOutOfRange(uint256 staleness);
 
+    /// @notice Lock the implementation contract from direct initialization.
+    ///         Clones deployed via `Clones.clone` have independent storage and
+    ///         are unaffected; this prevents an attacker from calling
+    ///         `initialize()` directly on the implementation that
+    ///         `OracleAdapterFactory.pythImplementation` points to.
+    constructor() {
+        initialized = true;
+    }
+
     /// @notice Initialize the adapter (called once by factory after clone deployment)
     /// @param _pythAccount Pyth Pull receiver PDA pubkey
     /// @param desc Human-readable description (e.g., "SOL / USD")

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -26,6 +26,18 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     error AlreadyInitialized();
     error OnlyFactory();
     error StalenessOutOfRange(uint256 staleness);
+    error ConfidenceExceedsThreshold();
+
+    /// @notice Maximum permitted `conf / price` ratio, in basis points.
+    /// @dev Pyth's canonical consumer guidance is to reject price updates
+    ///      where the 1-sigma confidence interval exceeds a fraction of the
+    ///      price. 2% (200 bps) is a widely-used default used by other
+    ///      Chainlink-compat adapters (Synthetix, Aave) and balances data
+    ///      availability vs. accepting wide-conf prices during market
+    ///      dislocations. Applies to the Chainlink-compat `latestRoundData`
+    ///      path only — `latestPriceData()` still returns raw conf for
+    ///      informed consumers who want to enforce a custom threshold.
+    uint256 public constant MAX_CONF_BPS = 200;
 
     /// @notice Lock the implementation contract from direct initialization.
     ///         Clones deployed via `Clones.clone` have independent storage and
@@ -88,6 +100,7 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
         _checkStaleness(parsed.publishTime);
 
         if (parsed.price <= 0) revert NonPositivePrice();
+        _checkConfidence(parsed.price, parsed.conf);
 
         answer = _normalize(parsed.price, parsed.expo);
         roundId = 1;
@@ -176,6 +189,17 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
 
     function _checkPaused() internal view {
         if (IAdapterFactory(factory).isPaused(address(this))) revert AdapterPaused();
+    }
+
+    /// @dev Reverts if `conf / price > MAX_CONF_BPS / 10_000`. Caller must
+    ///      ensure `price > 0` first so the cast to uint64 is safe. The
+    ///      multiplication uses uint256 to prevent overflow — conf is up to
+    ///      uint64 max (~1.8e19) and MAX_CONF_BPS is 200, so
+    ///      `conf * 10_000` fits comfortably in uint256.
+    function _checkConfidence(int64 price, uint64 conf) internal pure {
+        if (uint256(conf) * 10_000 > uint256(uint64(price)) * MAX_CONF_BPS) {
+            revert ConfidenceExceedsThreshold();
+        }
     }
 
     /// @dev Normalize Pyth price to 8 decimals.

--- a/contracts/oracle/PythPullParser.sol
+++ b/contracts/oracle/PythPullParser.sol
@@ -31,6 +31,7 @@ import "../convert.sol";
 library PythPullParser {
     error InvalidPythPullAccount();
     error PythPullDataTooShort();
+    error UnsupportedVerificationVariant();
 
     uint256 constant MIN_DATA_LENGTH = 133;
 
@@ -42,6 +43,13 @@ library PythPullParser {
     // the byte layout below. Run scripts/oracle/validate-pyth-pull-offsets.ts
     // against a live Solana devnet feed to confirm post-change.
     bytes8 constant DISCRIMINATOR = 0x22f123639d7ef4cd;
+
+    /// @notice Borsh enum tag for `VerificationLevel::Full`. The PriceUpdateV2
+    /// layout this parser targets is defined only for the Full variant; a
+    /// Partial account (tag 0x00) is followed by `num_signatures: u8`, shifting
+    /// every subsequent field by one byte. Reject such accounts explicitly so
+    /// we never silently read from shifted offsets.
+    bytes1 constant VERIFICATION_LEVEL_FULL = 0x01;
 
     struct PythPullPrice {
         int64 price;
@@ -64,6 +72,11 @@ library PythPullParser {
             disc := mload(add(data, 0x20))
         }
         if (disc != DISCRIMINATOR) revert InvalidPythPullAccount();
+
+        // Validate verification_level at offset 40 is Full (0x01). Any other
+        // value (Partial = 0x00, or an unknown future variant) shifts the
+        // remaining fields and would produce silent garbage.
+        if (data[40] != VERIFICATION_LEVEL_FULL) revert UnsupportedVerificationVariant();
 
         // price at offset 73 (int64, LE)
         (parsed.price,) = Convert.read_i64le(data, 73);

--- a/contracts/oracle/SwitchboardParser.sol
+++ b/contracts/oracle/SwitchboardParser.sol
@@ -4,7 +4,16 @@ pragma solidity ^0.8.20;
 import "../convert.sol";
 
 /// @title SwitchboardParser
-/// @notice Parses AggregatorAccountData from Switchboard V2 on Solana.
+/// @notice Parses AggregatorAccountData from Switchboard V2 on Solana
+///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f).
+/// @dev Despite the adjacent `SwitchboardV3Adapter` name, this parser and
+///      the adapter's Solana program ID both target the V2 legacy aggregator
+///      schema — V3 (Switchboard On-Demand, program
+///      SBondMDrcV3K4kxZR1HNVT7osZxAHVHgYXL5Ze1oMUv) uses a different layout
+///      and is not supported here. Renaming the adapter contract was out of
+///      scope for the M-6 audit fix because the contract name is wired into
+///      the deploy / test scripts we agreed not to touch.
+///
 /// @dev Switchboard stores results as SwitchboardDecimal:
 ///   - mantissa: i128 (16 bytes, little-endian)
 ///   - scale: u32 (4 bytes, little-endian)
@@ -26,13 +35,14 @@ library SwitchboardParser {
     error InvalidSwitchboardAccount();
     error SwitchboardDataTooShort();
 
-    /// @notice Anchor discriminator for AggregatorAccountData
+    /// @notice Anchor discriminator for Switchboard V2 AggregatorAccountData
+    ///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f).
     /// sha256("account:AggregatorAccountData")[0..8]
-    // Switchboard V3 AggregatorAccountData Anchor discriminator.
     // Derivation: bytes8(sha256("account:AggregatorAccountData")) = 0xd9e64165c9a21b7d.
-    // If Switchboard renames the account type, update this constant AND the
-    // byte layout. Run scripts/oracle/validate-switchboard-offsets.ts against
-    // a live Solana devnet aggregator to confirm post-change.
+    // If Switchboard renames the account type or migrates to V3 On-Demand,
+    // update this constant AND the byte layout. Run
+    // scripts/oracle/validate-switchboard-offsets.ts against a live Solana
+    // devnet aggregator to confirm post-change.
     bytes8 constant DISCRIMINATOR = 0xd9e64165c9a21b7d;
 
     /// @notice Byte offset of latest_confirmed_round.round_open_slot
@@ -54,7 +64,8 @@ library SwitchboardParser {
         uint64 slot;
     }
 
-    /// @notice Parse a Switchboard V2 AggregatorAccountData
+    /// @notice Parse a Switchboard V2 AggregatorAccountData (program
+    ///         SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f)
     /// @param data Raw account data from CPI precompile
     /// @return parsed The parsed price data
     function parse(bytes memory data) internal pure returns (SwitchboardPrice memory parsed) {

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -18,6 +18,10 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     address public factory;
     bool public initialized;
     uint64 public createdAt;
+    /// @notice Solana program that must own `switchboardAccount` on every
+    ///         read. See PythPullAdapter for the rationale; the same storage
+    ///         pattern applies (clones preclude `immutable`).
+    bytes32 public expectedProgramId;
 
     error StalePriceFeed();
     error AdapterPaused();
@@ -27,6 +31,7 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     error OnlyFactory();
     error EMANotSupported();
     error StalenessOutOfRange(uint256 staleness);
+    error AccountOwnerChanged();
 
     /// @notice Lock the implementation contract from direct initialization.
     ///         Clones deployed via `Clones.clone` have independent storage and
@@ -38,11 +43,15 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     }
 
     /// @notice Initialize the adapter (called once by factory after clone deployment)
+    /// @param _expectedProgramId Solana program that must own `_switchboardAccount`
+    ///        on every read (validated at each `_readAndParse` to detect
+    ///        account ownership reassignment via `assign` — M-5).
     function initialize(
         bytes32 _switchboardAccount,
         string calldata desc,
         uint256 _maxStaleness,
-        address _factory
+        address _factory,
+        bytes32 _expectedProgramId
     ) external {
         if (initialized) revert AlreadyInitialized();
         if (_maxStaleness < 1 || _maxStaleness > 24 hours) revert StalenessOutOfRange(_maxStaleness);
@@ -52,6 +61,7 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
         _description = desc;
         maxStaleness = _maxStaleness;
         factory = _factory;
+        expectedProgramId = _expectedProgramId;
         createdAt = uint64(block.timestamp);
     }
 
@@ -154,8 +164,17 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
 
     // --- Internal helpers ---
 
+    /// @dev Fetches the current owner and data for `switchboardAccount`.
+    ///      Split out as `virtual` so test harnesses can override the CPI
+    ///      precompile call (unavailable on hardhat's simulated network).
+    function _fetchAccount() internal view virtual returns (bytes32 owner, bytes memory data) {
+        (, owner,,,, data) = CpiProgram.account_info(switchboardAccount);
+    }
+
     function _readAndParse() internal view returns (SwitchboardParser.SwitchboardPrice memory) {
-        (,,,,, bytes memory data) = CpiProgram.account_info(switchboardAccount);
+        (bytes32 owner, bytes memory data) = _fetchAccount();
+        // M-5: revalidate owner on every read — see PythPullAdapter rationale.
+        if (owner != expectedProgramId) revert AccountOwnerChanged();
         return SwitchboardParser.parse(data);
     }
 

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -123,11 +123,14 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     }
 
     /// @notice Derived price status: 0 = Trading, 1 = Stale, 2 = Paused
+    /// @dev Clock skew (timestamp > block.timestamp) is treated as stale, not
+    ///      a panic — see _checkStaleness for the underflow guard rationale.
     function priceStatus() external view returns (uint8) {
         if (IAdapterFactory(factory).isPaused(address(this))) return 2;
 
         SwitchboardParser.SwitchboardPrice memory parsed = _readAndParse();
-        if (block.timestamp - uint256(uint64(parsed.timestamp)) > maxStaleness) return 1;
+        uint256 ts = uint256(uint64(parsed.timestamp));
+        if (ts > block.timestamp || block.timestamp - ts > maxStaleness) return 1;
         return 0;
     }
 
@@ -156,8 +159,17 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
         return SwitchboardParser.parse(data);
     }
 
+    /// @dev Guards against two failure modes:
+    ///      1. `timestamp > block.timestamp` — Solana clock runs a few seconds
+    ///         ahead of EVM on devnet. Without the explicit check, the subtraction
+    ///         would panic with 0x11 (arithmetic underflow), which is swallowed
+    ///         by BatchReader's `catch{}` and indistinguishable from other errors.
+    ///      2. `block.timestamp - timestamp > maxStaleness` — data too old.
     function _checkStaleness(int64 timestamp) internal view {
-        if (block.timestamp - uint256(uint64(timestamp)) > maxStaleness) revert StalePriceFeed();
+        uint256 ts = uint256(uint64(timestamp));
+        if (ts > block.timestamp || block.timestamp - ts > maxStaleness) {
+            revert StalePriceFeed();
+        }
     }
 
     function _checkPaused() internal view {

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -8,9 +8,16 @@ import "./SwitchboardParser.sol";
 import "../interface.sol";
 
 /// @title SwitchboardV3Adapter
-/// @notice Per-feed adapter that reads AggregatorAccountData from Switchboard V3
-///         via Rome's CPI precompile. Same interface as PythPullAdapter.
-///         Deployed as EIP-1167 clone by OracleAdapterFactory.
+/// @notice Per-feed adapter that reads AggregatorAccountData from Switchboard V2
+///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f) via Rome's CPI
+///         precompile. Same interface as PythPullAdapter. Deployed as EIP-1167
+///         clone by OracleAdapterFactory.
+/// @dev The contract name keeps "V3" for backwards compatibility with the
+///      deploy scripts and cached ABIs, but both the program ID passed by
+///      the factory and the byte layout consumed by SwitchboardParser target
+///      the Switchboard V2 legacy aggregator. See SwitchboardParser.sol for
+///      the underlying layout; see the M-6 fix commit for the naming-fix
+///      rationale.
 contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     bytes32 public switchboardAccount;
     string private _description;
@@ -144,7 +151,8 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
         return 0;
     }
 
-    /// @notice Oracle source type: 1 = SwitchboardV3
+    /// @notice Oracle source type: 1 = Switchboard V2 (see contract-level
+    ///         NatSpec for the name-retention rationale)
     function oracleType() external pure returns (uint8) {
         return 1;
     }

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -28,6 +28,15 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     error EMANotSupported();
     error StalenessOutOfRange(uint256 staleness);
 
+    /// @notice Lock the implementation contract from direct initialization.
+    ///         Clones deployed via `Clones.clone` have independent storage and
+    ///         are unaffected; this prevents an attacker from calling
+    ///         `initialize()` directly on the implementation that
+    ///         `OracleAdapterFactory.switchboardImplementation` points to.
+    constructor() {
+        initialized = true;
+    }
+
     /// @notice Initialize the adapter (called once by factory after clone deployment)
     function initialize(
         bytes32 _switchboardAccount,

--- a/contracts/oracle/test/AccountOwnerHarness.sol
+++ b/contracts/oracle/test/AccountOwnerHarness.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PythPullAdapter.sol";
+import "../SwitchboardV3Adapter.sol";
+
+/// @title PythAccountOwnerHarness
+/// @notice Inherits PythPullAdapter and overrides `_fetchAccount` so tests
+///         can drive the owner-revalidation check (M-5) without the CPI
+///         precompile (unavailable on hardhat's simulated network).
+contract PythAccountOwnerHarness is PythPullAdapter {
+    bytes32 private _mockAccount;
+    bytes32 private _mockOwner;
+    bytes private _mockData;
+
+    /// @dev Reset `initialized` after the parent constructor so this contract
+    ///      can be initialized directly in tests (same pattern as the
+    ///      staleness/confidence harnesses).
+    constructor() PythPullAdapter() {
+        initialized = false;
+    }
+
+    /// @notice Set the mocked CPI response for a given pubkey. Tests call
+    ///         this after initialize() to simulate the Solana account's
+    ///         current state.
+    function setMockAccount(bytes32 account, bytes32 owner, bytes calldata data) external {
+        _mockAccount = account;
+        _mockOwner = owner;
+        _mockData = data;
+    }
+
+    /// @dev Returns the most recently configured owner/data for the adapter's
+    ///      pythAccount. If the mock account pubkey doesn't match, returns
+    ///      zero-owner/empty-data so the owner check reverts cleanly.
+    function _fetchAccount() internal view override returns (bytes32 owner, bytes memory data) {
+        if (_mockAccount == pythAccount) {
+            return (_mockOwner, _mockData);
+        }
+        return (bytes32(0), "");
+    }
+
+    function readAndParseExt() external view returns (
+        int64 price,
+        uint64 conf,
+        int32 expo,
+        uint64 publishTime,
+        int64 emaPrice,
+        uint64 emaConf
+    ) {
+        PythPullParser.PythPullPrice memory p = _readAndParse();
+        return (p.price, p.conf, p.expo, p.publishTime, p.emaPrice, p.emaConf);
+    }
+}
+
+/// @title SwitchboardAccountOwnerHarness
+/// @notice Same as PythAccountOwnerHarness but for SwitchboardV3Adapter.
+contract SwitchboardAccountOwnerHarness is SwitchboardV3Adapter {
+    bytes32 private _mockAccount;
+    bytes32 private _mockOwner;
+    bytes private _mockData;
+
+    constructor() SwitchboardV3Adapter() {
+        initialized = false;
+    }
+
+    function setMockAccount(bytes32 account, bytes32 owner, bytes calldata data) external {
+        _mockAccount = account;
+        _mockOwner = owner;
+        _mockData = data;
+    }
+
+    function _fetchAccount() internal view override returns (bytes32 owner, bytes memory data) {
+        if (_mockAccount == switchboardAccount) {
+            return (_mockOwner, _mockData);
+        }
+        return (bytes32(0), "");
+    }
+
+    function readAndParseExt() external view returns (
+        int128 mantissa,
+        uint32 scale,
+        int64 timestamp,
+        uint64 slot
+    ) {
+        SwitchboardParser.SwitchboardPrice memory p = _readAndParse();
+        return (p.mantissa, p.scale, p.timestamp, p.slot);
+    }
+}

--- a/contracts/oracle/test/AdapterCloneFactory.sol
+++ b/contracts/oracle/test/AdapterCloneFactory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+/// @title AdapterCloneFactory
+/// @notice Minimal test helper for deploying EIP-1167 clones of adapter
+///         implementations without going through OracleAdapterFactory (which
+///         calls the CPI precompile to validate Solana account ownership).
+///         Used by unit tests that need to instantiate a clone and call
+///         initialize() directly.
+contract AdapterCloneFactory {
+    event Cloned(address indexed implementation, address indexed clone);
+
+    function cloneOf(address implementation) external returns (address clone) {
+        clone = Clones.clone(implementation);
+        emit Cloned(implementation, clone);
+    }
+}

--- a/contracts/oracle/test/StalenessHarness.sol
+++ b/contracts/oracle/test/StalenessHarness.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PythPullAdapter.sol";
+import "../SwitchboardV3Adapter.sol";
+
+/// @title PythStalenessHarness
+/// @notice Exposes `PythPullAdapter._checkStaleness` externally so the
+///         H-1 underflow guard can be unit-tested without the CPI precompile.
+///         Overrides the adapter's constructor so `initialized` stays false
+///         and `initialize()` can set `maxStaleness` during test setup.
+contract PythStalenessHarness is PythPullAdapter {
+    /// @dev Reset `initialized` after the parent constructor ran so this test
+    ///      contract can itself call initialize() as if it were a clone.
+    constructor() PythPullAdapter() {
+        initialized = false;
+    }
+
+    function checkStalenessExt(uint64 publishTime) external view {
+        _checkStaleness(publishTime);
+    }
+}
+
+/// @title SwitchboardStalenessHarness
+/// @notice Same as PythStalenessHarness but for SwitchboardV3Adapter.
+contract SwitchboardStalenessHarness is SwitchboardV3Adapter {
+    constructor() SwitchboardV3Adapter() {
+        initialized = false;
+    }
+
+    function checkStalenessExt(int64 timestamp) external view {
+        _checkStaleness(timestamp);
+    }
+}

--- a/contracts/oracle/test/StalenessHarness.sol
+++ b/contracts/oracle/test/StalenessHarness.sol
@@ -32,3 +32,16 @@ contract SwitchboardStalenessHarness is SwitchboardV3Adapter {
         _checkStaleness(timestamp);
     }
 }
+
+/// @title PythConfidenceHarness
+/// @notice Exposes `PythPullAdapter._checkConfidence` externally so the
+///         confidence-interval guard (H-3) can be unit-tested directly.
+contract PythConfidenceHarness is PythPullAdapter {
+    constructor() PythPullAdapter() {
+        initialized = false;
+    }
+
+    function checkConfidenceExt(int64 price, uint64 conf) external pure {
+        _checkConfidence(price, conf);
+    }
+}

--- a/tests/oracle/AccountOwnerRevalidation.test.ts
+++ b/tests/oracle/AccountOwnerRevalidation.test.ts
@@ -1,0 +1,111 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+import { buildSwitchboardAccount } from "./helpers/mockSwitchboard.js";
+
+/// Verifies M-5: adapters revalidate the account's Solana program-owner on
+/// every read. If the account was reassigned to a different program after
+/// `createPythFeed` / `createSwitchboardFeed` ran, the next read must revert
+/// with `AccountOwnerChanged` rather than continuing to parse raw bytes as
+/// if the account were still a Pyth/Switchboard account.
+describe("AccountOwnerRevalidation", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const DESC = "TEST";
+    const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const MAX_STALENESS = 60n;
+    const PROGRAM_ID_A = ("0x" + "11".repeat(32)) as `0x${string}`;
+    const PROGRAM_ID_B = ("0x" + "22".repeat(32)) as `0x${string}`;
+
+    describe("PythPullAdapter", function () {
+        it("stores expectedProgramId at initialize and exposes it via metadata", async function () {
+            const h = await viem.deployContract("PythAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+            const stored = (await h.read.expectedProgramId()) as string;
+            assert.equal(stored.toLowerCase(), PROGRAM_ID_A.toLowerCase());
+        });
+
+        it("reverts with AccountOwnerChanged when mocked owner differs", async function () {
+            const h = await viem.deployContract("PythAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+
+            const valid = buildPythPullAccount({
+                price: 100_000_000n,
+                conf: 100n,
+                expo: -8,
+                publishTime: 1711900800,
+            });
+            // Configure the harness to return PROGRAM_ID_B for this account
+            await h.write.setMockAccount([ACCT, PROGRAM_ID_B, valid]);
+
+            await assert.rejects(
+                async () => h.read.readAndParseExt(),
+                (err: any) => err?.message?.includes("AccountOwnerChanged") ?? false,
+            );
+        });
+
+        it("passes when mocked owner matches expectedProgramId", async function () {
+            const h = await viem.deployContract("PythAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+
+            const valid = buildPythPullAccount({
+                price: 100_000_000n,
+                conf: 100n,
+                expo: -8,
+                publishTime: 1711900800,
+            });
+            await h.write.setMockAccount([ACCT, PROGRAM_ID_A, valid]);
+
+            const [, , , publishTime] = (await h.read.readAndParseExt()) as any;
+            assert.equal(publishTime, 1711900800n);
+        });
+    });
+
+    describe("SwitchboardV3Adapter", function () {
+        it("stores expectedProgramId at initialize and exposes it via metadata", async function () {
+            const h = await viem.deployContract("SwitchboardAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+            const stored = (await h.read.expectedProgramId()) as string;
+            assert.equal(stored.toLowerCase(), PROGRAM_ID_A.toLowerCase());
+        });
+
+        it("reverts with AccountOwnerChanged when mocked owner differs", async function () {
+            const h = await viem.deployContract("SwitchboardAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+
+            const valid = buildSwitchboardAccount({
+                mantissa: 15_000_000_000n,
+                scale: 8,
+                timestamp: 1711900800,
+            });
+            await h.write.setMockAccount([ACCT, PROGRAM_ID_B, valid]);
+
+            await assert.rejects(
+                async () => h.read.readAndParseExt(),
+                (err: any) => err?.message?.includes("AccountOwnerChanged") ?? false,
+            );
+        });
+
+        it("passes when mocked owner matches expectedProgramId", async function () {
+            const h = await viem.deployContract("SwitchboardAccountOwnerHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY, PROGRAM_ID_A]);
+
+            const valid = buildSwitchboardAccount({
+                mantissa: 15_000_000_000n,
+                scale: 8,
+                timestamp: 1711900800,
+            });
+            await h.write.setMockAccount([ACCT, PROGRAM_ID_A, valid]);
+
+            const [, , timestamp] = (await h.read.readAndParseExt()) as any;
+            assert.equal(timestamp, 1711900800n);
+        });
+    });
+});

--- a/tests/oracle/AdapterMetadata.test.ts
+++ b/tests/oracle/AdapterMetadata.test.ts
@@ -56,7 +56,13 @@ describe("AdapterMetadata", function () {
             const description = "SOL / USD";
             const maxStaleness = 60n;
 
-            await adapter.write.initialize([account, description, maxStaleness, factoryAddress]);
+            await adapter.write.initialize([
+                account,
+                description,
+                maxStaleness,
+                factoryAddress,
+                ("0x" + "77".repeat(32)) as `0x${string}`,
+            ]);
 
             const m: any = await adapter.read.metadata();
             assert.equal(m.description, description);
@@ -77,7 +83,13 @@ describe("AdapterMetadata", function () {
             const description = "BTC / USD";
             const maxStaleness = 120n;
 
-            await adapter.write.initialize([account, description, maxStaleness, factoryAddress]);
+            await adapter.write.initialize([
+                account,
+                description,
+                maxStaleness,
+                factoryAddress,
+                ("0x" + "88".repeat(32)) as `0x${string}`,
+            ]);
 
             const m: any = await adapter.read.metadata();
             assert.equal(m.description, description);

--- a/tests/oracle/AdapterMetadata.test.ts
+++ b/tests/oracle/AdapterMetadata.test.ts
@@ -7,19 +7,28 @@ describe("AdapterMetadata", function () {
     const SRC_SWITCHBOARD = 1;
 
     let viem: any;
+    let cloneHelper: any;
+    let pythImplAddr: `0x${string}`;
+    let sbImplAddr: `0x${string}`;
     let factoryAddress: `0x${string}`;
 
     before(async function () {
         const conn = await hardhat.network.connect();
         viem = conn.viem;
 
+        cloneHelper = await viem.deployContract("AdapterCloneFactory", []);
+        const pythImpl = await viem.deployContract("PythPullAdapter", []);
+        const sbImpl = await viem.deployContract("SwitchboardV3Adapter", []);
+        pythImplAddr = pythImpl.address;
+        sbImplAddr = sbImpl.address;
+
         // Deploy a real OracleAdapterFactory so adapter.metadata() can resolve
         // the live paused lookup (which calls IAdapterFactory(factory).isPaused).
         // Impl / programId placeholders are fine — the factory's isPaused()
         // just reads a mapping and returns false for any unpaused adapter.
         const factory = await viem.deployContract("OracleAdapterFactory", [
-            "0x0000000000000000000000000000000000000001" as `0x${string}`, // pythImpl placeholder
-            "0x0000000000000000000000000000000000000002" as `0x${string}`, // switchboardImpl placeholder
+            pythImplAddr,
+            sbImplAddr,
             ("0x" + "00".repeat(31) + "03") as `0x${string}`,              // pythReceiverProgramId placeholder
             ("0x" + "00".repeat(31) + "04") as `0x${string}`,              // switchboardProgramId placeholder
             60n,                                                            // defaultMaxStaleness
@@ -27,9 +36,21 @@ describe("AdapterMetadata", function () {
         factoryAddress = factory.address;
     });
 
+    // Deploy an EIP-1167 clone of an implementation. The implementation
+    // contracts are locked from direct initialize() (C-1), so metadata
+    // tests must run against a clone.
+    async function cloneOf(impl: `0x${string}`, contractName: string) {
+        const publicClient = await viem.getPublicClient();
+        const hash = await cloneHelper.write.cloneOf([impl]);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        const topic = receipt.logs[0].topics[2] as `0x${string}`;
+        const cloneAddr = ("0x" + topic.slice(-40)) as `0x${string}`;
+        return await viem.getContractAt(contractName, cloneAddr);
+    }
+
     describe("PythPullAdapter.metadata()", function () {
         it("returns the values passed at initialize", async function () {
-            const adapter = await viem.deployContract("PythPullAdapter", []);
+            const adapter = await cloneOf(pythImplAddr, "PythPullAdapter");
 
             const account = ("0x" + "ab".repeat(32)) as `0x${string}`;
             const description = "SOL / USD";
@@ -50,7 +71,7 @@ describe("AdapterMetadata", function () {
 
     describe("SwitchboardV3Adapter.metadata()", function () {
         it("returns the values passed at initialize", async function () {
-            const adapter = await viem.deployContract("SwitchboardV3Adapter", []);
+            const adapter = await cloneOf(sbImplAddr, "SwitchboardV3Adapter");
 
             const account = ("0x" + "cd".repeat(32)) as `0x${string}`;
             const description = "BTC / USD";

--- a/tests/oracle/FactoryOwnership.test.ts
+++ b/tests/oracle/FactoryOwnership.test.ts
@@ -1,0 +1,44 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// Unit tests for OracleAdapterFactory ownership transfer guardrails.
+describe("OracleAdapterFactory.transferOwnership", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    async function deployFactory() {
+        const pyth = await viem.deployContract("PythPullAdapter", []);
+        const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        return await viem.deployContract("OracleAdapterFactory", [
+            pyth.address,
+            sb.address,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
+            ("0x" + "01".repeat(32)) as `0x${string}`,
+            60n,
+        ]);
+    }
+
+    it("reverts when transferring ownership to the zero address", async function () {
+        const factory = await deployFactory();
+        await assert.rejects(
+            async () =>
+                factory.write.transferOwnership([
+                    "0x0000000000000000000000000000000000000000" as `0x${string}`,
+                ]),
+            (err: any) => err?.message?.includes("ZeroAddress") ?? false,
+        );
+    });
+
+    it("allows transferring ownership to a non-zero address", async function () {
+        const factory = await deployFactory();
+        const newOwner = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+        await factory.write.transferOwnership([newOwner]);
+        const current = (await factory.read.owner()) as string;
+        assert.equal(current.toLowerCase(), newOwner.toLowerCase());
+    });
+});

--- a/tests/oracle/FactoryPauseRegistry.test.ts
+++ b/tests/oracle/FactoryPauseRegistry.test.ts
@@ -1,0 +1,63 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// Verifies H-4: factory-owner pause/unpause ops must target only registered
+/// adapters. The registry prevents typos from marking arbitrary addresses
+/// as "paused" and keeps emitted events auditable.
+describe("OracleAdapterFactory pause registry", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    async function deployFactory() {
+        const pyth = await viem.deployContract("PythPullAdapter", []);
+        const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        return await viem.deployContract("OracleAdapterFactory", [
+            pyth.address,
+            sb.address,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
+            ("0x" + "01".repeat(32)) as `0x${string}`,
+            60n,
+        ]);
+    }
+
+    function expectAdapterNotRegistered(err: any): boolean {
+        return err?.message?.includes("AdapterNotRegistered") ?? false;
+    }
+
+    it("pauseAdapter reverts for an unregistered address", async function () {
+        const factory = await deployFactory();
+        const rando = "0x000000000000000000000000000000000000cafe" as `0x${string}`;
+        await assert.rejects(
+            async () => factory.write.pauseAdapter([rando]),
+            expectAdapterNotRegistered,
+        );
+    });
+
+    it("unpauseAdapter reverts for an unregistered address", async function () {
+        const factory = await deployFactory();
+        const rando = "0x000000000000000000000000000000000000cafe" as `0x${string}`;
+        await assert.rejects(
+            async () => factory.write.unpauseAdapter([rando]),
+            expectAdapterNotRegistered,
+        );
+    });
+
+    it("isRegisteredAdapter returns false for a fresh EOA", async function () {
+        const factory = await deployFactory();
+        const rando = "0x000000000000000000000000000000000000cafe" as `0x${string}`;
+        const reg = (await factory.read.isRegisteredAdapter([rando])) as boolean;
+        assert.equal(reg, false);
+    });
+
+    // Note: pause/unpause on a genuinely-registered adapter cannot be tested
+    // without going through `createPythFeed` / `createSwitchboardFeed`, both
+    // of which call the CPI precompile (unavailable on hardhat's simulated
+    // network). The successful path is exercised end-to-end on live networks
+    // via scripts/oracle/test-feeds-v2.ts. The registry gate itself — which is
+    // the entire point of H-4 — is covered here.
+});

--- a/tests/oracle/ImplementationLock.test.ts
+++ b/tests/oracle/ImplementationLock.test.ts
@@ -1,0 +1,41 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// Verifies implementation contracts are locked from direct `initialize()`
+/// calls. Bare implementations (pointed to by `pythImplementation` /
+/// `switchboardImplementation` in the factory) must not be callable — any
+/// attacker-controlled initialization of the implementation itself must
+/// revert with `AlreadyInitialized`.
+describe("ImplementationLock", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const DESC = "TEST";
+    const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+
+    function expectAlreadyInitialized(err: any): boolean {
+        return err?.message?.includes("AlreadyInitialized") ?? false;
+    }
+
+    it("PythPullAdapter implementation reverts initialize() on freshly deployed contract", async function () {
+        const impl = await viem.deployContract("PythPullAdapter", []);
+        await assert.rejects(
+            async () => impl.write.initialize([ACCT, DESC, 60n, FACTORY]),
+            expectAlreadyInitialized,
+        );
+    });
+
+    it("SwitchboardV3Adapter implementation reverts initialize() on freshly deployed contract", async function () {
+        const impl = await viem.deployContract("SwitchboardV3Adapter", []);
+        await assert.rejects(
+            async () => impl.write.initialize([ACCT, DESC, 60n, FACTORY]),
+            expectAlreadyInitialized,
+        );
+    });
+});

--- a/tests/oracle/ImplementationLock.test.ts
+++ b/tests/oracle/ImplementationLock.test.ts
@@ -26,7 +26,13 @@ describe("ImplementationLock", function () {
     it("PythPullAdapter implementation reverts initialize() on freshly deployed contract", async function () {
         const impl = await viem.deployContract("PythPullAdapter", []);
         await assert.rejects(
-            async () => impl.write.initialize([ACCT, DESC, 60n, FACTORY]),
+            async () => impl.write.initialize([
+                ACCT,
+                DESC,
+                60n,
+                FACTORY,
+                ("0x" + "bb".repeat(32)) as `0x${string}`,
+            ]),
             expectAlreadyInitialized,
         );
     });
@@ -34,7 +40,13 @@ describe("ImplementationLock", function () {
     it("SwitchboardV3Adapter implementation reverts initialize() on freshly deployed contract", async function () {
         const impl = await viem.deployContract("SwitchboardV3Adapter", []);
         await assert.rejects(
-            async () => impl.write.initialize([ACCT, DESC, 60n, FACTORY]),
+            async () => impl.write.initialize([
+                ACCT,
+                DESC,
+                60n,
+                FACTORY,
+                ("0x" + "bb".repeat(32)) as `0x${string}`,
+            ]),
             expectAlreadyInitialized,
         );
     });

--- a/tests/oracle/ImplementationLock.test.ts
+++ b/tests/oracle/ImplementationLock.test.ts
@@ -51,3 +51,171 @@ describe("ImplementationLock", function () {
         );
     });
 });
+
+/// Verifies C-1 clone-level protection and the M-5 re-init invariant.
+/// Clones deployed via `AdapterCloneFactory.cloneOf` have independent storage,
+/// so the constructor-level lock on the implementation does not protect them.
+/// The production guard is the `if (initialized) revert AlreadyInitialized()`
+/// check inside `initialize()` itself. These tests deploy a fresh clone,
+/// successfully initialize it once, and then verify that a second
+/// `initialize(...)` call always reverts — even when passing different args,
+/// in particular a different `expectedProgramId` (M-5 linchpin).
+describe("CloneDoubleInit", function () {
+    let viem: any;
+    let cloneHelper: any;
+    let pythImplAddr: `0x${string}`;
+    let sbImplAddr: `0x${string}`;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        cloneHelper = await viem.deployContract("AdapterCloneFactory", []);
+        const pythImpl = await viem.deployContract("PythPullAdapter", []);
+        const sbImpl = await viem.deployContract("SwitchboardV3Adapter", []);
+        pythImplAddr = pythImpl.address;
+        sbImplAddr = sbImpl.address;
+    });
+
+    const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const DESC = "TEST";
+    const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const MAX_STALENESS = 60n;
+    const PROGRAM_ID_A = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const PROGRAM_ID_B = ("0x" + "bb".repeat(32)) as `0x${string}`;
+
+    function expectAlreadyInitialized(err: any): boolean {
+        return err?.message?.includes("AlreadyInitialized") ?? false;
+    }
+
+    async function cloneOf(impl: `0x${string}`, contractName: string) {
+        const publicClient = await viem.getPublicClient();
+        const hash = await cloneHelper.write.cloneOf([impl]);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        const topic = receipt.logs[0].topics[2] as `0x${string}`;
+        const cloneAddr = ("0x" + topic.slice(-40)) as `0x${string}`;
+        return await viem.getContractAt(contractName, cloneAddr);
+    }
+
+    describe("PythPullAdapter clone", function () {
+        it("allows initialize() exactly once", async function () {
+            const adapter = await cloneOf(pythImplAddr, "PythPullAdapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            const init = (await adapter.read.initialized()) as boolean;
+            assert.equal(init, true);
+        });
+
+        it("reverts a second initialize() with the same args", async function () {
+            const adapter = await cloneOf(pythImplAddr, "PythPullAdapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            await assert.rejects(
+                async () => adapter.write.initialize([
+                    ACCT,
+                    DESC,
+                    MAX_STALENESS,
+                    FACTORY,
+                    PROGRAM_ID_A,
+                ]),
+                expectAlreadyInitialized,
+            );
+        });
+
+        // M-5 gap: expectedProgramId is the linchpin of owner re-validation.
+        // Once set during initialize() it must not be overwritable by a
+        // subsequent initialize() call.
+        it("reverts a second initialize() with a different expectedProgramId and preserves the stored value (M-5)", async function () {
+            const adapter = await cloneOf(pythImplAddr, "PythPullAdapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            await assert.rejects(
+                async () => adapter.write.initialize([
+                    ACCT,
+                    DESC,
+                    MAX_STALENESS,
+                    FACTORY,
+                    PROGRAM_ID_B,
+                ]),
+                expectAlreadyInitialized,
+            );
+            const stored = (await adapter.read.expectedProgramId()) as string;
+            assert.equal(stored.toLowerCase(), PROGRAM_ID_A.toLowerCase());
+        });
+    });
+
+    describe("SwitchboardV3Adapter clone", function () {
+        it("allows initialize() exactly once", async function () {
+            const adapter = await cloneOf(sbImplAddr, "SwitchboardV3Adapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            const init = (await adapter.read.initialized()) as boolean;
+            assert.equal(init, true);
+        });
+
+        it("reverts a second initialize() with the same args", async function () {
+            const adapter = await cloneOf(sbImplAddr, "SwitchboardV3Adapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            await assert.rejects(
+                async () => adapter.write.initialize([
+                    ACCT,
+                    DESC,
+                    MAX_STALENESS,
+                    FACTORY,
+                    PROGRAM_ID_A,
+                ]),
+                expectAlreadyInitialized,
+            );
+        });
+
+        // M-5 gap: same invariant as PythPullAdapter — expectedProgramId
+        // cannot be overwritten by a second initialize().
+        it("reverts a second initialize() with a different expectedProgramId and preserves the stored value (M-5)", async function () {
+            const adapter = await cloneOf(sbImplAddr, "SwitchboardV3Adapter");
+            await adapter.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                PROGRAM_ID_A,
+            ]);
+            await assert.rejects(
+                async () => adapter.write.initialize([
+                    ACCT,
+                    DESC,
+                    MAX_STALENESS,
+                    FACTORY,
+                    PROGRAM_ID_B,
+                ]),
+                expectAlreadyInitialized,
+            );
+            const stored = (await adapter.read.expectedProgramId()) as string;
+            assert.equal(stored.toLowerCase(), PROGRAM_ID_A.toLowerCase());
+        });
+    });
+});

--- a/tests/oracle/PythConfidence.test.ts
+++ b/tests/oracle/PythConfidence.test.ts
@@ -1,0 +1,59 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// Verifies H-3: PythPullAdapter.latestRoundData must reject updates whose
+/// confidence interval exceeds MAX_CONF_BPS of the price (Pyth's canonical
+/// consumer guidance). The check lives in the Chainlink-compat path; the
+/// raw `latestPriceData()` surface continues to return unchecked conf.
+describe("PythConfidence", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const DESC = "TEST";
+    const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const MAX_STALENESS = 60n;
+
+    async function deployHarness() {
+        const h = await viem.deployContract("PythConfidenceHarness", []);
+        await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+        return h;
+    }
+
+    it("MAX_CONF_BPS is 200 (2%)", async function () {
+        const h = await deployHarness();
+        const max = await h.read.MAX_CONF_BPS();
+        assert.equal(max, 200n);
+    });
+
+    it("passes when conf is exactly at the 2% threshold", async function () {
+        const h = await deployHarness();
+        // price = 100_000_000 (= $1.00 at expo=-8)
+        // threshold = price * 200 / 10000 = 2_000_000
+        await h.read.checkConfidenceExt([100_000_000n, 2_000_000n]);
+    });
+
+    it("reverts with ConfidenceExceedsThreshold when conf is 1 above the threshold", async function () {
+        const h = await deployHarness();
+        await assert.rejects(
+            async () => h.read.checkConfidenceExt([100_000_000n, 2_000_001n]),
+            (err: any) => err?.message?.includes("ConfidenceExceedsThreshold") ?? false,
+        );
+    });
+
+    it("passes for a legitimate low-conf price (0.05%)", async function () {
+        const h = await deployHarness();
+        // 50_000 / 100_000_000 = 0.0005 = 5 bps ≤ 200 bps
+        await h.read.checkConfidenceExt([100_000_000n, 50_000n]);
+    });
+
+    it("passes for conf = 0 (perfect signal)", async function () {
+        const h = await deployHarness();
+        await h.read.checkConfidenceExt([100_000_000n, 0n]);
+    });
+});

--- a/tests/oracle/PythConfidence.test.ts
+++ b/tests/oracle/PythConfidence.test.ts
@@ -62,4 +62,37 @@ describe("PythConfidence", function () {
         const h = await deployHarness();
         await h.read.checkConfidenceExt([100_000_000n, 0n]);
     });
+
+    // H-3 quality note: `_checkConfidence` is exposed via the harness
+    // as `checkConfidenceExt`, so the function's safety contract must
+    // hold even when called with price <= 0 directly (not just via
+    // `latestRoundData`, which calls NonPositivePrice first). Without
+    // the explicit guard, `uint64(price)` silently wraps a negative
+    // int64 to a huge unsigned value and the conf comparison passes.
+    it("reverts with NonPositivePrice when price == 0", async function () {
+        const h = await deployHarness();
+        await assert.rejects(
+            async () => h.read.checkConfidenceExt([0n, 0n]),
+            (err: any) => err?.message?.includes("NonPositivePrice") ?? false,
+        );
+    });
+
+    it("reverts with NonPositivePrice when price == -1", async function () {
+        const h = await deployHarness();
+        await assert.rejects(
+            async () => h.read.checkConfidenceExt([-1n, 0n]),
+            (err: any) => err?.message?.includes("NonPositivePrice") ?? false,
+        );
+    });
+
+    it("reverts with NonPositivePrice when price is negative and conf would otherwise pass", async function () {
+        const h = await deployHarness();
+        // Without the guard, `uint64(-1)` == 2^64 - 1, so a tiny conf would
+        // pass the `conf * 10_000 > uint64(price) * 200` comparison. Assert
+        // we reject on price <= 0 up front instead.
+        await assert.rejects(
+            async () => h.read.checkConfidenceExt([-1_000_000_000n, 100n]),
+            (err: any) => err?.message?.includes("NonPositivePrice") ?? false,
+        );
+    });
 });

--- a/tests/oracle/PythConfidence.test.ts
+++ b/tests/oracle/PythConfidence.test.ts
@@ -21,7 +21,13 @@ describe("PythConfidence", function () {
 
     async function deployHarness() {
         const h = await viem.deployContract("PythConfidenceHarness", []);
-        await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+        await h.write.initialize([
+            ACCT,
+            DESC,
+            MAX_STALENESS,
+            FACTORY,
+            ("0x" + "bb".repeat(32)) as `0x${string}`,
+        ]);
         return h;
     }
 

--- a/tests/oracle/PythPullParser.test.ts
+++ b/tests/oracle/PythPullParser.test.ts
@@ -183,6 +183,39 @@ describe("PythPullParser", function () {
         );
     });
 
+    it("reverts with UnsupportedVerificationVariant when variant byte is 0x00 (Partial)", async function () {
+        // M-1: the parser's fixed offsets are calibrated for the Full variant
+        // (0x01). A Partial account (0x00) shifts every subsequent field by
+        // at least 1 byte, silently producing garbage.
+        const mockData = buildPythPullAccount({
+            verificationVariant: 0x00,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711902000,
+        });
+
+        await assert.rejects(
+            async () => parser.read.parse([mockData]),
+            (err: any) => err?.message?.includes("UnsupportedVerificationVariant") ?? false,
+        );
+    });
+
+    it("reverts with UnsupportedVerificationVariant for an unknown variant byte", async function () {
+        const mockData = buildPythPullAccount({
+            verificationVariant: 0x42,
+            price: 100n,
+            conf: 10n,
+            expo: -8,
+            publishTime: 1711902100,
+        });
+
+        await assert.rejects(
+            async () => parser.read.parse([mockData]),
+            (err: any) => err?.message?.includes("UnsupportedVerificationVariant") ?? false,
+        );
+    });
+
     // ──────────────────────────────────────────────
     // Fuzz: offset stability
     // ──────────────────────────────────────────────
@@ -197,6 +230,7 @@ describe("PythPullParser", function () {
             const knownErrors = [
                 "InvalidPythPullAccount",
                 "PythPullDataTooShort",
+                "UnsupportedVerificationVariant",
                 "revert",
             ];
 

--- a/tests/oracle/StalenessGuard.test.ts
+++ b/tests/oracle/StalenessGuard.test.ts
@@ -18,6 +18,7 @@ describe("StalenessGuard", function () {
     const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
     const DESC = "TEST";
     const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const PROGRAM_ID = ("0x" + "bb".repeat(32)) as `0x${string}`;
 
     // Deploy an EIP-1167 clone of the PythPullAdapter implementation. The
     // implementation itself is locked (initialized=true in constructor) per
@@ -52,7 +53,7 @@ describe("StalenessGuard", function () {
         it("rejects staleness = 0", async function () {
             const a = await deployAdapter();
             await assert.rejects(
-                async () => a.write.initialize([ACCT, DESC, 0n, FACTORY]),
+                async () => a.write.initialize([ACCT, DESC, 0n, FACTORY, PROGRAM_ID]),
                 expectStalenessOutOfRange,
             );
         });
@@ -61,24 +62,24 @@ describe("StalenessGuard", function () {
             const a = await deployAdapter();
             const TOO_LONG = 24n * 60n * 60n + 1n;
             await assert.rejects(
-                async () => a.write.initialize([ACCT, DESC, TOO_LONG, FACTORY]),
+                async () => a.write.initialize([ACCT, DESC, TOO_LONG, FACTORY, PROGRAM_ID]),
                 expectStalenessOutOfRange,
             );
         });
 
         it("accepts staleness = 1", async function () {
             const a = await deployAdapter();
-            await a.write.initialize([ACCT, DESC, 1n, FACTORY]);
+            await a.write.initialize([ACCT, DESC, 1n, FACTORY, PROGRAM_ID]);
         });
 
         it("accepts staleness = 24 hours (86400)", async function () {
             const a = await deployAdapter();
-            await a.write.initialize([ACCT, DESC, 86400n, FACTORY]);
+            await a.write.initialize([ACCT, DESC, 86400n, FACTORY, PROGRAM_ID]);
         });
 
         it("accepts staleness = 60", async function () {
             const a = await deployAdapter();
-            await a.write.initialize([ACCT, DESC, 60n, FACTORY]);
+            await a.write.initialize([ACCT, DESC, 60n, FACTORY, PROGRAM_ID]);
         });
     });
 

--- a/tests/oracle/StalenessGuard.test.ts
+++ b/tests/oracle/StalenessGuard.test.ts
@@ -4,18 +4,32 @@ import hardhat from "hardhat";
 
 describe("StalenessGuard", function () {
     let viem: any;
+    let cloneHelper: any;
+    let pythImplAddr: `0x${string}`;
 
     before(async function () {
         const conn = await hardhat.network.connect();
         viem = conn.viem;
+        cloneHelper = await viem.deployContract("AdapterCloneFactory", []);
+        const impl = await viem.deployContract("PythPullAdapter", []);
+        pythImplAddr = impl.address;
     });
 
     const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
     const DESC = "TEST";
     const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
 
+    // Deploy an EIP-1167 clone of the PythPullAdapter implementation. The
+    // implementation itself is locked (initialized=true in constructor) per
+    // C-1, so tests that exercise `initialize()` must run against a clone.
     async function deployAdapter() {
-        return await viem.deployContract("PythPullAdapter", []);
+        const publicClient = await viem.getPublicClient();
+        const hash = await cloneHelper.write.cloneOf([pythImplAddr]);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        // The Cloned(impl, clone) event's `clone` address lives in topic[2].
+        const topic = receipt.logs[0].topics[2] as `0x${string}`;
+        const cloneAddr = ("0x" + topic.slice(-40)) as `0x${string}`;
+        return await viem.getContractAt("PythPullAdapter", cloneAddr);
     }
 
     async function deployFactory(defaultStaleness: bigint) {

--- a/tests/oracle/StalenessUnderflow.test.ts
+++ b/tests/oracle/StalenessUnderflow.test.ts
@@ -41,7 +41,13 @@ describe("StalenessUnderflow", function () {
     describe("PythPullAdapter._checkStaleness", function () {
         async function deployHarness() {
             const h = await viem.deployContract("PythStalenessHarness", []);
-            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+            await h.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                ("0x" + "bb".repeat(32)) as `0x${string}`,
+            ]);
             return h;
         }
 
@@ -75,7 +81,13 @@ describe("StalenessUnderflow", function () {
     describe("SwitchboardV3Adapter._checkStaleness", function () {
         async function deployHarness() {
             const h = await viem.deployContract("SwitchboardStalenessHarness", []);
-            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+            await h.write.initialize([
+                ACCT,
+                DESC,
+                MAX_STALENESS,
+                FACTORY,
+                ("0x" + "bb".repeat(32)) as `0x${string}`,
+            ]);
             return h;
         }
 

--- a/tests/oracle/StalenessUnderflow.test.ts
+++ b/tests/oracle/StalenessUnderflow.test.ts
@@ -1,0 +1,107 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// Verifies H-1: `_checkStaleness` must not panic with 0x11 (arithmetic
+/// underflow) when `publishTime > block.timestamp`. Such clock skew is
+/// real on devnet — Solana's clock can run a few seconds ahead of EVM's
+/// — and the old code's `block.timestamp - publishTime` subtraction would
+/// panic, which is swallowed by BatchReader's `catch{}` and indistinguishable
+/// from other failure modes.
+///
+/// The fix reverts with `StalePriceFeed` instead, for both adapters.
+describe("StalenessUnderflow", function () {
+    let viem: any;
+    let publicClient: any;
+    const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const DESC = "TEST";
+    const FACTORY = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const MAX_STALENESS = 60n;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        publicClient = await viem.getPublicClient();
+    });
+
+    function expectStalePriceFeed(err: any): boolean {
+        // panic 0x11 is the underflow — if we see it, the fix is missing.
+        assert.ok(
+            !(err?.message?.includes("0x11") || err?.message?.includes("underflow")),
+            `Unexpected arithmetic underflow panic: ${err?.message}`,
+        );
+        return err?.message?.includes("StalePriceFeed") ?? false;
+    }
+
+    async function currentBlockTimestamp(): Promise<bigint> {
+        const block = await publicClient.getBlock();
+        return BigInt(block.timestamp);
+    }
+
+    describe("PythPullAdapter._checkStaleness", function () {
+        async function deployHarness() {
+            const h = await viem.deployContract("PythStalenessHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+            return h;
+        }
+
+        it("passes when publishTime == block.timestamp", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            await h.read.checkStalenessExt([ts]);
+        });
+
+        it("reverts with StalePriceFeed when publishTime is one second in the future", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            await assert.rejects(
+                async () => h.read.checkStalenessExt([ts + 1n]),
+                expectStalePriceFeed,
+            );
+        });
+
+        it("reverts with StalePriceFeed when publishTime is older than maxStaleness", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            // ts - MAX_STALENESS - 1 → strictly older than maxStaleness.
+            await assert.rejects(
+                async () =>
+                    h.read.checkStalenessExt([ts - MAX_STALENESS - 1n]),
+                expectStalePriceFeed,
+            );
+        });
+    });
+
+    describe("SwitchboardV3Adapter._checkStaleness", function () {
+        async function deployHarness() {
+            const h = await viem.deployContract("SwitchboardStalenessHarness", []);
+            await h.write.initialize([ACCT, DESC, MAX_STALENESS, FACTORY]);
+            return h;
+        }
+
+        it("passes when timestamp == block.timestamp", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            await h.read.checkStalenessExt([ts]);
+        });
+
+        it("reverts with StalePriceFeed when timestamp is one second in the future", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            await assert.rejects(
+                async () => h.read.checkStalenessExt([ts + 1n]),
+                expectStalePriceFeed,
+            );
+        });
+
+        it("reverts with StalePriceFeed when timestamp is older than maxStaleness", async function () {
+            const h = await deployHarness();
+            const ts = await currentBlockTimestamp();
+            await assert.rejects(
+                async () =>
+                    h.read.checkStalenessExt([ts - MAX_STALENESS - 1n]),
+                expectStalePriceFeed,
+            );
+        });
+    });
+});

--- a/tests/oracle/helpers/mockPythPull.ts
+++ b/tests/oracle/helpers/mockPythPull.ts
@@ -25,6 +25,10 @@ export interface PythPullAccountParams {
     emaPrice?: bigint;
     emaConf?: bigint;
     feedId?: string;
+    /// Verification variant byte at offset 40. Pyth's Anchor enum uses
+    /// 0x00 = Partial, 0x01 = Full. Defaults to Full. Set to 0x00 to exercise
+    /// the parser's variant guard (M-1).
+    verificationVariant?: number;
 }
 
 const DEFAULT_DISCRIMINATOR = 0x22f123639d7ef4cdn;
@@ -65,8 +69,8 @@ export function buildPythPullAccount(params: PythPullAccountParams): `0x${string
         buf[i] = Number((disc >> BigInt((7 - i) * 8)) & 0xffn);
     }
 
-    // verification_level = Full at offset 40
-    buf[40] = 0x01;
+    // verification_level at offset 40 (default 0x01 = Full)
+    buf[40] = params.verificationVariant ?? 0x01;
 
     // price at offset 73 (i64, LE)
     writeInt64LE(buf, 73, params.price);


### PR DESCRIPTION
## Summary

Fixes 8 findings from the Oracle Gateway V2 security audit:

| Tag | Severity | Fix |
|-----|----------|-----|
| C-1 | Critical | Lock implementation contracts from direct `initialize()` via `initialized = true` in constructor |
| C-2 | Critical | Guard `transferOwnership` against `address(0)` to prevent brick-by-typo |
| H-1 | High | Reject `publishTime > block.timestamp` cleanly instead of arithmetic panic |
| H-3 | High | Reject Pyth prices whose confidence interval exceeds 2% of price in `latestRoundData`; also guard `_checkConfidence` primitive against non-positive prices |
| H-4 | High | Gate `pauseAdapter` / `unpauseAdapter` on a new `isRegisteredAdapter` mapping |
| M-1 | Medium | Reject non-Full Pyth verification variants (`data[40] != 0x01`) |
| M-5 | Medium | Revalidate Solana account owner on every `_readAndParse` via stored `expectedProgramId` passed through `initialize()` |
| M-6 | Medium | Document Switchboard V2 naming consistently; contract filename kept for downstream compat |

## Tests

- `70 passing / 0 failing` (up from 35 on master).
- 6 new test files: `ImplementationLock`, `FactoryOwnership`, `StalenessUnderflow`, `PythConfidence`, `FactoryPauseRegistry`, `AccountOwnerRevalidation`.
- 3 new test-only harnesses under `contracts/oracle/test/`.
- Added `CloneDoubleInit` coverage validating clones cannot be re-initialized (closes C-1/M-5 clone-level threat).

## Known scope gaps (follow-ups)

- **CI currently runs zero oracle tests.** `npx hardhat test` in `.github/workflows/ci.yml` runs the Solidity-test runner only; the node:test runner must be invoked via `npx hardhat test nodejs <files>`. Needs separate PR (OAuth workflow scope).
- **H-4 / M-5 happy-path round trip** requires CPI precompile, covered by devnet integration scripts, not unit tests.
- **M-6 contract rename** (`SwitchboardV3Adapter.sol` → `SwitchboardV2Adapter.sol`) deferred — would touch deploy scripts + deployments JSON + portal ABI caches. NatSpec is now consistent.
- **Remaining audit findings (H-2, M-2, M-3, M-4, L-1, L-2)** to be addressed in a follow-up PR.

## Test plan

- [ ] CI (`build-and-test`, CodeQL, GitGuardian) all green
- [ ] Local: `npx hardhat compile` clean
- [ ] Local: `npx hardhat test nodejs tests/oracle/*.test.ts` → 70 passing
- [ ] After merge: re-run `scripts/oracle/test-feeds-v2.ts --network marcus` and confirm existing feeds still read (no runtime regression from the `expectedProgramId` init-signature change — only newly deployed adapters get the check, existing ones are already live)

🤖 _This response was generated by Claude Code._