### PR TITLE
test(bridge): sync fixtures with Phase 1 contracts and enable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npx hardhat compile
-      - run: npx hardhat test nodejs tests/oracle/*.test.ts
+      - run: npx hardhat test nodejs tests/oracle/*.test.ts tests/bridge/*.test.ts

--- a/tests/bridge/RomeBridgeWithdraw.test.ts
+++ b/tests/bridge/RomeBridgeWithdraw.test.ts
@@ -60,6 +60,7 @@ describe("RomeBridgeWithdraw — error paths", () => {
       // CctpParams — all fields now required including program IDs
       {
         tokenMessengerProgram: DUMMY_PROGRAM,
+        messageTransmitterProgram: DUMMY_PROGRAM,
         splTokenProgram: DUMMY_PROGRAM,
         systemProgram: ZERO_BYTES32,
         messageTransmitterConfig: ZERO_BYTES32,
@@ -67,6 +68,7 @@ describe("RomeBridgeWithdraw — error paths", () => {
         remoteTokenMessenger: ZERO_BYTES32,
         tokenMinter: ZERO_BYTES32,
         localTokenUsdc: ZERO_BYTES32,
+        senderAuthorityPda: ZERO_BYTES32,
         eventAuthority: ZERO_BYTES32,
       },
       // WormholeParams — all fields now required including program IDs and sysvars
@@ -85,6 +87,8 @@ describe("RomeBridgeWithdraw — error paths", () => {
         feeCollector: ZERO_BYTES32,
         emitter: ZERO_BYTES32,
         sequence: ZERO_BYTES32,
+        wrappedMeta: ZERO_BYTES32,
+        targetChain: 2,
       },
     ]);
   });

--- a/tests/bridge/derive.test.ts
+++ b/tests/bridge/derive.test.ts
@@ -3,7 +3,7 @@
  *
  * Runs without a Rome stack or live network — pure TypeScript + @solana/web3.js.
  * Verifies that deriveCctpAccounts and deriveWormholeAccounts:
- *   1. Return the correct number of fields (6 CCTP, 8 Wormhole).
+ *   1. Return the correct number of fields (7 CCTP, 9 Wormhole).
  *   2. All field values are well-formed bytes32 (0x + 64 hex digits).
  *   3. Derivations are deterministic (same input → same output).
  *
@@ -20,21 +20,21 @@ import { SPL_MINTS } from "../../scripts/bridge/constants.js";
 const BYTES32_RE = /^0x[0-9a-fA-F]{64}$/;
 
 describe("Bridge PDA derivations", () => {
-  it("deriveCctpAccounts returns 6 well-formed bytes32 values", () => {
+  it("deriveCctpAccounts returns 7 well-formed bytes32 values", () => {
     const usdcMint = new PublicKey(SPL_MINTS.USDC_NATIVE);
     const pdas = deriveCctpAccounts(usdcMint);
     const keys = Object.keys(pdas);
-    assert.strictEqual(keys.length, 6);
+    assert.strictEqual(keys.length, 7);
     for (const [, value] of Object.entries(pdas)) {
       assert.match(value, BYTES32_RE, `Expected bytes32 hex, got: ${value}`);
     }
   });
 
-  it("deriveWormholeAccounts returns 8 well-formed bytes32 values", () => {
+  it("deriveWormholeAccounts returns 9 well-formed bytes32 values", () => {
     const wethMint = new PublicKey(SPL_MINTS.WETH_WORMHOLE);
     const pdas = deriveWormholeAccounts(wethMint);
     const keys = Object.keys(pdas);
-    assert.strictEqual(keys.length, 8);
+    assert.strictEqual(keys.length, 9);
     for (const [, value] of Object.entries(pdas)) {
       assert.match(value, BYTES32_RE, `Expected bytes32 hex, got: ${value}`);
     }


### PR DESCRIPTION
Closes #34.

## Summary

- Unblock the 9 bridge unit tests that were silently failing on master (CI wasn't running them until #32 landed).
- Extend the CI glob to also run \`tests/bridge/*.test.ts\` so drift is caught on PR.
- All 9 failures were **test-only drift** from PR #28 (Rome Bridge Phase 1). No contract changes.

## Why

PR #28 added new fields to both the Solana account-bundle helpers and the \`RomeBridgeWithdraw\` constructor structs, but the test fixtures were not updated in lockstep. Because CI wasn't executing \`tests/bridge/*.test.ts\` (the Hardhat 3 \`nodejs\` runner wasn't being invoked — fixed in #32), the drift accumulated invisibly. Running the suite locally against current master reproduces all 9 failures.

## Changes

- \`tests/bridge/derive.test.ts\`
  - \`deriveCctpAccounts\` length assertion: 6 → **7** (\`cctpSenderAuthorityPda\` was added).
  - \`deriveWormholeAccounts\` length assertion: 8 → **9** (\`wormholeWrappedMeta\` was added).
  - File-header doc comment updated to match.
  - The per-field bytes32 regex and distinctness tests already iterate \`Object.entries\` / \`Object.values\`, so the new fields are covered automatically.
- \`tests/bridge/RomeBridgeWithdraw.test.ts\` — in the \`beforeEach\` \`viem.deployContract\` call, add the four fields that the current struct definitions in \`contracts/bridge/RomeBridgeWithdraw.sol\` require but the test was omitting:
  - \`CctpParams\`: \`messageTransmitterProgram\`, \`senderAuthorityPda\`.
  - \`WormholeParams\`: \`wrappedMeta\`, \`targetChain\` (uint16, \`2\` = Wormhole Ethereum mainnet chain id — value is arbitrary since these tests only exercise pre-CPI guard reverts).
  - Inserted in struct-declaration order.
- \`.github/workflows/ci.yml\` — extend the test invocation to also include \`tests/bridge/*.test.ts\`.

## Not changed

- No Solidity contract, deploy script, or derive helper is modified. The contract code is correct; only the tests were stale.
- \`RomeBridgePaymaster.test.ts\` — all 11 tests already pass; no change needed (constructor is \`(address admin)\`, no drift).
- \`tests/damm_v1_pool.integration.ts\`, \`tests/erc20spl_factory.integration.ts\`, \`tests/bridge/RomeBridgeWithdraw.integration.ts\` — these are \`*.integration.ts\` files; they need a live Rome-EVM stack and stay excluded from CI until the separate integration-tests-in-CI initiative is scoped.

## Test plan

- [x] \`npx hardhat test nodejs tests/bridge/*.test.ts\` → **24 passing** locally (was 15 passing / 9 failing on master).
- [x] \`npx hardhat test nodejs tests/oracle/*.test.ts tests/bridge/*.test.ts\` (matches the new CI invocation) → **94 passing**.
- [ ] CI on this PR turns green using the combined glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)