### PR TITLE
ci: run oracle tests in CI and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -17,4 +18,4 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npx hardhat compile
-      - run: npx hardhat test
+      - run: npx hardhat test nodejs tests/oracle/*.test.ts


### PR DESCRIPTION
Closes #32.

## Summary

- Fix the CI test step so the 70 oracle tests in \`tests/oracle/*.test.ts\` actually run on every PR. Bare \`npx hardhat test\` under Hardhat 3 only invokes the Solidity test runner (which finds nothing under \`contracts/test/\`), so the suite has been silently unenforced on master since it was written.
- Add \`workflow_dispatch:\` so CI can be re-run manually from the Actions UI.
- Enable weekly Dependabot for \`npm\` and \`github-actions\` per the issue body.

## Changes

- \`.github/workflows/ci.yml\`
  - \`on:\` — add \`workflow_dispatch:\` alongside the existing \`push\` / \`pull_request\` triggers on \`master\`.
  - \`run:\` — change \`npx hardhat test\` → \`npx hardhat test nodejs tests/oracle/*.test.ts\`.
- \`.github/dependabot.yml\` — new file, weekly \`npm\` + \`github-actions\` updates, PR caps of 5 / 3 respectively.

## Why oracle-only (not bridge too)

Pre-flight local run revealed that \`tests/bridge/*.test.ts\` has **9 real failures** — stale derive-account counts and a viem \`deployContract\` failure that points at constructor-ABI drift since Bridge Phase 1 (PR #28). Fixing those is a non-trivial test-code change and outside #32's scope (\"CI is running zero oracle tests\").

Filed as follow-up issue **#34**. When that's closed, the \`run:\` step can be extended to \`tests/oracle/*.test.ts tests/bridge/*.test.ts\`.

## Out of scope (tracked separately)

- Integration tests (\`*.integration.ts\`) in CI — requires a funded key and live Rome-EVM stack; will be its own issue.
- Fixing bridge unit-test drift — issue #34.

## Test plan

- [x] Run \`npx hardhat test nodejs tests/oracle/*.test.ts\` locally → **70/70 passing** (2.4s on hardhatMainnet simulated EDR).
- [x] Confirm the glob does not match \`*.integration.ts\`.
- [x] Confirm Hardhat v3.1.12 exposes the \`nodejs\` runner subcommand (it does).
- [ ] CI on this PR turns green.
- [ ] (Post-merge sanity) Trigger the workflow via \`workflow_dispatch\` from the Actions UI to confirm manual runs work.
- [ ] (Post-merge sanity) Confirm Dependabot opens its first PRs within a week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)