### PR TITLE
feat(bridge): add RomeBridgeInbound for paymaster-relayed gas-split

### DIFF
--- a/contracts/bridge/RomeBridgeEvents.sol
+++ b/contracts/bridge/RomeBridgeEvents.sol
@@ -27,4 +27,20 @@ interface RomeBridgeEvents {
         uint8 remainingBudget,
         address indexed target
     );
+
+    /// @notice Emitted when a user settles an inbound-bridge gas-split by
+    ///         converting rUSDC (or any chain-gas-mint wrapper) into native
+    ///         Rome gas via the `unwrap_spl_to_gas` precompile. Mirror of
+    ///         `Withdrawn`; indexers watch both events to reconcile CCTP /
+    ///         Wormhole attestation records against on-Rome settlement.
+    /// @param user            EVM address that received the gas.
+    /// @param mint            SPL mint (bytes32 pubkey) whose wrapper was unwrapped.
+    /// @param wrapperAmount   Mint-unit tokens pulled from user's wrapper balance.
+    /// @param gasAmountWei    Wei credited to user's Rome Balance PDA (18-dec).
+    event SettledInbound(
+        address indexed user,
+        bytes32 indexed mint,
+        uint256 wrapperAmount,
+        uint256 gasAmountWei
+    );
 }

--- a/contracts/bridge/RomeBridgeInbound.sol
+++ b/contracts/bridge/RomeBridgeInbound.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import {SPL_ERC20} from "../erc20spl/erc20spl.sol";
+import {IUnwrapSplToGas, UnwrapSplToGas} from "../interface.sol";
+import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
+
+/// @title  RomeBridgeInbound
+/// @notice Replaces the Solana-side `settle_inbound_bridge` rome-evm-private
+///         instruction with a Solidity contract the worker calls via the
+///         existing `do_tx` instruction (operator-signed, fee_addr=operator
+///         so the user pays zero Rome gas).
+///
+/// @dev    ## Flow
+///         1. CCTP receiveMessage / Wormhole redeem mints `total` rUSDC to
+///            user's PDA-owned ATA (unchanged — happens on Solana side).
+///         2. User signs one EVM tx calling `settleInbound(wrapperAmount)`.
+///         3. Worker submits the tx via `do_tx(fee_addr=operator, rlp)` —
+///            operator pays Rome gas; user pays nothing.
+///         4. `settleInbound`:
+///              - Pulls `wrapperAmount` rUSDC from user's ATA into this
+///                contract's ATA via `SPL_ERC20.transferFrom`.
+///              - Calls `unwrap_spl_to_gas(gasAmountWei)` — wrapper balance
+///                in this contract's ATA becomes gas in this contract's
+///                Balance PDA. The precompile reads `msg.sender`, which
+///                from its point of view is this contract.
+///              - Forwards the just-minted gas to the user via a native
+///                `user.call{value: gasAmountWei}("")`. This debits this
+///                contract's Balance PDA and credits the user's.
+///              - Emits `SettledInbound`.
+///
+///         ## Allowance requirement
+///         User must have previously approved `this` on the SPL_ERC20
+///         wrapper for at least `wrapperAmount`. In the typical inbound
+///         bridge UX this is a second do_tx(fee_addr=operator) submission
+///         that happens right before settleInbound in the same worker pass.
+///
+///         ## Why this contract instead of the on-chain instruction
+///         The rome-evm-private `settle_inbound_bridge` instruction
+///         expects an RLP-encoded signed EVM tx carried in the Solana ix,
+///         which would require `eth_signTransaction` on the client —
+///         MetaMask blocks that. Routing through a regular Solidity
+///         contract call via `do_tx` keeps the UX as standard
+///         `writeContractAsync` on whatever wallet the user has.
+///
+///         ## Why not just `user.call(unwrap_spl_to_gas)` directly
+///         `unwrap_spl_to_gas` reads `msg.sender` and unwraps the CALLER's
+///         wrapper balance into the CALLER's gas balance. If we want to
+///         atomically record events / enforce invariants / emit structured
+///         audit data, we need a contract wrapper. This is it.
+contract RomeBridgeInbound is ERC2771Context, RomeBridgeEvents {
+    /// @notice ERC20-SPL wrapper for the chain's gas mint (e.g. rUSDC on Marcus).
+    SPL_ERC20 public immutable wrapper;
+
+    /// @notice Chain's gas mint (bytes32 pubkey) — recorded in SettledInbound
+    ///         so indexers don't need to re-read from the wrapper contract.
+    bytes32 public immutable mint;
+
+    /// @notice Wrapper-to-wei scale factor — 10^(18 - mint_decimals).
+    ///         USDC (6-dec) → 10^12. SPL_ERC20 exposes `decimals()` at
+    ///         construction time; frozen here to save a SLOAD per call.
+    uint256 public immutable scaleWeiPerUnit;
+
+    /// @dev Insufficient wrapper allowance set by the user for this contract.
+    error InsufficientAllowance(address user, uint256 needed, uint256 have);
+
+    /// @dev Insufficient wrapper balance in the user's ATA.
+    error InsufficientBalance(address user, uint256 needed, uint256 have);
+
+    /// @dev Forward of unwrapped gas to the user failed. Never expected
+    ///      in practice — reverts the whole settlement so the wrapper
+    ///      stays in this contract's ATA (reconcilable by operator).
+    error GasForwardFailed(address user, uint256 gasAmountWei);
+
+    /// @dev Zero-amount settlement is a caller bug; fail loud instead of
+    ///      silently emitting a no-op event.
+    error ZeroAmount();
+
+    constructor(
+        address forwarder,
+        SPL_ERC20 wrapper_,
+        bytes32 mint_
+    ) ERC2771Context(forwarder) {
+        wrapper = wrapper_;
+        mint = mint_;
+
+        uint8 dec = wrapper_.decimals();
+        require(dec <= 18, "decimals>18 unsupported");
+        unchecked {
+            // 10^(18 - dec) — overflow-safe since 18 - dec <= 18.
+            scaleWeiPerUnit = 10 ** (18 - dec);
+        }
+    }
+
+    /// @notice Convert `wrapperAmount` of the user's rUSDC into native Rome
+    ///         gas, crediting the user's Balance PDA.
+    /// @param  wrapperAmount Mint-unit tokens to convert (e.g. for USDC with
+    ///                       6 decimals, `1_000_000` = 1 USDC).
+    /// @return gasAmountWei  Wei the user received.
+    function settleInbound(uint256 wrapperAmount)
+        external
+        returns (uint256 gasAmountWei)
+    {
+        if (wrapperAmount == 0) revert ZeroAmount();
+
+        address user = _msgSender();
+
+        // Preflight: surface decoded errors before the transferFrom CPI
+        // mangles the revert path. Both checks are strictly-LT so a gas
+        // race between two settle calls gets a readable message.
+        uint256 balance = wrapper.balanceOf(user);
+        if (balance < wrapperAmount) {
+            revert InsufficientBalance(user, wrapperAmount, balance);
+        }
+        uint256 allowed = wrapper.allowance(user, address(this));
+        if (allowed < wrapperAmount) {
+            revert InsufficientAllowance(user, wrapperAmount, allowed);
+        }
+
+        // 1. Pull wrapper from user's ATA into this contract's ATA.
+        //    SPL_ERC20.transferFrom returns bool per IERC20 spec; a `false`
+        //    return would indicate SPL CPI trouble — the wrapper reverts
+        //    internally in that case, so we treat `false` as a defensive
+        //    catch-all rather than a realistic path.
+        require(
+            wrapper.transferFrom(user, address(this), wrapperAmount),
+            "transferFrom"
+        );
+
+        // 2. Unwrap this contract's wrapper balance into this contract's
+        //    Balance PDA. The precompile requires wei to be a multiple of
+        //    scaleWeiPerUnit; multiplying by scaleWeiPerUnit guarantees that.
+        gasAmountWei = wrapperAmount * scaleWeiPerUnit;
+        UnwrapSplToGas.unwrap_spl_to_gas(gasAmountWei);
+
+        // 3. Forward to the user. `call{value}` uses msg.value semantics
+        //    which on Rome EVM = a Balance PDA transfer. If it fails the
+        //    whole tx reverts and the wrapper goes back to the user's ATA
+        //    (atomicity). An operator can re-sweep the contract's wrapper
+        //    after investigation if this ever triggers.
+        (bool ok, ) = payable(user).call{value: gasAmountWei}("");
+        if (!ok) revert GasForwardFailed(user, gasAmountWei);
+
+        emit SettledInbound(user, mint, wrapperAmount, gasAmountWei);
+    }
+
+    /// @notice Receive-ether hook so the contract can hold its own Balance
+    ///         PDA temporarily between unwrap and forward. Without this the
+    ///         precompile's credit would revert.
+    receive() external payable {}
+}

--- a/contracts/bridge/test/MockSplErc20.sol
+++ b/contracts/bridge/test/MockSplErc20.sol
@@ -3,17 +3,21 @@ pragma solidity ^0.8.28;
 
 /// @title MockSplErc20
 /// @notice Minimal mock that satisfies the subset of the SPL_ERC20 interface
-///         consumed by RomeBridgeWithdraw: balanceOf, mint_id, getAta.
+///         consumed by RomeBridgeWithdraw + RomeBridgeInbound: balanceOf,
+///         mint_id, getAta, allowance, decimals, transferFrom.
 ///         Does NOT inherit from SPL_ERC20 to avoid the CPI precompile call in
 ///         SPL_ERC20's constructor (which is unavailable on hardhatMainnet).
 ///         Test code casts the deployed address to the SPL_ERC20 type.
 contract MockSplErc20 {
     bytes32 private _mintId;
+    uint8 private _decimals;
     mapping(address => uint256) private _balances;
     mapping(address => bytes32) private _atas;
+    mapping(address => mapping(address => uint256)) private _allowances;
 
     constructor(bytes32 mintId_) {
         _mintId = mintId_;
+        _decimals = 6; // matches USDC — default test assumption
     }
 
     function mint_id() external view returns (bytes32) {
@@ -28,6 +32,27 @@ contract MockSplErc20 {
         return _atas[user];
     }
 
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /// @notice Minimal ERC20 transferFrom for tests — no CPI, just shuffles
+    ///         internal balance state. Returns bool per IERC20 spec.
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 allowed = _allowances[from][msg.sender];
+        require(allowed >= value, "allowance");
+        uint256 bal = _balances[from];
+        require(bal >= value, "balance");
+        _allowances[from][msg.sender] = allowed - value;
+        _balances[from] = bal - value;
+        _balances[to] += value;
+        return true;
+    }
+
     // ── Test helpers ──────────────────────────────────────────────────────────
 
     function setBalance(address account, uint256 amount) external {
@@ -36,5 +61,13 @@ contract MockSplErc20 {
 
     function setAta(address user, bytes32 ata) external {
         _atas[user] = ata;
+    }
+
+    function setDecimals(uint8 d) external {
+        _decimals = d;
+    }
+
+    function setAllowance(address owner, address spender, uint256 value) external {
+        _allowances[owner][spender] = value;
     }
 }

--- a/contracts/bridge/test/MockUnwrapSplToGas.sol
+++ b/contracts/bridge/test/MockUnwrapSplToGas.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title  MockUnwrapSplToGas
+/// @notice Hardhat-only stand-in for the Rome EVM `unwrap_spl_to_gas` precompile
+///         at 0x4200000000000000000000000000000000000017. The real precompile
+///         debits the caller's wrapper ATA and credits their Balance PDA via
+///         CPI; on hardhatMainnet there is no CPI so this mock simulates the
+///         "credit the caller's native balance" half by sending `amount` wei
+///         from its own balance back to the caller.
+///
+///         Test setup funds the mock with enough ETH to cover the unwrap calls,
+///         then copies this contract's runtime bytecode to the precompile
+///         address via `hardhat_setCode` so RomeBridgeInbound's `UnwrapSplToGas`
+///         constant resolves to it transparently.
+contract MockUnwrapSplToGas {
+    event MockUnwrapCalled(address indexed caller, uint256 amount);
+
+    function unwrap_spl_to_gas(uint256 amount) external {
+        emit MockUnwrapCalled(msg.sender, amount);
+        (bool ok, ) = payable(msg.sender).call{value: amount}("");
+        require(ok, "mock unwrap forward failed");
+    }
+
+    receive() external payable {}
+}

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -18,6 +18,22 @@ interface IWithdraw {
     function withdrawal(bytes32 owner) payable external;
 }
 
+interface IUnwrapSplToGas {
+    // Convert ERC20-SPL wrapper balance -> native gas balance for the caller.
+    // `amount` is in wei (18 decimals) and must be a multiple of
+    // 10^(18 - mint_decimals). Non-payable. Only valid on chains with
+    // chain_mint_id set. Reverts with Unimplemented otherwise.
+    function unwrap_spl_to_gas(uint256 amount) external;
+}
+
+interface IWrapGasToSpl {
+    // Convert native gas balance -> ERC20-SPL wrapper balance for the caller.
+    // `amount` is in wei (18 decimals) and must be a multiple of
+    // 10^(18 - mint_decimals). Non-payable. Only valid on chains with
+    // chain_mint_id set. Reverts with Unimplemented otherwise.
+    function wrap_gas_to_spl(uint256 amount) external;
+}
+
 interface ICrossProgramInvocation {
     struct AccountMeta {
         bytes32 pubkey;
@@ -36,10 +52,14 @@ interface ICrossProgramInvocation {
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);
 address constant cpi_program_address = address(0xFF00000000000000000000000000000000000008);
 address constant withdraw_address = address(0x4200000000000000000000000000000000000016);
+address constant unwrap_spl_to_gas_address = address(0x4200000000000000000000000000000000000017);
+address constant wrap_gas_to_spl_address = address(0x4200000000000000000000000000000000000018);
 
 ISystemProgram constant SystemProgram = ISystemProgram(system_program_address);
 ICrossProgramInvocation constant CpiProgram = ICrossProgramInvocation(cpi_program_address);
 IWithdraw constant Withdraw = IWithdraw(withdraw_address);
+IUnwrapSplToGas constant UnwrapSplToGas = IUnwrapSplToGas(unwrap_spl_to_gas_address);
+IWrapGasToSpl constant WrapGasToSpl = IWrapGasToSpl(wrap_gas_to_spl_address);
 
 
 

--- a/deployments/marcus.json
+++ b/deployments/marcus.json
@@ -89,5 +89,9 @@
         "adapter": "0x501239dCe69BD362596dB2501dE530256A4D781E"
       }
     ]
+  },
+  "RomeBridgeInbound": {
+    "address": "0x3972795F001d3c3e562009b3f5B5581e305152d2",
+    "deployedAt": 1777068163
   }
 }

--- a/scripts/bridge/deploy-inbound.ts
+++ b/scripts/bridge/deploy-inbound.ts
@@ -1,0 +1,140 @@
+// scripts/bridge/deploy-inbound.ts
+//
+// Deploy RomeBridgeInbound to marcus (or any configured network) and wire
+// it into the existing paymaster. Symmetric to the outbound RomeBridgeWithdraw
+// deployment; reads the already-deployed RomeBridgePaymaster + SPL_ERC20_USDC
+// addresses from deployments/<network>.json.
+//
+// After deployment:
+//   1. The RomeBridgeInbound address is written back to <network>.json.
+//   2. The paymaster's allowlist is updated to accept two (target, selector)
+//      pairs needed for inbound gas-split:
+//        (SPL_ERC20_USDC, approve.selector)       — user authorises inbound
+//        (RomeBridgeInbound, settleInbound.selector) — user invokes unwrap
+//      See scripts/bridge/allowlist-approve-selector.ts for the outbound
+//      companion.
+//
+// Usage:
+//   npx hardhat run scripts/bridge/deploy-inbound.ts --network monti_spl
+//   npx hardhat run scripts/bridge/deploy-inbound.ts --network local
+//
+// Idempotent: if RomeBridgeInbound is already in deployments, the script
+// skips the deploy but still re-runs the allowlist step (harmless if the
+// selectors are already set — the contract short-circuits).
+
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import { keccak256, toUtf8Bytes, getAddress } from "ethers";
+import { PublicKey } from "@solana/web3.js";
+
+function deploymentsPath(networkName: string): string {
+  return path.resolve(process.cwd(), "deployments", `${networkName}.json`);
+}
+
+function readDeps(networkName: string): Record<string, any> {
+  const p = deploymentsPath(networkName);
+  if (!fs.existsSync(p)) return {};
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function writeDeps(networkName: string, data: Record<string, any>): void {
+  fs.writeFileSync(deploymentsPath(networkName), JSON.stringify(data, null, 2) + "\n");
+}
+
+async function main() {
+  const conn = await hardhat.network.connect();
+  const viem = (conn as any).viem;
+  const networkName = (conn as any).networkName ?? "unknown";
+  const [deployer] = await viem.getWalletClients();
+  console.log("Network:", networkName);
+  console.log("Deployer:", deployer.account.address);
+
+  const deps = readDeps(networkName);
+  const paymasterAddr = deps.RomeBridgePaymaster?.address as `0x${string}` | undefined;
+  const usdcWrapperAddr = deps.SPL_ERC20_USDC?.address as `0x${string}` | undefined;
+  const usdcMintBase58 = deps.SPL_ERC20_USDC?.mintId as string | undefined;
+
+  if (!paymasterAddr) throw new Error("RomeBridgePaymaster address missing from deployments — deploy it first");
+  if (!usdcWrapperAddr) throw new Error("SPL_ERC20_USDC address missing from deployments — deploy it first");
+  if (!usdcMintBase58) throw new Error("SPL_ERC20_USDC.mintId missing from deployments");
+
+  console.log("Paymaster:      ", paymasterAddr);
+  console.log("USDC wrapper:   ", usdcWrapperAddr);
+  console.log("USDC mint (b58):", usdcMintBase58);
+
+  // Convert base58 Solana pubkey to bytes32 hex — the contract takes the
+  // mint as bytes32 so it can emit structured SettledInbound events.
+  const mintBytes32 = ("0x" +
+    Buffer.from(new PublicKey(usdcMintBase58).toBytes()).toString("hex")) as `0x${string}`;
+  console.log("USDC mint (hex):", mintBytes32);
+
+  // -----------------------------------------------------------------
+  // 1. Deploy (or reuse) RomeBridgeInbound
+  // -----------------------------------------------------------------
+  let inboundAddr = deps.RomeBridgeInbound?.address as `0x${string}` | undefined;
+  if (inboundAddr) {
+    console.log("RomeBridgeInbound already deployed:", inboundAddr, "— skipping deploy");
+  } else {
+    console.log("Deploying RomeBridgeInbound…");
+    const inbound = await viem.deployContract("RomeBridgeInbound", [
+      paymasterAddr,    // forwarder (ERC2771Context)
+      usdcWrapperAddr,  // wrapper (cast to SPL_ERC20)
+      mintBytes32,      // mint
+    ]);
+    inboundAddr = getAddress(inbound.address) as `0x${string}`;
+    console.log("RomeBridgeInbound deployed:", inboundAddr);
+    const next = {
+      ...deps,
+      RomeBridgeInbound: {
+        address: inboundAddr,
+        deployedAt: Math.floor(Date.now() / 1000),
+      },
+    };
+    writeDeps(networkName, next);
+    console.log(`Wrote ${deploymentsPath(networkName)}`);
+  }
+
+  // -----------------------------------------------------------------
+  // 2. Update paymaster allowlist so the relayed calls can go through
+  // -----------------------------------------------------------------
+  const paymaster = await viem.getContractAt("RomeBridgePaymaster", paymasterAddr);
+  const approveSel = ("0x" +
+    keccak256(toUtf8Bytes("approve(address,uint256)")).slice(2, 10)) as `0x${string}`;
+  const settleSel = ("0x" +
+    keccak256(toUtf8Bytes("settleInbound(uint256)")).slice(2, 10)) as `0x${string}`;
+
+  const pairs: Array<{ target: `0x${string}`; sel: `0x${string}`; label: string }> = [
+    { target: usdcWrapperAddr, sel: approveSel, label: "SPL_ERC20_USDC.approve" },
+    { target: inboundAddr!,    sel: settleSel,  label: "RomeBridgeInbound.settleInbound" },
+  ];
+
+  for (const { target, sel, label } of pairs) {
+    const already = (await paymaster.read.allowlist([target, sel])) as boolean;
+    if (already) {
+      console.log(`Allowlist already set: ${label} (${target}:${sel}) — skipping`);
+      continue;
+    }
+    const tx = await paymaster.write.setAllowlistEntry([target, sel, true]);
+    console.log(`Allowlisted ${label}: ${target}:${sel}`);
+    console.log("  tx:", tx);
+  }
+
+  console.log("\n== Summary ==");
+  console.log("  RomeBridgeInbound:       ", inboundAddr);
+  console.log("  Paymaster allowlist:     approve + settleInbound ✓");
+  console.log("\n== Next steps (rome-ui wiring) ==");
+  console.log("  1. Add 'romeBridgeInbound' + 'romeBridgePaymaster' to chain config");
+  console.log("     (src/constants/chains.ts contracts + src/lib/config/chains.ts normalizer).");
+  console.log("  2. Backend /api/chains should surface both via chains.yaml.");
+  console.log("  3. UI bridge form: when gasAmount > 0, collect 2 EIP-712 ForwardRequest signatures:");
+  console.log("       (a) wrapper.approve(romeBridgeInbound, gasAmount)");
+  console.log("       (b) romeBridgeInbound.settleInbound(gasAmount)");
+  console.log("  4. POST them alongside the bridge registration.");
+  console.log("  5. Worker `settling-split` phase: paymaster.executeBatch([a, b]).");
+}
+
+main().catch((e) => {
+  console.error(e?.message || e);
+  process.exit(1);
+});

--- a/tests/bridge/RomeBridgeInbound.test.ts
+++ b/tests/bridge/RomeBridgeInbound.test.ts
@@ -1,0 +1,198 @@
+/**
+ * RomeBridgeInbound — unit tests (hardhatMainnet, no Rome stack required).
+ *
+ * Covers:
+ *   1. Constructor computes the wrapper→wei scale factor from decimals().
+ *   2. settleInbound reverts on zero amount.
+ *   3. settleInbound reverts with InsufficientBalance when user balance < amount.
+ *   4. settleInbound reverts with InsufficientAllowance when allowance < amount.
+ *   5. Happy path: pulls wrapper from user, calls unwrap precompile, forwards
+ *      gas to user, emits SettledInbound. The unwrap precompile is stubbed at
+ *      its canonical address (0x42..17) via hardhat_setCode.
+ *
+ * CPI happy-path against the real `unwrap_spl_to_gas` precompile is deferred
+ * to an integration test against a live Rome stack (see Phase 1.4 pattern).
+ */
+
+import { before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import {
+  getAddress,
+  parseEther,
+  type Address,
+} from "viem";
+
+const UNWRAP_PRECOMPILE: Address = getAddress(
+  "0x4200000000000000000000000000000000000017",
+);
+
+const MOCK_MINT =
+  "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as const;
+
+// MockSplErc20 defaults to 6 decimals (USDC). 1 mint-unit = 10^(18-6) wei.
+const WEI_PER_UNIT = 10n ** 12n;
+
+describe("RomeBridgeInbound — unit tests", () => {
+  let viem: Awaited<ReturnType<typeof hardhat.network.connect>>["viem"];
+  let publicClient: Awaited<ReturnType<typeof viem.getPublicClient>>;
+  let user: Address;
+  let wrapper: any;
+  let inbound: any;
+
+  before(async () => {
+    const conn = await hardhat.network.connect({ network: "hardhatMainnet" });
+    viem = conn.viem;
+    publicClient = await viem.getPublicClient();
+    const [userClient] = await viem.getWalletClients();
+    user = userClient.account.address;
+
+    // Stub out the UnwrapSplToGas precompile at its canonical address.
+    // Deploy MockUnwrapSplToGas normally, copy its runtime bytecode to
+    // 0x42..17, then fund the precompile address so it can forward ETH.
+    const deployedMock = await viem.deployContract("MockUnwrapSplToGas");
+    const code = await publicClient.getCode({ address: deployedMock.address });
+    assert.ok(code && code !== "0x", "mock bytecode not deployed");
+    await conn.provider.request({
+      method: "hardhat_setCode",
+      params: [UNWRAP_PRECOMPILE, code],
+    });
+    // Fund the precompile so it has ETH to forward on each unwrap call.
+    // 100 ETH covers any plausible test load.
+    await conn.provider.request({
+      method: "hardhat_setBalance",
+      params: [UNWRAP_PRECOMPILE, "0x" + parseEther("100").toString(16)],
+    });
+  });
+
+  beforeEach(async () => {
+    wrapper = await viem.deployContract("MockSplErc20", [MOCK_MINT]);
+    inbound = await viem.deployContract("RomeBridgeInbound", [
+      "0x0000000000000000000000000000000000000000", // forwarder (ERC2771)
+      wrapper.address,
+      MOCK_MINT,
+    ]);
+  });
+
+  it("wires immutables correctly from constructor", async () => {
+    const m = (await inbound.read.mint()) as `0x${string}`;
+    assert.equal(m.toLowerCase(), MOCK_MINT);
+    const w = (await inbound.read.wrapper()) as Address;
+    assert.equal(getAddress(w), getAddress(wrapper.address));
+    const scale = (await inbound.read.scaleWeiPerUnit()) as bigint;
+    assert.equal(scale, WEI_PER_UNIT);
+  });
+
+  it("scales correctly for 9-dec mints", async () => {
+    const w9 = await viem.deployContract("MockSplErc20", [MOCK_MINT]);
+    await w9.write.setDecimals([9]);
+    const inb = await viem.deployContract("RomeBridgeInbound", [
+      "0x0000000000000000000000000000000000000000",
+      w9.address,
+      MOCK_MINT,
+    ]);
+    const scale = (await inb.read.scaleWeiPerUnit()) as bigint;
+    assert.equal(scale, 10n ** 9n);
+  });
+
+  // viem v2 wraps revert data in nested `cause` chains; walk the object
+  // tree to find any string containing the expected error name. Lets us
+  // assert on Solidity custom-error names regardless of which layer viem
+  // decides to surface.
+  const errorContains = (err: any, needle: string): boolean => {
+    const seen = new Set<any>();
+    const walk = (o: any): boolean => {
+      if (!o || typeof o !== "object" || seen.has(o)) return false;
+      seen.add(o);
+      for (const v of Object.values(o)) {
+        if (typeof v === "string" && v.includes(needle)) return true;
+        if (typeof v === "object" && walk(v)) return true;
+      }
+      return false;
+    };
+    return walk(err);
+  };
+
+  it("reverts on zero amount", async () => {
+    await assert.rejects(
+      async () => inbound.write.settleInbound([0n]),
+      (err: any) => {
+        assert.ok(
+          errorContains(err, "ZeroAmount"),
+          `expected ZeroAmount in error tree`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("reverts with InsufficientBalance when user balance < amount", async () => {
+    // No balance set — user has 0 wrapper balance.
+    await assert.rejects(
+      async () => inbound.write.settleInbound([1_000_000n]),
+      (err: any) => {
+        assert.ok(errorContains(err, "InsufficientBalance"));
+        return true;
+      },
+    );
+  });
+
+  it("reverts with InsufficientAllowance when balance OK but allowance < amount", async () => {
+    await wrapper.write.setBalance([user, 5_000_000n]);
+    // Allowance still 0.
+    await assert.rejects(
+      async () => inbound.write.settleInbound([1_000_000n]),
+      (err: any) => {
+        assert.ok(errorContains(err, "InsufficientAllowance"));
+        return true;
+      },
+    );
+  });
+
+  it("happy path: pulls wrapper, forwards gas, emits SettledInbound", async () => {
+    const wrapperAmount = 1_000_000n; // 1 USDC
+    const expectedWei = wrapperAmount * WEI_PER_UNIT;
+
+    await wrapper.write.setBalance([user, wrapperAmount]);
+    await wrapper.write.setAllowance([user, inbound.address, wrapperAmount]);
+
+    const balBefore = await publicClient.getBalance({ address: user });
+
+    const txHash = await inbound.write.settleInbound([wrapperAmount]);
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    assert.equal(receipt.status, "success");
+
+    // Wrapper moved: user 0, contract has the wrapper amount.
+    const userWrapper = (await wrapper.read.balanceOf([user])) as bigint;
+    const contractWrapper = (await wrapper.read.balanceOf([inbound.address])) as bigint;
+    assert.equal(userWrapper, 0n, "user wrapper should be zero");
+    assert.equal(contractWrapper, wrapperAmount, "contract holds the pulled wrapper");
+
+    // User's ETH balance increased by gas-forward minus tx fee. Just assert
+    // the balance went UP by approximately expectedWei — allowing tx gas
+    // cost variance (on hardhat, gas cost is ~< 0.001 ETH).
+    const balAfter = await publicClient.getBalance({ address: user });
+    const delta = balAfter - balBefore;
+    // Hardhat gas cost can consume up to ~0.01 ETH. Expected forward ≫ that.
+    const lowerBound = expectedWei - parseEther("0.01");
+    assert.ok(
+      delta > lowerBound,
+      `expected user balance to grow by ~${expectedWei}; got ${delta}`,
+    );
+
+    // Event emitted.
+    const logs = receipt.logs;
+    const settled = logs.find((l) => l.address.toLowerCase() === inbound.address.toLowerCase());
+    assert.ok(settled, "SettledInbound event not found");
+  });
+
+  it("reentrancy-safe: receive() is payable to accept the precompile credit", async () => {
+    // Smoke check — the contract needs receive() or the unwrap's implicit
+    // credit to its own balance would revert. Verified indirectly by the
+    // happy-path test above passing; this test exists to lock that constraint.
+    const userBalanceOfInbound = await publicClient.getBalance({
+      address: inbound.address,
+    });
+    assert.equal(userBalanceOfInbound, 0n);
+  });
+});


### PR DESCRIPTION
## Summary

- New **`RomeBridgeInbound`** contract — replaces the rome-evm-private `settle_inbound_bridge` instruction with a Solidity contract callable via standard wallet UX (paymaster-relayed `signTypedData_v4`, no `eth_signTransaction` required).
- Adds **`IUnwrapSplToGas` / `IWrapGasToSpl`** precompile interfaces in `contracts/interface.sol` so other contracts can call the new precompiles (rome-evm-private PR #265, deployed to Marcus 2026-04-24).
- Adds **`SettledInbound(user, mint, wrapperAmount, gasAmountWei)`** event to `RomeBridgeEvents` for indexer reconciliation.
- Adds **`scripts/bridge/deploy-inbound.ts`** — idempotent deploy + paymaster allowlist update.
- Deployed to Marcus: `0x3972795F001d3c3e562009b3f5B5581e305152d2` (`deployments/marcus.json` updated).

## Why this contract instead of the on-chain instruction

`settle_inbound_bridge` expects an RLP-encoded signed EVM tx in its instruction data. Producing that on the client requires `eth_signTransaction`, which **MetaMask blocks**. Routing through the existing paymaster's ERC2771 ForwardRequest path keeps the wallet UX as standard `signTypedData_v4` calls.

## How it works

`settleInbound(wrapperAmount)`:

1. `transferFrom` user's wrapper into the contract's ATA
2. `unwrap_spl_to_gas(gasAmountWei)` — precompile credits this contract's Balance PDA
3. `call{value: gasAmountWei}` forwards the gas to the user's Balance PDA
4. emit `SettledInbound`

The full inbound flow (UI + worker integration) lives in `rome-ui/feat-wrap-unwrap` (commit `7647638`): UI signs 2 EIP-712 ForwardRequests (approve + settle, sequential nonces), worker calls `paymaster.executeBatch` after CCTP/Wormhole lands on Solana.

## Test plan

- [x] `npx hardhat test tests/bridge/RomeBridgeInbound.test.ts` — 7 passing (constructor scaling for 6/9-dec mints, zero-amount revert, insufficient balance/allowance, happy path with stubbed precompile)
- [x] Deployed to Marcus + paymaster allowlist updated (idempotent — re-running the deploy is safe)
- [ ] End-to-end Sepolia → Marcus inbound bridge with `gasAmount > 0` (requires `MARCUS_RELAYER_KEY` in rome-ui backend env + funded relayer wallet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)