### PR TITLE
feat(bridge): production hardening — Pausable, ReentrancyGuard, slippage, mutable cap

### DIFF
--- a/contracts/bridge/RomeBridgeInbound.sol
+++ b/contracts/bridge/RomeBridgeInbound.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {SPL_ERC20} from "../erc20spl/erc20spl.sol";
 import {IUnwrapSplToGas, UnwrapSplToGas} from "../interface.sol";
 import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
@@ -49,7 +50,7 @@ import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
 ///         wrapper balance into the CALLER's gas balance. If we want to
 ///         atomically record events / enforce invariants / emit structured
 ///         audit data, we need a contract wrapper. This is it.
-contract RomeBridgeInbound is ERC2771Context, RomeBridgeEvents {
+contract RomeBridgeInbound is ERC2771Context, ReentrancyGuard, RomeBridgeEvents {
     /// @notice ERC20-SPL wrapper for the chain's gas mint (e.g. rUSDC on Marcus).
     SPL_ERC20 public immutable wrapper;
 
@@ -77,6 +78,12 @@ contract RomeBridgeInbound is ERC2771Context, RomeBridgeEvents {
     ///      silently emitting a no-op event.
     error ZeroAmount();
 
+    /// @dev Slippage check failed: the unwrap precompile credited a
+    ///      different wei amount than expected. Catches a precompile
+    ///      bug or version mismatch where the unwrap doesn't produce
+    ///      the expected `wrapperAmount * scaleWeiPerUnit` delta.
+    error UnexpectedUnwrapDelta(uint256 expected, uint256 actual);
+
     constructor(
         address forwarder,
         SPL_ERC20 wrapper_,
@@ -100,6 +107,7 @@ contract RomeBridgeInbound is ERC2771Context, RomeBridgeEvents {
     /// @return gasAmountWei  Wei the user received.
     function settleInbound(uint256 wrapperAmount)
         external
+        nonReentrant
         returns (uint256 gasAmountWei)
     {
         if (wrapperAmount == 0) revert ZeroAmount();
@@ -131,8 +139,18 @@ contract RomeBridgeInbound is ERC2771Context, RomeBridgeEvents {
         // 2. Unwrap this contract's wrapper balance into this contract's
         //    Balance PDA. The precompile requires wei to be a multiple of
         //    scaleWeiPerUnit; multiplying by scaleWeiPerUnit guarantees that.
+        //
+        //    Slippage check (audit A3): snapshot balance before, assert
+        //    delta exactly matches expected after. Catches a precompile
+        //    bug crediting less than expected — without the check, we'd
+        //    silently underforward to the user.
         gasAmountWei = wrapperAmount * scaleWeiPerUnit;
+        uint256 balanceBefore = address(this).balance;
         UnwrapSplToGas.unwrap_spl_to_gas(gasAmountWei);
+        uint256 actualDelta = address(this).balance - balanceBefore;
+        if (actualDelta != gasAmountWei) {
+            revert UnexpectedUnwrapDelta(gasAmountWei, actualDelta);
+        }
 
         // 3. Forward to the user. `call{value}` uses msg.value semantics
         //    which on Rome EVM = a Balance PDA transfer. If it fails the

--- a/contracts/bridge/RomeBridgePaymaster.sol
+++ b/contracts/bridge/RomeBridgePaymaster.sol
@@ -3,21 +3,27 @@ pragma solidity ^0.8.28;
 
 import {ERC2771Forwarder} from "@openzeppelin/contracts/metatx/ERC2771Forwarder.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
 
 /// @title RomeBridgePaymaster
-/// @notice EIP-2771 trusted forwarder that sponsors up to SPONSORED_TX_CAP Rome EVM
+/// @notice EIP-2771 trusted forwarder that sponsors up to `sponsoredTxCap` Rome EVM
 ///         transactions per user, restricted to an allowlist of (target, selector) pairs.
 /// @dev Sponsorship budget is only consumed when a request actually executes. Batch
 ///      mode requests that fail signature/deadline validation are skipped without
 ///      charging the budget. Callers must be aware: once exhausted, a user's budget
-///      does not reset — Phase 1 does not offer a top-up flow.
-contract RomeBridgePaymaster is ERC2771Forwarder, Ownable, RomeBridgeEvents {
-    uint8 public constant SPONSORED_TX_CAP = 3;
+///      does not reset automatically — operator can raise the per-user cap via
+///      `setSponsoredTxCap` to grant additional sponsorship retroactively.
+contract RomeBridgePaymaster is ERC2771Forwarder, Ownable, Pausable, RomeBridgeEvents {
+    /// @notice Per-user sponsorship cap. Owner-mutable via `setSponsoredTxCap`.
+    ///         Default is 3 (set in the constructor) — chosen for the Phase 1
+    ///         inbound-bridge flow which needs at most 2 relayed calls per
+    ///         user (approve + settleInbound), with one in reserve.
+    uint8 public sponsoredTxCap;
 
-    /// @dev Per-user consumed sponsorship count. Never resets in Phase 1 — a user who
-    ///      exhausts their budget must pay gas themselves thereafter (gas token on Rome
-    ///      EVM is rUSDC, which the bridge-in flow populates).
+    /// @dev Per-user consumed sponsorship count. Never auto-resets — a user who
+    ///      exhausts their budget must either pay gas themselves thereafter or
+    ///      get the cap raised by the operator.
     mapping(address => uint8) public sponsoredTxCount;
 
     mapping(address => mapping(bytes4 => bool)) public allowlist;
@@ -29,10 +35,15 @@ contract RomeBridgePaymaster is ERC2771Forwarder, Ownable, RomeBridgeEvents {
     ///      like PaymasterSponsored live in RomeBridgeEvents for indexer composability.
     event AllowlistUpdated(address indexed target, bytes4 indexed selector, bool allowed);
 
+    /// @notice Emitted when the owner changes the per-user sponsorship cap.
+    event SponsoredTxCapChanged(uint8 indexed previousCap, uint8 indexed newCap);
+
     constructor(address admin)
         ERC2771Forwarder("RomeBridgePaymaster")
         Ownable(admin)
-    {}
+    {
+        sponsoredTxCap = 3;
+    }
 
     /// @notice Adds or removes an (target, selector) pair from the sponsorship allowlist.
     /// @dev Admin-only; emits AllowlistUpdated.
@@ -41,18 +52,42 @@ contract RomeBridgePaymaster is ERC2771Forwarder, Ownable, RomeBridgeEvents {
         emit AllowlistUpdated(target, selector, allowed);
     }
 
+    /// @notice Owner-only update of the per-user sponsorship cap.
+    /// @dev Lowering the cap doesn't refund existing counters; raising it lets
+    ///      already-exhausted users be sponsored again up to the new ceiling.
+    function setSponsoredTxCap(uint8 newCap) external onlyOwner {
+        uint8 previousCap = sponsoredTxCap;
+        sponsoredTxCap = newCap;
+        emit SponsoredTxCapChanged(previousCap, newCap);
+    }
+
+    /// @notice Pause the relayed-execution path. Inherited Pausable; owner-only.
+    /// @dev While paused, both `execute()` and `executeBatch()` revert via the
+    ///      `whenNotPaused` modifier on `_execute`. Use for incident response —
+    ///      e.g. if a flaw is found in one of the allowlisted targets, the
+    ///      operator can pause without iterating the allowlist to remove entries.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume the relayed-execution path after a pause.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
     /// @dev Override of ERC2771Forwarder._execute that enforces the (target, selector)
-    ///      allowlist and charges the per-user sponsorship budget. Budget is charged AFTER
-    ///      super._execute so that batch-mode requests with invalid signatures (which OZ
-    ///      skips silently, returning success=false) do not consume the victim's budget.
-    ///      In the execute() path (requireValidRequest=true), bad sigs revert inside super
-    ///      and never reach the budget logic. In the executeBatch() path
-    ///      (requireValidRequest=false), only requests where success=true were actually
-    ///      dispatched and count against the budget.
+    ///      allowlist, the pause state, and charges the per-user sponsorship budget.
+    ///      Budget is charged AFTER super._execute so that batch-mode requests with
+    ///      invalid signatures (which OZ skips silently, returning success=false)
+    ///      do not consume the victim's budget. In the execute() path
+    ///      (requireValidRequest=true), bad sigs revert inside super and never reach
+    ///      the budget logic. In the executeBatch() path (requireValidRequest=false),
+    ///      only requests where success=true were actually dispatched and count
+    ///      against the budget.
     function _execute(
         ForwardRequestData calldata request,
         bool requireValidRequest
-    ) internal override returns (bool success) {
+    ) internal override whenNotPaused returns (bool success) {
         // Allowlist check applies to all code paths.
         bytes4 selector = _extractSelector(request.data);
         if (!allowlist[request.to][selector]) {
@@ -72,11 +107,12 @@ contract RomeBridgePaymaster is ERC2771Forwarder, Ownable, RomeBridgeEvents {
         if (requireValidRequest || success) {
             address user = request.from;
             uint8 current = sponsoredTxCount[user];
-            if (current >= SPONSORED_TX_CAP) {
+            uint8 cap = sponsoredTxCap;
+            if (current >= cap) {
                 revert BudgetExhausted(user);
             }
             unchecked { sponsoredTxCount[user] = current + 1; }
-            emit PaymasterSponsored(user, SPONSORED_TX_CAP - current - 1, request.to);
+            emit PaymasterSponsored(user, cap - current - 1, request.to);
         }
     }
 

--- a/contracts/bridge/test/PartialPayoutUnwrap.sol
+++ b/contracts/bridge/test/PartialPayoutUnwrap.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title  PartialPayoutUnwrap
+/// @notice Test-only stand-in for `unwrap_spl_to_gas` that credits only
+///         HALF of the requested amount to the caller. Lets us verify
+///         RomeBridgeInbound's slippage check (A3) catches a hypothetical
+///         precompile bug crediting less than expected.
+contract PartialPayoutUnwrap {
+    function unwrap_spl_to_gas(uint256 amount) external {
+        uint256 half = amount / 2;
+        (bool ok, ) = payable(msg.sender).call{value: half}("");
+        require(ok, "partial unwrap forward failed");
+    }
+
+    receive() external payable {}
+}

--- a/contracts/bridge/test/ReentrantReceiver.sol
+++ b/contracts/bridge/test/ReentrantReceiver.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {SPL_ERC20} from "../../erc20spl/erc20spl.sol";
+
+interface IRomeBridgeInbound {
+    function settleInbound(uint256 wrapperAmount) external returns (uint256);
+}
+
+/// @title ReentrantReceiver
+/// @notice Test-only contract whose `receive()` re-enters
+///         RomeBridgeInbound.settleInbound during the gas forward. Exists
+///         purely to verify the ReentrancyGuard on the inbound contract
+///         (audit hardening item A2).
+///
+/// @dev On the first hop, the inbound contract calls `call{value}` on
+///      this contract — that lands in `receive()`, which re-invokes
+///      `settleInbound`. With a guard in place the re-entry must revert
+///      ("ReentrancyGuardReentrantCall"). Without one, the second call
+///      would proceed to spend whatever wrapper allowance is left.
+contract ReentrantReceiver {
+    IRomeBridgeInbound public immutable inbound;
+    SPL_ERC20 public immutable wrapper;
+    uint256 public immutable replayAmount;
+    bool public attempted;
+    bytes public lastRevertData;
+
+    constructor(IRomeBridgeInbound _inbound, SPL_ERC20 _wrapper, uint256 _replayAmount) {
+        inbound = _inbound;
+        wrapper = _wrapper;
+        replayAmount = _replayAmount;
+    }
+
+    /// @notice Call this from the test to fire the first settleInbound. The
+    ///         contract must already hold a wrapper balance + have approved
+    ///         `inbound` for at least `replayAmount * 2` worth.
+    function trigger(uint256 amount) external returns (uint256) {
+        return inbound.settleInbound(amount);
+    }
+
+    receive() external payable {
+        if (attempted) return; // only re-enter once
+        attempted = true;
+        // Try to re-enter the inbound contract. If the guard is in place
+        // this call reverts with ReentrancyGuardReentrantCall and we
+        // capture the revert data; otherwise we silently proceed (the
+        // test then asserts the second call did not happen).
+        try inbound.settleInbound(replayAmount) {
+            // Re-entry succeeded — guard absent or broken. Test will
+            // detect by observing wrapper balance change.
+        } catch (bytes memory revertData) {
+            lastRevertData = revertData;
+        }
+    }
+}

--- a/scripts/bridge/REDEPLOY_HARDENING.md
+++ b/scripts/bridge/REDEPLOY_HARDENING.md
@@ -1,0 +1,112 @@
+# Bridge hardening redeploy runbook (post-#55)
+
+Use this **only** after rome-solidity #55 has merged to `main` and you have
+the latest `contracts/bridge/` artifacts compiled on the deployer host.
+
+The PR ships four hardening fixes:
+
+| Fix | Contract | Severity | Constructor changed? | Forwarder change? |
+|---|---|---|---|---|
+| Pausable + `pause()`/`unpause()` | `RomeBridgePaymaster` | Operational | No | n/a |
+| `sponsoredTxCap` mutable + `setSponsoredTxCap()` | `RomeBridgePaymaster` | Operational | No | n/a |
+| `ReentrancyGuard` on `settleInbound` | `RomeBridgeInbound`   | **Security** | No | No |
+| Slippage check after `unwrap_spl_to_gas` | `RomeBridgeInbound`   | **Security** | No | No |
+
+## What this runbook covers
+
+The conservative path: **redeploy `RomeBridgeInbound` only.** This delivers
+both security-critical fixes with zero blast radius.
+
+The paymaster (Pausable + mutable cap) stays put. Its constructor is
+unchanged, but redeploying it would force a `RomeBridgeWithdraw` redeploy
+too because Withdraw stores the forwarder as an immutable
+`ERC2771Context` field. Pausable is operational — ship it later if/when
+an incident makes it load-bearing.
+
+## Steps
+
+```bash
+cd rome-solidity
+
+# 1. Confirm you're on main + the artifacts match the merged PR.
+git checkout main && git pull
+npx hardhat compile
+
+# 2. Make sure the deployer wallet has rUSDC for gas on Marcus.
+#    (Funding floor in deployments/marcus.json's deployer notes.)
+
+# 3. Run the redeploy script.
+npx hardhat run scripts/bridge/redeploy-inbound.ts --network monti_spl
+
+# Expected output:
+#   - Deploys new RomeBridgeInbound at <NEW_ADDRESS>
+#   - Archives old address under archive.RomeBridgeInboundPrevious
+#   - Re-runs allowlist for (RomeBridgeInbound, settleInbound) on the paymaster
+#   - Writes deployments/marcus.json
+```
+
+After the script writes `deployments/marcus.json`, **commit it** and open a
+small PR (`chore(deploy): redeploy RomeBridgeInbound on Marcus post-#55`)
+so the artifact's authoritative state is in `main`.
+
+## Downstream updates (rome-ui)
+
+The new address must propagate to three places:
+
+1. **`rome-ui/deploy/chains.sample.yaml`** — line ~26, `marcus.contracts.romeBridgeInbound`.
+   This is the committed canonical config.
+2. **`rome-ui/backend/chains.yaml`** (operator-local, gitignored) — same
+   field. Each operator updates their own copy.
+3. **`rome-ui/src/server/bridge/flows/inboundCctp.ts`** — only if you
+   redeployed the paymaster too (this redeploy doesn't, so leave it
+   alone). The hardcoded `MARCUS_PAYMASTER_ADDRESS` env-fallback there is
+   the paymaster, not the inbound.
+
+After updating `chains.yaml`, restart the rome-ui backend so it re-reads.
+
+## Smoke test
+
+```bash
+# 1. Confirm the new contract picked up the hardening:
+npx hardhat console --network monti_spl
+> const i = await viem.getContractAt("RomeBridgeInbound", "<NEW_ADDRESS>")
+> // The reentrancy guard storage slot is _NOT_ENTERED (1) on a fresh deploy.
+> // The slippage error UnexpectedUnwrapDelta is in the ABI:
+> Object.keys(i.abi).filter(k => k.includes("Unexpected"))
+
+# 2. End-to-end inbound bridge with gas-split:
+#    Run an inbound CCTP bridge from Sepolia → Marcus through the rome-ui
+#    portal. Watch the worker's [bridge-worker] settling-split phase
+#    succeed against the new inbound address.
+
+# 3. Negative test (best-effort):
+#    Build a malicious wrapper deployment that re-enters settleInbound
+#    inside its receive() and confirm the call reverts with
+#    ReentrancyGuardReentrantCall — hard to exercise on real Marcus
+#    without a custom mint, so the hardhat test in
+#    tests/bridge/RomeBridgeInbound.test.ts is the authoritative proof.
+```
+
+## Rollback
+
+If the new inbound misbehaves:
+
+1. Revert `chains.sample.yaml` + `backend/chains.yaml` to the old address
+   (still recorded in `deployments/marcus.json` under
+   `archive.RomeBridgeInboundPrevious`).
+2. Restart rome-ui backend.
+3. The old (paymaster, settleInbound) allowlist entry was never removed
+   — old bridges keep working immediately.
+4. Open a hot-fix PR on rome-solidity, do not delete the new address from
+   the deployment record (we want the trail).
+
+## Why no Withdraw or paymaster touched
+
+- **Withdraw** has no #55 changes. Bytecode unchanged.
+- **Paymaster** has #55 changes (Pausable + mutable cap) but redeploying
+  it cascades to both Withdraw and Inbound (immutable forwarder fields).
+  The cost/benefit doesn't pencil out when the security-critical fixes
+  are all in Inbound.
+
+If a follow-up incident makes Pausable load-bearing, plan the full
+triple-redeploy explicitly — that's a different runbook (TODO).

--- a/scripts/bridge/redeploy-inbound.ts
+++ b/scripts/bridge/redeploy-inbound.ts
@@ -1,0 +1,141 @@
+// scripts/bridge/redeploy-inbound.ts
+//
+// Redeploys ONLY RomeBridgeInbound — for picking up the security hardening
+// shipped in rome-solidity #55 (ReentrancyGuard on settleInbound + slippage
+// check after unwrap_spl_to_gas).
+//
+// Why inbound-only and not paymaster:
+//   The paymaster #55 changes (Pausable + mutable sponsoredTxCap) are also
+//   useful but redeploying the paymaster cascades to RomeBridgeWithdraw +
+//   RomeBridgeInbound because both store the forwarder as an immutable
+//   ERC2771Context field. The reentrancy + slippage fixes are the
+//   security-critical part; ship those first, redeploy the paymaster
+//   later if Pausable becomes load-bearing.
+//
+// What this script does:
+//   1. Reads current RomeBridgeInbound + RomeBridgePaymaster + SPL_ERC20_USDC
+//      from deployments/<network>.json.
+//   2. Archives the current RomeBridgeInbound under
+//      archive.RomeBridgeInboundPrevious (so we can roll back).
+//   3. Deploys a new RomeBridgeInbound against the SAME paymaster + wrapper.
+//   4. Re-runs the paymaster allowlist for the new inbound's settleInbound
+//      selector (the existing entry points at the old address — leaves it
+//      in place, but the new entry is what the worker will use).
+//   5. Writes the new address back to deployments/<network>.json.
+//
+// Idempotent in the weak sense: if you re-run, you get a fresh deploy each
+// time and overwrite archive.RomeBridgeInboundPrevious with whatever was
+// "current" at the start of this run. Don't run twice without good reason.
+//
+// Usage:
+//   npx hardhat run scripts/bridge/redeploy-inbound.ts --network monti_spl
+//   npx hardhat run scripts/bridge/redeploy-inbound.ts --network local
+
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import { keccak256, toUtf8Bytes, getAddress } from "ethers";
+import { PublicKey } from "@solana/web3.js";
+
+function deploymentsPath(networkName: string): string {
+  return path.resolve(process.cwd(), "deployments", `${networkName}.json`);
+}
+
+function readDeps(networkName: string): Record<string, any> {
+  const p = deploymentsPath(networkName);
+  if (!fs.existsSync(p)) return {};
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function writeDeps(networkName: string, data: Record<string, any>): void {
+  fs.writeFileSync(deploymentsPath(networkName), JSON.stringify(data, null, 2) + "\n");
+}
+
+async function main() {
+  const conn = await hardhat.network.connect();
+  const viem = (conn as any).viem;
+  const networkName = (conn as any).networkName ?? "unknown";
+  const [deployer] = await viem.getWalletClients();
+
+  console.log("Network: ", networkName);
+  console.log("Deployer:", deployer.account.address);
+
+  const deps = readDeps(networkName);
+  const paymasterAddr = deps.RomeBridgePaymaster?.address as `0x${string}` | undefined;
+  const usdcWrapperAddr = deps.SPL_ERC20_USDC?.address as `0x${string}` | undefined;
+  const usdcMintBase58 = deps.SPL_ERC20_USDC?.mintId as string | undefined;
+  const oldInboundAddr = deps.RomeBridgeInbound?.address as `0x${string}` | undefined;
+
+  if (!paymasterAddr) throw new Error("RomeBridgePaymaster missing from deployments — run scripts/bridge/deploy.ts first");
+  if (!usdcWrapperAddr) throw new Error("SPL_ERC20_USDC missing from deployments — run scripts/bridge/deploy.ts first");
+  if (!usdcMintBase58) throw new Error("SPL_ERC20_USDC.mintId missing from deployments");
+  if (!oldInboundAddr) {
+    console.log("No existing RomeBridgeInbound recorded — running a fresh deploy via deploy-inbound.ts is more appropriate.");
+    process.exit(1);
+  }
+
+  console.log("\nReusing:");
+  console.log("  RomeBridgePaymaster: ", paymasterAddr);
+  console.log("  SPL_ERC20_USDC:      ", usdcWrapperAddr);
+  console.log("  USDC mint (b58):     ", usdcMintBase58);
+  console.log("\nReplacing:");
+  console.log("  RomeBridgeInbound (old):", oldInboundAddr);
+
+  const mintBytes32 = ("0x" +
+    Buffer.from(new PublicKey(usdcMintBase58).toBytes()).toString("hex")) as `0x${string}`;
+
+  console.log("\nDeploying new RomeBridgeInbound (PR #55 hardening)…");
+  const inbound = await viem.deployContract("RomeBridgeInbound", [
+    paymasterAddr,
+    usdcWrapperAddr,
+    mintBytes32,
+  ]);
+  const newInboundAddr = getAddress(inbound.address) as `0x${string}`;
+  console.log("  RomeBridgeInbound (new):", newInboundAddr);
+
+  // Archive old, write new.
+  if (!deps.archive) deps.archive = {};
+  deps.archive.RomeBridgeInboundPrevious = {
+    address: oldInboundAddr,
+    archivedAt: Math.floor(Date.now() / 1000),
+  };
+  deps.RomeBridgeInbound = {
+    address: newInboundAddr,
+    deployedAt: Math.floor(Date.now() / 1000),
+  };
+  writeDeps(networkName, deps);
+  console.log(`  Wrote ${deploymentsPath(networkName)}`);
+
+  // Allowlist the new inbound's settleInbound on the paymaster.
+  // The old (RomeBridgeInbound, settleInbound) entry stays in place — harmless,
+  // and lets in-flight bridges that signed against the old address still work
+  // until their TTL expires. The worker will start signing against the new
+  // address once chains.yaml is updated.
+  const paymaster = await viem.getContractAt("RomeBridgePaymaster", paymasterAddr);
+  const settleSel = ("0x" +
+    keccak256(toUtf8Bytes("settleInbound(uint256)")).slice(2, 10)) as `0x${string}`;
+
+  const already = (await paymaster.read.allowlist([newInboundAddr, settleSel])) as boolean;
+  if (already) {
+    console.log("  Allowlist already set: RomeBridgeInbound.settleInbound — skipping");
+  } else {
+    const tx = await paymaster.write.setAllowlistEntry([newInboundAddr, settleSel, true]);
+    console.log("  Allowlisted RomeBridgeInbound.settleInbound on paymaster");
+    console.log("  tx:", tx);
+  }
+
+  console.log("\n== Summary ==");
+  console.log("  RomeBridgeInbound (new):", newInboundAddr);
+  console.log("  Old (archived):         ", oldInboundAddr);
+  console.log("\n== Manual follow-ups (rome-ui) ==");
+  console.log("  1. rome-ui/deploy/chains.sample.yaml — update marcus.contracts.romeBridgeInbound");
+  console.log("  2. rome-ui/backend/chains.yaml (operator-local, gitignored) — same field");
+  console.log("  3. (Optional) rome-ui/src/server/bridge/flows/inboundCctp.ts — only if MARCUS_PAYMASTER_ADDRESS env var fallback also changed (not in this redeploy)");
+  console.log("  4. Restart rome-ui backend so it re-reads chains.yaml");
+  console.log("  5. See scripts/bridge/REDEPLOY_HARDENING.md for the full runbook.");
+}
+
+main().catch((e) => {
+  console.error(e?.message || e);
+  process.exit(1);
+});

--- a/tests/bridge/RomeBridgeInbound.test.ts
+++ b/tests/bridge/RomeBridgeInbound.test.ts
@@ -34,6 +34,7 @@ const MOCK_MINT =
 const WEI_PER_UNIT = 10n ** 12n;
 
 describe("RomeBridgeInbound — unit tests", () => {
+  let conn: Awaited<ReturnType<typeof hardhat.network.connect>>;
   let viem: Awaited<ReturnType<typeof hardhat.network.connect>>["viem"];
   let publicClient: Awaited<ReturnType<typeof viem.getPublicClient>>;
   let user: Address;
@@ -41,7 +42,7 @@ describe("RomeBridgeInbound — unit tests", () => {
   let inbound: any;
 
   before(async () => {
-    const conn = await hardhat.network.connect({ network: "hardhatMainnet" });
+    conn = await hardhat.network.connect({ network: "hardhatMainnet" });
     viem = conn.viem;
     publicClient = await viem.getPublicClient();
     const [userClient] = await viem.getWalletClients();
@@ -194,5 +195,109 @@ describe("RomeBridgeInbound — unit tests", () => {
       address: inbound.address,
     });
     assert.equal(userBalanceOfInbound, 0n);
+  });
+
+  // ─── Hardening A2: ReentrancyGuard ───────────────────────────────────────
+
+  describe("ReentrancyGuard (A2)", () => {
+    it("blocks re-entry from a malicious receiver during the gas forward", async () => {
+      // Deploy a contract that re-enters settleInbound from receive()
+      const wrapperAmount = 1_000_000n;
+      const replayAmount = 500_000n;
+      const reentrant = await viem.deployContract("ReentrantReceiver", [
+        inbound.address,
+        wrapper.address,
+        replayAmount,
+      ]);
+
+      // Fund the receiver with enough wrapper for both the outer call AND
+      // a hypothetical re-entry, with allowance for the inbound contract.
+      // If the guard is missing, the receive() handler would consume
+      // `replayAmount` more wrapper on re-entry.
+      await wrapper.write.setBalance([reentrant.address, wrapperAmount + replayAmount]);
+      await wrapper.write.setAllowance([
+        reentrant.address,
+        inbound.address,
+        wrapperAmount + replayAmount,
+      ]);
+
+      // The trigger fires the first settleInbound. With ReentrancyGuard
+      // in place, the re-entry inside receive() reverts; the catch
+      // swallows the revert; the outer call still succeeds. The test
+      // proves the guard works by observing that the wrapper balance
+      // dropped by exactly `wrapperAmount` (not `wrapperAmount +
+      // replayAmount`).
+      const txHash = await reentrant.write.trigger([wrapperAmount]);
+      await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      const after = (await wrapper.read.balanceOf([reentrant.address])) as bigint;
+      // Without the guard, after === replayAmount (only the second call's
+      // tail would remain). With the guard, after === replayAmount because
+      // the re-entry attempted but failed — only the outer wrapperAmount
+      // got consumed.
+      assert.equal(
+        after,
+        replayAmount,
+        `expected receiver to retain ${replayAmount} wrapper after blocked re-entry; got ${after}`,
+      );
+
+      // The receive() captured a revert — confirms it actually attempted.
+      const lastRevertData = (await reentrant.read.lastRevertData()) as `0x${string}`;
+      assert.ok(
+        lastRevertData && lastRevertData !== "0x",
+        "expected ReentrantReceiver to capture a revert during re-entry attempt",
+      );
+    });
+  });
+
+  // ─── Hardening A3: Slippage / balance-delta check ────────────────────────
+
+  describe("Slippage check on unwrap_spl_to_gas (A3)", () => {
+    it("reverts with UnexpectedUnwrapDelta if precompile credits less than expected", async () => {
+      // Deploy a partial-payout mock at the precompile address that only
+      // forwards half the requested amount. This simulates a hypothetical
+      // precompile bug or version mismatch where the unwrap doesn't
+      // produce the expected wei delta.
+      const partialMock = await viem.deployContract("PartialPayoutUnwrap");
+      const code = await publicClient.getCode({ address: partialMock.address });
+      assert.ok(code && code !== "0x", "partial-payout mock not deployed");
+      await conn.provider.request({
+        method: "hardhat_setCode",
+        params: [UNWRAP_PRECOMPILE, code],
+      });
+      await conn.provider.request({
+        method: "hardhat_setBalance",
+        params: [UNWRAP_PRECOMPILE, "0x" + parseEther("100").toString(16)],
+      });
+
+      const wrapperAmount = 1_000_000n;
+      await wrapper.write.setBalance([user, wrapperAmount]);
+      await wrapper.write.setAllowance([user, inbound.address, wrapperAmount]);
+
+      // Should revert because address(this).balance after unwrap will be
+      // half of expected — the slippage check catches it.
+      await assert.rejects(
+        async () => inbound.write.settleInbound([wrapperAmount]),
+        (err: any) => {
+          assert.ok(
+            errorContains(err, "UnexpectedUnwrapDelta"),
+            "expected UnexpectedUnwrapDelta in error tree",
+          );
+          return true;
+        },
+      );
+
+      // Restore the full-payout mock for subsequent tests in the suite.
+      const goodMock = await viem.deployContract("MockUnwrapSplToGas");
+      const goodCode = await publicClient.getCode({ address: goodMock.address });
+      await conn.provider.request({
+        method: "hardhat_setCode",
+        params: [UNWRAP_PRECOMPILE, goodCode],
+      });
+      await conn.provider.request({
+        method: "hardhat_setBalance",
+        params: [UNWRAP_PRECOMPILE, "0x" + parseEther("100").toString(16)],
+      });
+    });
   });
 });

--- a/tests/bridge/RomeBridgePaymaster.test.ts
+++ b/tests/bridge/RomeBridgePaymaster.test.ts
@@ -88,8 +88,8 @@ describe("RomeBridgePaymaster", () => {
     assert.strictEqual(count, 0);
   });
 
-  it("exposes the per-user cap as a public constant", async () => {
-    const cap = await paymaster.read.SPONSORED_TX_CAP();
+  it("exposes the per-user cap as a public state var (default 3)", async () => {
+    const cap = await paymaster.read.sponsoredTxCap();
     assert.strictEqual(cap, 3);
   });
 
@@ -536,5 +536,120 @@ describe("RomeBridgePaymaster", () => {
     // Victim's budget MUST remain at 0.
     const count = await paymaster.read.sponsoredTxCount([victim]);
     assert.strictEqual(count, 0);
+  });
+
+  // ─── Hardening A1: Pausable ──────────────────────────────────────────────
+
+  describe("Pausable (A1 — incident response)", () => {
+    it("starts unpaused", async () => {
+      const paused = await paymaster.read.paused();
+      assert.strictEqual(paused, false);
+    });
+
+    it("owner can pause + unpause", async () => {
+      const pc = await viem.getPublicClient();
+      const tx1 = await paymaster.write.pause({ account: adminWallet.account });
+      await pc.waitForTransactionReceipt({ hash: tx1 });
+      assert.strictEqual(await paymaster.read.paused(), true);
+      const tx2 = await paymaster.write.unpause({ account: adminWallet.account });
+      await pc.waitForTransactionReceipt({ hash: tx2 });
+      assert.strictEqual(await paymaster.read.paused(), false);
+    });
+
+    it("non-owner cannot pause", async () => {
+      await assert.rejects(
+        async () => paymaster.write.pause({ account: userWallet.account }),
+        (err: any) => /OwnableUnauthorizedAccount|Ownable/.test(String(err?.message ?? err)),
+      );
+    });
+
+    it("execute() reverts while paused; resumes after unpause", async () => {
+      await paymaster.write.setAllowlistEntry(
+        [mockTarget.address, TOUCH_SELECTOR, true],
+        { account: adminWallet.account },
+      );
+      const pc = await viem.getPublicClient();
+      await pc.waitForTransactionReceipt({
+        hash: await paymaster.write.pause({ account: adminWallet.account }),
+      });
+
+      const nonce = await paymaster.read.nonces([user]);
+      const deadline = Math.floor(Date.now() / 1000) + 3600;
+      const data = encodeFunctionData({
+        abi: parseAbi(["function touch()"]),
+        functionName: "touch",
+      });
+      const request = { from: user, to: mockTarget.address as Address, value: 0n, gas: 100_000n, nonce, deadline, data: data as `0x${string}` };
+      const signature = await signForwardRequest(userWallet, paymaster.address, chainId, request);
+      const fwd = { from: request.from, to: request.to, value: request.value, gas: request.gas, deadline: request.deadline, data: request.data, signature };
+
+      // Paused: must revert
+      await assert.rejects(
+        async () => paymaster.write.execute([fwd], { account: adminWallet.account }),
+        (err: any) => /EnforcedPause|paused/i.test(String(err?.message ?? err)),
+      );
+
+      // Unpause and retry — must succeed (and NOT consume nonce on the failed try
+      // since the revert reverted state)
+      await pc.waitForTransactionReceipt({
+        hash: await paymaster.write.unpause({ account: adminWallet.account }),
+      });
+      const tx = await paymaster.write.execute([fwd], { account: adminWallet.account });
+      await pc.waitForTransactionReceipt({ hash: tx });
+      assert.strictEqual(await paymaster.read.sponsoredTxCount([user]), 1);
+    });
+  });
+
+  // ─── Hardening A4: SPONSORED_TX_CAP — owner-mutable ──────────────────────
+
+  describe("Mutable sponsorship cap (A4)", () => {
+    it("defaults to 3 in constructor", async () => {
+      const cap = await paymaster.read.sponsoredTxCap();
+      assert.strictEqual(cap, 3);
+    });
+
+    it("owner can raise the cap; users with already-exhausted budget can be sponsored again", async () => {
+      const pc = await viem.getPublicClient();
+      // Burn through 3 tx for the user
+      await paymaster.write.setAllowlistEntry(
+        [mockTarget.address, TOUCH_SELECTOR, true],
+        { account: adminWallet.account },
+      );
+      const data = encodeFunctionData({ abi: parseAbi(["function touch()"]), functionName: "touch" });
+      for (let i = 0; i < 3; i++) {
+        const nonce = await paymaster.read.nonces([user]);
+        const deadline = Math.floor(Date.now() / 1000) + 3600;
+        const req = { from: user, to: mockTarget.address as Address, value: 0n, gas: 100_000n, nonce, deadline, data: data as `0x${string}` };
+        const sig = await signForwardRequest(userWallet, paymaster.address, chainId, req);
+        const fwd = { from: req.from, to: req.to, value: req.value, gas: req.gas, deadline: req.deadline, data: req.data, signature: sig };
+        await pc.waitForTransactionReceipt({
+          hash: await paymaster.write.execute([fwd], { account: adminWallet.account }),
+        });
+      }
+      assert.strictEqual(await paymaster.read.sponsoredTxCount([user]), 3);
+
+      // Raise cap to 5 — user can now be sponsored two more times
+      await pc.waitForTransactionReceipt({
+        hash: await paymaster.write.setSponsoredTxCap([5], { account: adminWallet.account }),
+      });
+      assert.strictEqual(await paymaster.read.sponsoredTxCap(), 5);
+
+      const nonce = await paymaster.read.nonces([user]);
+      const deadline = Math.floor(Date.now() / 1000) + 3600;
+      const req = { from: user, to: mockTarget.address as Address, value: 0n, gas: 100_000n, nonce, deadline, data: data as `0x${string}` };
+      const sig = await signForwardRequest(userWallet, paymaster.address, chainId, req);
+      const fwd = { from: req.from, to: req.to, value: req.value, gas: req.gas, deadline: req.deadline, data: req.data, signature: sig };
+      await pc.waitForTransactionReceipt({
+        hash: await paymaster.write.execute([fwd], { account: adminWallet.account }),
+      });
+      assert.strictEqual(await paymaster.read.sponsoredTxCount([user]), 4);
+    });
+
+    it("non-owner cannot change the cap", async () => {
+      await assert.rejects(
+        async () => paymaster.write.setSponsoredTxCap([10], { account: userWallet.account }),
+        (err: any) => /OwnableUnauthorizedAccount|Ownable/.test(String(err?.message ?? err)),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes the four open Solidity-side audit items from [`rome-ui/deploy/PRODUCTION_HARDENING.md`](https://github.com/rome-protocol/rome-ui/blob/main/deploy/PRODUCTION_HARDENING.md).

| Audit item | Contract | What |
|---|---|---|
| **A1: Pausable** | RomeBridgePaymaster | OZ Pausable. `whenNotPaused` on `_execute`. Owner-only `pause()` / `unpause()`. Lets operators halt all relayed flows during incident without iterating the allowlist. |
| **A2: ReentrancyGuard** | RomeBridgeInbound | OZ ReentrancyGuard. `nonReentrant` on `settleInbound`. Defense-in-depth — `call{value}` hands control to user, malicious receivers can't re-enter. |
| **A3: Slippage check** | RomeBridgeInbound | `address(this).balance` snapshot before/after `unwrap_spl_to_gas`; revert with `UnexpectedUnwrapDelta` if delta ≠ expected. Catches a hypothetical precompile underforward bug. |
| **A4: Mutable budget cap** | RomeBridgePaymaster | `SPONSORED_TX_CAP` constant → `sponsoredTxCap` state var. Default 3. Owner-mutable via `setSponsoredTxCap(uint8)`. Emits `SponsoredTxCapChanged`. |

## Test coverage (TDD)

184 passing total in the suite. **9 new tests** (4 Pausable, 3 mutable-cap, 1 ReentrancyGuard, 1 slippage) — all written before the contract changes (RED → GREEN verified per item).

Two new test mocks:
- \`ReentrantReceiver\` — re-enters \`settleInbound\` from \`receive()\`
- \`PartialPayoutUnwrap\` — precompile stand-in that credits half the requested amount

## Deployment notes

This is a contract change. After merge:
1. Redeploy \`RomeBridgePaymaster\` on Marcus + any other deployment targets
2. Redeploy \`RomeBridgeInbound\` (constructor arg unchanged: forwarder, wrapper, mint)
3. Re-run \`scripts/bridge/deploy-inbound.ts\` to set the paymaster allowlist (idempotent)
4. Update \`deployments/marcus.json\` with new addresses
5. Update rome-ui's \`chains.yaml\` with the new paymaster + inbound addresses
6. Existing user counters reset to 0 on the new paymaster (acceptable — testnet)

## Test plan

- [x] \`npx hardhat test tests/bridge/\` — 184 passing
- [ ] Local: deploy on hardhat fork, paymaster.pause() blocks bridge submit; unpause restores
- [ ] Marcus dry-run: redeploy + re-run end-to-end inbound CCTP with gas-split (wrapper-only and slider > 0 paths)
- [ ] Verify the existing test "rejects on Marcus" smoke probe still works against the new contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)