### PR TITLE
chore: upgrade Dependabot config to canonical template + add auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,54 @@
+# Sourced from: rome-protocol/rome-ops/templates/dependabot/node.yml
+# Solidity contracts repo with Hardhat (Node.js dev tooling).
+#
+# Replaces the previous thin config (only had npm + github-actions
+# weekly with no grouping or ignores). New config adds grouping for
+# patch+minor and the framework split for the Hardhat ecosystem.
+
 version: 2
+
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: friday
+    open-pull-requests-limit: 8
+    labels:
+      - dependencies
+      - node
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          - "hardhat"
+          - "@nomicfoundation/*"
+          - "ethers"
+      framework:
+        patterns:
+          - "hardhat"
+          - "@nomicfoundation/*"
+          - "ethers"
+        update-types:
+          - patch
+          - minor
+    ignore:
+      - dependency-name: "picomatch"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday
     open-pull-requests-limit: 5
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+    groups:
+      gh-actions:
+        update-types:
+          - patch
+          - minor
+          - major

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+# Sourced from: rome-protocol/rome-ops/templates/dependabot/dependabot-auto-merge.yml
+#
+# Phase 2: auto-merge patch + minor for github_actions, cargo, npm, pip, gomod.
+# Docker stays manual indefinitely (nginx:1.30-alpine-slim curl regression precedent).
+# Major version bumps across all ecosystems still queue for human review.
+#
+# Security note: PR_URL is sourced from `github.event.pull_request.html_url`,
+# which is GitHub-generated (not user-controlled), routed through env: with
+# quoted "$PR_URL" expansion — no direct ${{ }} interpolation in run:.
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for low-risk updates
+        if: |
+          (steps.meta.outputs.package-ecosystem == 'github_actions' ||
+           steps.meta.outputs.package-ecosystem == 'cargo' ||
+           steps.meta.outputs.package-ecosystem == 'npm_and_yarn' ||
+           steps.meta.outputs.package-ecosystem == 'pip' ||
+           steps.meta.outputs.package-ecosystem == 'gomod') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Replaces the existing 13-line `dependabot.yml` with the canonical `node.yml` template from rome-ops, and adds the Phase 2 auto-merge workflow.

## Why

rome-solidity was the only repo with a pre-existing Dependabot config — and it had **7 stale dep PRs piling up** because there was no auto-merge wiring. This was actually the case study that motivated the org-wide rollout: config without auto-merge = noise no one merges.

## What's New

| Aspect | Before | After |
|---|---|---|
| npm grouping | None — N PRs/week | Patch+minor bundled into 1 PR |
| Framework split | None | `hardhat` / `@nomicfoundation/*` / `ethers` in own group |
| Ignores | None | `picomatch` (template consistency) |
| github-actions | Weekly, no grouping | Weekly, all-in-one group (incl. major) |
| Auto-merge | None | Phase 2: github_actions/cargo/npm/pip/gomod patch+minor |

Phase 2 auto-merge will retroactively unblock the existing 7 stale dep PRs (they'll match patch/minor on rebase).

## After This Lands

The Dependabot rollout across all 19 active code repos is **complete**.

🤖 _This response was generated by Claude Code._