### PR TITLE
fix(erc20spl): self-bootstrap user + ATA on every entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SPL_ERC20` is fully self-bootstrapping for first-time callers.** Every
+  user-side function (`transfer`, `transferFrom`, `approve`, `mint_to`,
+  `ensure_token_account`) now calls `_users.ensure_user(msg.sender)` instead
+  of `_users.get_user(msg.sender)` AND auto-creates the relevant ATA cache
+  entries before the SPL CPI. A brand-new wallet — never bridged, never
+  wrapped — can now `transfer` straight from MetaMask without an
+  out-of-band `ensure_user` / `ensure_token_account` setup tx. Same model as
+  Phantom and every other Solana wallet.
+  - `_transfer` calls `ensure_token_account(from)` AND `ensure_token_account(to)`
+    so both sides' ATAs are present before `transfer_checked`.
+  - `mint_to` / `approve` apply the same auto-ensure pattern.
+  - `balanceOf` is now total: returns `0` for unregistered or unfunded users
+    instead of reverting with `"Token account does not exist"`. Reads from
+    `_accounts` cache when present, otherwise derives the deterministic ATA
+    via the new `derive_token_account` helper. If the underlying SPL token
+    account doesn't yet exist on Solana, `account_info` returns empty data
+    and we short-circuit to `0` via a length check.
+  - Pre-fix symptoms this resolves: MetaMask "Send" greys out for any
+    fresh recipient; first-time callers hit `"Token account does not exist"`
+    on transfer / approve / balanceOf; `RomeBridgeWithdraw.burnUSDC` cannot
+    be invoked by users who hold rUSDC but never registered.
+
 ### Added
 - `IUnwrapSplToGas` / `IWrapGasToSpl` interfaces + pre-bound `UnwrapSplToGas`
   / `WrapGasToSpl` constants in `contracts/interface.sol`. Maps to the new
   non_evm precompiles in rome-evm-private at `0x42..17` and `0x42..18`.
   Selector parity test at `tests/interface_wrap_unwrap.test.ts` locks the
   keccak256 bytes against the Rust program's constants.
+- `SPL_ERC20.derive_token_account(address)` — deterministic ATA derivation
+  helper used by `balanceOf`'s no-revert fallback.
 - Agent Execution Guide and Change Impact Map in CLAUDE.md
 - PR and issue templates for standardized contributions
 - CI pipeline with Hardhat compile and test stages

--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -68,6 +68,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     ERC20Users private _users;
     mapping(address => bytes32) private _accounts;
 
+    /// @notice Public reader for the SPL token account owned by this EVM user.
+    /// @dev Returns the cached ATA; callers may treat a zero return as "not yet initialized".
+    function getAta(address user) external view returns (bytes32) {
+        return _accounts[user];
+    }
 
     error ERC20InvalidApprover(address approver);
     error ERC20InvalidSpender(address spender);
@@ -132,9 +137,15 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      * Checks if the user has an associated token account, and if not, creates one. Returns the associated token account address.
      * @param user EVM address of the user for whom to ensure the associated token account exists
      * @return associated_account_address The address of the associated token account created or existing for the user
+     *
+     * Uses `_users.ensure_user(msg.sender)` (not `get_user`) so a brand-
+     * new caller — one who's never bridged, never wrapped, never been
+     * through any flow that registered them in `ERC20Users` — gets
+     * auto-registered on the first call. Self-bootstrapping; no
+     * out-of-band setup tx required.
      */
     function ensure_token_account(address user) public returns (bytes32) {
-        ERC20Users.User memory initiator = _users.get_user(msg.sender);
+        ERC20Users.User memory initiator = _users.ensure_user(msg.sender);
         bytes32 token_account = _accounts[user];
         if (token_account == bytes32(0)) {
             return create_token_account(user, initiator);
@@ -167,13 +178,48 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         return uint256(mint.supply);
     }
 
+    /// Derives the deterministic PDA-owned ATA for a user without
+    /// reading or writing the local `_accounts` cache. Used by
+    /// `balanceOf` so the view-side never reverts on unregistered
+    /// users — matches the standard ERC20 spec where `balanceOf` is
+    /// total. Wallet derivation matches `create_token_account`'s
+    /// (`new_user.owner` = `RomeEVMAccount.pda(user)`, no salt) so the
+    /// derived ATA is the same address `_accounts[user]` would cache.
+    function derive_token_account(address user) public view returns (bytes32) {
+        bytes32 wallet = RomeEVMAccount.pda(user);
+        return AssociatedSplToken.get_associated_token_address_with_program_id(
+            wallet, mint_id, SplTokenLib.SPL_TOKEN_PROGRAM, associated_token_program_id
+        );
+    }
+
+    /// ERC20 `balanceOf` — never reverts. Resolves the ATA in this order:
+    ///   1. cached `_accounts[account]` (fast path — populated by
+    ///      `ensure_token_account`, called by transfer / approve /
+    ///      mint_to / inbound bridge worker);
+    ///   2. deterministic derivation via `derive_token_account` (fallback
+    ///      so brand-new wallets read 0 instead of reverting).
+    /// If the resolved SPL token account doesn't yet exist on Solana
+    /// (truly fresh user, never received SPL), `account_info` returns
+    /// empty data and we return 0 instead of letting
+    /// `parse_token_account_amount` revert with `IndexOutOfBounds`.
     function balanceOf(address account) public view virtual returns (uint256) {
-        bytes32 token_account = get_token_account(account);
-        return uint256(SplTokenLib.load_token_amount(token_account, cpi_program));
+        bytes32 token_account = _accounts[account];
+        if (token_account == bytes32(0)) {
+            token_account = derive_token_account(account);
+        }
+        (,,,,, bytes memory data) = ICrossProgramInvocation(cpi_program).account_info(token_account);
+        if (data.length < SplTokenLib.SPL_TOKEN_ACCOUNT_MIN_LEN) {
+            return 0;
+        }
+        return uint256(SplTokenLib.parse_token_account_amount(data));
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {
-        return _transfer(_users.get_user(msg.sender), msg.sender, to, value);
+        // Auto-register the sender in ERC20Users on first call. Without
+        // this a brand-new wallet hits "User does not exist" before
+        // `_transfer` runs. `ensure_user` is idempotent — cached after
+        // the first call, no extra cost on subsequent transfers.
+        return _transfer(_users.ensure_user(msg.sender), msg.sender, to, value);
     }
 
     /**
@@ -187,20 +233,32 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      */
     function _transfer(
         ERC20Users.User memory user,
-        address from, 
-        address to, 
+        address from,
+        address to,
         uint256 value
     ) internal returns (bool) {
         require(value <= type(uint64).max, "Transfer amount exceeds uint64");
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) = 
+        // Auto-create both sides' PDA-owned ATA cache. Without this,
+        // sending to a fresh address reverts with "Token account does
+        // not exist" (recipient side), and a sender who's never
+        // touched THIS wrapper before reverts on the from side even
+        // though their underlying SPL ATA exists on Solana. MetaMask's
+        // `eth_call` simulation surfaces both as a greyed-out Send
+        // button. `ensure_token_account` is idempotent; it pays a
+        // create-idempotent CPI on first encounter (no-op when the
+        // ATA already exists on Solana, ~0.002 SOL rent paid by the
+        // sender otherwise).
+        bytes32 from_account = ensure_token_account(from);
+        bytes32 to_account = ensure_token_account(to);
+        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) =
         SplTokenLib.transfer_checked(
             SplTokenLib.SPL_TOKEN_PROGRAM,
-            get_token_account(from), 
-            mint_id, 
-            get_token_account(to),
+            from_account,
+            mint_id,
+            to_account,
             user.owner,
             new bytes32[](0),
-            uint64(value), 
+            uint64(value),
             decimals
         );
 
@@ -227,13 +285,19 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {
-        ERC20Users.User memory ownerUser = _users.get_user(msg.sender);
-        ERC20Users.User memory spenderUser = _users.get_user(spender);
+        // Auto-register both parties + the owner's ATA cache. Same
+        // reasoning as `transfer` — owner / spender may not have
+        // touched this wrapper before, so falling through with
+        // `get_user` would revert with "User does not exist" in
+        // MetaMask's simulation.
+        ERC20Users.User memory ownerUser   = _users.ensure_user(msg.sender);
+        ERC20Users.User memory spenderUser = _users.ensure_user(spender);
+        bytes32 ownerAta                    = ensure_token_account(msg.sender);
 
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) = 
+        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) =
         SplTokenLib.approve(
             SplTokenLib.SPL_TOKEN_PROGRAM,
-            get_token_account(msg.sender),
+            ownerAta,
             spenderUser.owner,
             ownerUser.owner,
             new bytes32[](0),
@@ -252,15 +316,19 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
+        // Auto-register the spender (msg.sender) — they're the
+        // initiator paying for any ATA-creation CPIs inside
+        // _transfer's auto-ensure path. Same reasoning as `transfer`.
         address spender = msg.sender;
-        return _transfer(_users.get_user(spender), from, to, value);
+        return _transfer(_users.ensure_user(spender), from, to, value);
     }
 
     function mint_to(address to, uint256 value) public virtual returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
 
-        ERC20Users.User memory user = _users.get_user(msg.sender);
-        bytes32 to_account = get_token_account(to);
+        // Auto-register the mint authority + the recipient's ATA cache.
+        ERC20Users.User memory user = _users.ensure_user(msg.sender);
+        bytes32 to_account = ensure_token_account(to);
         (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data)
             = SplTokenLib.mint_to_checked(
             SplTokenLib.SPL_TOKEN_PROGRAM,


### PR DESCRIPTION
## Summary

Stacks on top of #52. Every user-side function on `SPL_ERC20` now auto-registers the caller in `ERC20Users` and auto-creates the relevant ATA cache entries before the SPL CPI. The wrapper is fully self-bootstrapping for first-time callers — no out-of-band `ensure_user` / `ensure_token_account` setup tx required.

## What this fixes

- MetaMask **Send button greys out** when transferring wUSDC / wETH to a fresh recipient → the contract now auto-creates the recipient ATA (same model as Phantom).
- A user holding rUSDC but never registered in `ERC20Users` could not call `RomeBridgeWithdraw.burnUSDC` → `_users.ensure_user(msg.sender)` is now called on every entry point.
- `balanceOf` reverted with `"Token account does not exist"` for unregistered or unfunded users → now returns `0` (matches the standard ERC20 spec).

## Why stacked on PR #52, not master

The on-chain `ERC20Users` at `0x803f6923…` uses the **struct-based ABI** (`User { payer, owner, seed }`) that PR #52's branch carries. Master refactored this to a single `bytes32`. A redeploy from master:
1. Couldn't decode responses from the live `ERC20Users` (ABI mismatch).
2. Computed a different ATA address — `ata(payer_pda, mint)` instead of the live `ata(EXTERNAL_AUTHORITY_pda, mint)` — so existing user balances would not be visible on the new wrapper.

Verified live on marcus: deployer's old-wrapper cached ATA `0xaeb1da96…93` vs master-derived `0x434f0305…20`. Different addresses. PR #65 documents the orphan deploys this caused.

This branch keeps the struct-based design intact and just layers the auto-ensure fix on top.

## Changes

| Function | Before | After |
|---|---|---|
| `transfer` | `_users.get_user(msg.sender)` reverts on fresh wallets | `_users.ensure_user(msg.sender)` self-registers |
| `transferFrom` | same | same fix on the spender side |
| `_transfer` | `get_token_account(from)` + `get_token_account(to)` revert on cache miss | `ensure_token_account(from)` + `ensure_token_account(to)` |
| `ensure_token_account` | `_users.get_user(msg.sender)` reverted on fresh callers | `_users.ensure_user(msg.sender)` |
| `approve` | `get_user` + `get_token_account` reverts | `ensure_user` for both parties + `ensure_token_account` for owner |
| `mint_to` | reverts on unregistered authority + missing recipient ATA | `ensure_user` + `ensure_token_account(to)` |
| `balanceOf` | reverts on unregistered users | reads cache → derives via new `derive_token_account` → length-guards `account_info` and returns `0` instead of reverting |

New helper: `derive_token_account(address) public view returns (bytes32)` — pure deterministic ATA derivation, same wallet rule as `create_token_account` (`new_user.owner`, no salt).

## Deploy path

Once this lands and PR #52 merges:
1. Compile from PR #52's branch.
2. Run `scripts/bridge/redeploy-wrappers-and-withdraw.ts` from PR #65.
3. Update `rome-ui/deploy/chains.yaml` `marcus.contracts.gasWrapper` + `romeBridgeWithdraw` to the new addresses (printed by the script).
4. Smoke-test transfer-to-fresh-recipient from MetaMask.

## Test plan

- [ ] Compile clean (verified locally with `--build-profile production`).
- [ ] Transfer to brand-new address from a wallet that's never touched the wrapper before — succeeds.
- [ ] `balanceOf(unregistered)` returns `0` instead of reverting.
- [ ] `RomeBridgeWithdraw.burnUSDC` simulates cleanly for a wUSDC holder who never explicitly registered.
- [ ] After redeploy + chain-config swap, MetaMask Send button enables for fresh recipients.

🤖 _This response was generated by Claude Code._