### PR TITLE
fix(deps) + ops(oracle): unblock npm ci and deploy V2 to subura

### DIFF
--- a/deployments/subura.json
+++ b/deployments/subura.json
@@ -1,0 +1,71 @@
+{
+  "OracleGatewayV2": {
+    "deployedAt": "2026-04-21T19:50:11.685Z",
+    "defaultMaxStaleness": 300,
+    "pythReceiverProgramId": "0x0cb7fabb52f7a648bb5b317d9a018b9057cb024774fafe01e6c4df98cc385881",
+    "switchboardProgramId": "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90",
+    "PythPullAdapterImpl": "0xefe4c8edeeb7379c688ce6227b13e16b4f8d7f6f",
+    "SwitchboardV3AdapterImpl": "0x37fcb45465348a3102c56efd1ad210baf23706e6",
+    "OracleAdapterFactory": "0xf543ae0b6cab80a9ea282ee7e706e4eb735d0e72",
+    "BatchReader": "0x6a3bcb3dea144de2609e9841c4a7d875b6cb8a6e",
+    "feeds": {
+      "pyth": [
+        {
+          "pair": "SOL/USD",
+          "adapter": "0x9D01A836CdA49EC579D77D452b2955Dcf2FBcE6c",
+          "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+          "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
+        },
+        {
+          "pair": "BTC/USD",
+          "adapter": "0x32Ecf7fe2B4D0a5Ab571a2a0662b4674BE2c39C9",
+          "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+          "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
+        },
+        {
+          "pair": "ETH/USD",
+          "adapter": "0x486b1bFfc19153Fb030E5d25ED0FC5a9b57A7992",
+          "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+          "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
+        },
+        {
+          "pair": "USDC/USD",
+          "adapter": "0x9749688C82A3f442456C046655BBb2b12a90B9F9",
+          "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
+          "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
+        },
+        {
+          "pair": "USDT/USD",
+          "adapter": "0xE520aFee5b92a9A15a24d8C3A7779c1916D2C796",
+          "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
+          "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
+        }
+      ],
+      "switchboard": [
+        {
+          "pair": "SOL/USD",
+          "adapter": "0x018FdD49E8432f243fB855b1713EDc6773ded14F",
+          "pubkey": "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
+          "pubkeyBytes32": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a"
+        }
+      ]
+    },
+    "feedsVerified": [
+      {
+        "pair": "SOL / USD",
+        "pythAccountBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243",
+        "adapter": "0x9D01A836CdA49EC579D77D452b2955Dcf2FBcE6c"
+      },
+      {
+        "pair": "BTC / USD",
+        "pythAccountBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de",
+        "adapter": "0x32Ecf7fe2B4D0a5Ab571a2a0662b4674BE2c39C9"
+      },
+      {
+        "pair": "ETH / USD",
+        "pythAccountBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb",
+        "adapter": "0x486b1bFfc19153Fb030E5d25ED0FC5a9b57A7992"
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rome-bridge-phase1-contracts",
+  "name": "rome-solidity",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1685,9 +1685,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1705,9 +1702,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1725,9 +1719,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,9 +1736,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,9 +1753,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1785,9 +1770,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3715,9 +3697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3739,9 +3718,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3763,9 +3739,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3787,9 +3760,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "typescript": "~5.8.0",
     "viem": "^2.47.4",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "utf-8-validate": "^6.0.2"
   }
 }


### PR DESCRIPTION
Two things in one branch:

1. **Lockfile fix** — unblocks \`npm ci\` in both CI workflows (\`build-and-test\` and the new \`Deploy Oracle Gateway V2\`), which have been failing on \`Missing: utf-8-validate@5.0.10 from lock file\` since Node 22 / npm 10 is stricter than the local npm 11 we were using.
2. **Subura V2 deployment** — first real devnet deploy produced by running the workflow's exact three-script pipeline locally against subura (workflow itself can't be triggered from a non-default branch, and master's own CI can't pass until item 1 lands).

Esquiline was attempted in the same session but deferred — Hercules is down and \`waitForTransactionReceipt\` timed out after the first impl deploy. Will land as a follow-up once the network recovers.

## Part 1 — lockfile fix

Closes the failure observed at: https://github.com/rome-protocol/rome-solidity/actions/runs/24742762093

### Root cause

\`@solana/web3.js\` → \`jayson@4.3.0\` → \`ws@7.5.10\` wants \`utf-8-validate ^5.0.2\`. Every other ws consumer (\`hardhat\`, \`viem\`, \`ethers\`) pulls \`utf-8-validate ^6.0.0\`. Local npm 11 dedupes to \`6.0.6\` with an "invalid" warning but still installs; CI's npm 10 (Node 22) refuses the lockfile outright.

### Fix

\`\`\`json
"overrides": {
  "utf-8-validate": "^6.0.2"
}
\`\`\`

Then regenerate \`package-lock.json\`. \`utf-8-validate\` is an optional native dep of ws (pure-JS fallback exists and ws silently uses it when the native addon is absent or version-mismatched), so forcing 6.x everywhere doesn't change runtime behaviour — just makes the lockfile internally consistent.

Incidental cleanup from the regen: stale \`name\` field corrected (\`rome-bridge-phase1-contracts\` → \`rome-solidity\`) and a few \`libc\` metadata entries stripped (npm version difference).

### Verification

- \`npm ls utf-8-validate\` — all 5 consumers resolve to \`6.0.6\`, no invalid markers.
- \`npm ci\` — clean exit locally.
- \`npx hardhat test nodejs tests/oracle/*.test.ts tests/bridge/*.test.ts\` — **94 passing**.

## Part 2 — subura V2 deployment

Ran the deploy pipeline end-to-end against \`subura\` (chainId 121222):

\`\`\`bash
# step 1 — core
npx hardhat run scripts/oracle/deploy-v2-polish.ts --network subura
# step 2 — feeds
npx hardhat run scripts/oracle/deploy-seed-feeds.ts --network subura
# step 3 — verify
npx hardhat run scripts/oracle/test-feeds-v2.ts --network subura
\`\`\`

### Subura addresses

| Contract | Address |
|---|---|
| OracleAdapterFactory | \`0xf543ae0b6cab80a9ea282ee7e706e4eb735d0e72\` |
| BatchReader | \`0x6a3bcb3dea144de2609e9841c4a7d875b6cb8a6e\` |
| PythPullAdapterImpl | \`0xefe4c8edeeb7379c688ce6227b13e16b4f8d7f6f\` |
| SwitchboardV3AdapterImpl | \`0x37fcb45465348a3102c56efd1ad210baf23706e6\` |

### Feeds

- **Pyth**: SOL/USD, BTC/USD, ETH/USD, USDC/USD, USDT/USD (5 deployed). JUP/USD and JTO/USD fail \`InvalidAccountOwner\` upstream; per-feed try/catch skipped them.
- **Switchboard**: SOL/USD (1 deployed).

### Verify output

All 7 sections of \`test-feeds-v2.ts\` pass. BatchReader live prices at deploy time: SOL $84.48, BTC $74942.67, ETH $2293.69. Chainlink compliance, duplicate prevention, pause/unpause — all green.

## Test plan

- [x] \`npm ci\` exits 0 locally with the regenerated lockfile.
- [x] Unit tests green (94 passing).
- [x] Subura V2 deployed + seeded + verified against live network.
- [ ] This PR's CI turns green (the real test for the lockfile fix — confirms npm 10 on GitHub runner accepts the new lockfile).
- [ ] Post-merge: trigger the \`Deploy Oracle Gateway V2\` workflow against \`subura\` via the Actions UI — should idempotently skip the core deploy (since it's already present) and report the existing feeds.

## Not in this PR

- **Esquiline deployment** — blocked on Hercules. Will ship as a follow-up when the network recovers.
- **Marcus address refresh in \`rome-oracle-portal\`** — unchanged from #44's note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)