### PR TITLE
chore(deploy): redeploy RomeBridgeInbound on Marcus post-hardening (#55)

### DIFF
--- a/deployments/marcus.json
+++ b/deployments/marcus.json
@@ -19,7 +19,11 @@
     "deployedAt": 1776768105
   },
   "archive": {
-    "RomeBridgeWithdrawPrevious": null
+    "RomeBridgeWithdrawPrevious": null,
+    "RomeBridgeInboundPrevious": {
+      "address": "0x3972795F001d3c3e562009b3f5B5581e305152d2",
+      "archivedAt": 1777090061
+    }
   },
   "OracleGatewayV2": {
     "deployedAt": "2026-04-21T19:15:31.160Z",
@@ -91,7 +95,7 @@
     ]
   },
   "RomeBridgeInbound": {
-    "address": "0x3972795F001d3c3e562009b3f5B5581e305152d2",
-    "deployedAt": 1777068163
+    "address": "0x01d5cCfb9349F051A2a78bA75285168cbA0D206a",
+    "deployedAt": 1777090061
   }
 }

--- a/scripts/bridge/REDEPLOY_HARDENING.md
+++ b/scripts/bridge/REDEPLOY_HARDENING.md
@@ -36,7 +36,7 @@ npx hardhat compile
 #    (Funding floor in deployments/marcus.json's deployer notes.)
 
 # 3. Run the redeploy script.
-npx hardhat run scripts/bridge/redeploy-inbound.ts --network monti_spl
+npx hardhat run scripts/bridge/redeploy-inbound.ts --network marcus
 
 # Expected output:
 #   - Deploys new RomeBridgeInbound at <NEW_ADDRESS>
@@ -68,7 +68,7 @@ After updating `chains.yaml`, restart the rome-ui backend so it re-reads.
 
 ```bash
 # 1. Confirm the new contract picked up the hardening:
-npx hardhat console --network monti_spl
+npx hardhat console --network marcus
 > const i = await viem.getContractAt("RomeBridgeInbound", "<NEW_ADDRESS>")
 > // The reentrancy guard storage slot is _NOT_ENTERED (1) on a fresh deploy.
 > // The slippage error UnexpectedUnwrapDelta is in the ABI:

--- a/scripts/bridge/redeploy-inbound.ts
+++ b/scripts/bridge/redeploy-inbound.ts
@@ -28,8 +28,11 @@
 // "current" at the start of this run. Don't run twice without good reason.
 //
 // Usage:
-//   npx hardhat run scripts/bridge/redeploy-inbound.ts --network monti_spl
+//   npx hardhat run scripts/bridge/redeploy-inbound.ts --network marcus
 //   npx hardhat run scripts/bridge/redeploy-inbound.ts --network local
+//
+// Requires the MARCUS_PRIVATE_KEY hardhat config variable to be set
+// (deployer wallet that funded the original deploy).
 
 import hardhat from "hardhat";
 import fs from "node:fs";


### PR DESCRIPTION
## Summary

- Records the post-#55 redeploy of `RomeBridgeInbound` on Marcus (chainId 121226)
- Old: `0x3972795F001d3c3e562009b3f5B5581e305152d2` → archived under `archive.RomeBridgeInboundPrevious`
- New: `0x01d5cCfb9349F051A2a78bA75285168cbA0D206a`
- Fixes a doc bug merged in #55: `--network monti_spl` → `--network marcus` (the hardhat config has a dedicated `marcus` network for 121226)

The new contract picks up the security-critical fixes from #55:
- `ReentrancyGuard` on `settleInbound`
- Slippage check (`UnexpectedUnwrapDelta` revert) after `unwrap_spl_to_gas`

## Verification

```
=== New RomeBridgeInbound ===
Code present: true (length 3486)

=== Allowlist tx receipt ===
Status:     success
Block:      332
GasUsed:    1443760
From:       0x3403e0de09bc76ca7d74762f264e4f6b649a0562
To:         0xcaf1fbcf60c3686d87d0a5111f340a99250ce4ef

=== Allowlist storage check ===
settleInbound selector: 0xb22e39b7
Paymaster.allowlist[(new inbound, settleInbound)]: true
```

Tx hashes:
- Allowlist: [`0xa0b24704fdf4f20b7a94739b2e68f994b4ea54389b60e362f7fef23966921025`](https://marcus.devnet.romeprotocol.xyz/tx/0xa0b24704fdf4f20b7a94739b2e68f994b4ea54389b60e362f7fef23966921025)

## Scope

Paymaster + Withdraw are intentionally untouched. Per [`scripts/bridge/REDEPLOY_HARDENING.md`](./scripts/bridge/REDEPLOY_HARDENING.md):
- Paymaster constructor unchanged in #55
- Pausable + mutable `sponsoredTxCap` are operational features, not security-critical
- Redeploying the paymaster would cascade to `RomeBridgeWithdraw` + `RomeBridgeInbound` because both store the forwarder as an immutable `ERC2771Context` field

## Downstream follow-ups (separate PR on rome-ui)

- [ ] Update `rome-ui/deploy/chains.sample.yaml` line ~26: `marcus.contracts.romeBridgeInbound`
- [ ] Operator updates `rome-ui/backend/chains.yaml` (gitignored)
- [ ] Restart rome-ui backend so it re-reads the chain config

## Test plan

- [x] On-chain: code present at new address
- [x] On-chain: allowlist tx succeeded + storage confirms entry
- [ ] End-to-end: run an inbound CCTP bridge from Sepolia → Marcus through the rome-ui portal once the chains config update lands; watch the worker's `[bridge-worker] settling-split` phase succeed against the new inbound

🤖 _This response was generated by Claude Code._