### PR TITLE
chore(pkg): add name + version so downstream file-deps resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "@rome-protocol/rome-solidity",
+  "version": "0.1.0",
+  "private": true,
   "dependencies": {
     "@openzeppelin/contracts": "^5.6.1",
     "@solana/web3.js": "^1.98.4",


### PR DESCRIPTION
## Summary

Adds \`name\`, \`version\`, and \`private: true\` to \`package.json\` so Hardhat v2 in downstream repos can resolve a \`file:../rome-solidity\` dependency.

## Why

rome-showcase imports generic primitives from this repo (e.g. ICrossProgramInvocation, Convert, RomeEVMAccount, ERC20SPL) via a local path dep. Without \`name\` + \`version\` in this package.json, Hardhat v2's HH11 resolver rejects the link at \`npm install\` time.

Caught during M2D execution in rome-showcase. Landing this fix upstream so any fresh clone of rome-showcase just works after \`npm install\`.

## Scope

- No code changes.
- No CI changes.
- \`"private": true\` prevents accidental npm publish since this is an internal package.

## Test plan

- [x] \`npm install\` still works in rome-solidity itself
- [ ] Confirm rome-showcase builds cleanly after this merges (I'll re-run \`npm install\` there once merged to \`master\`)

🤖 _This response was generated by Claude Code._