### PR TITLE
feat(bridge): factory-register canonical SPL wrappers so Rome UI sees them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — Bridged-wrapper bootstrap script
+- `scripts/bridge/bootstrap-bridged-wrappers.ts` — registers the canonical bridged SPL mints (USDC, WETH) on a chain's `ERC20SPLFactory` via `add_spl_token_no_metadata`. The factory's `TokenCreated` event is what the rome-ui backend's token watcher consumes to populate Portfolio / Swap / TokenSelectModal; wrappers deployed by direct `new SPL_ERC20(...)` (legacy bridge redeploy scripts) bypass that event and stay invisible in the UI. Run after `scripts/deploy_erc20spl_factory.ts` on a fresh chain — the script is idempotent (skips mints with a non-zero `token_by_mint`) and writes resulting wrapper addresses into `deployments/<network>.json` under `SPL_ERC20_USDC` / `SPL_ERC20_WETH`. Mint set is auto-selected per network (devnet vs mainnet); override via `BRIDGED_SET=devnet|mainnet` for one-offs.
+
 ### Added — Oracle Gateway V2 GitHub Actions deploy workflow
 - `.github/workflows/deploy-oracle.yml` — manual-trigger (`workflow_dispatch`) workflow that deploys Oracle Gateway V2 (core + seed feeds + verification) against a selected Rome devnet using a single shared GitHub Secret (`ROME_DEVNET_PRIVATE_KEY`). Posts the resulting `deployments/<network>.json` back as a reviewable bot PR via `peter-evans/create-pull-request` when `open_pr: true`. Toggles: `run_seed_feeds`, `run_verification`, `open_pr`, `force_redeploy`. Closes #33.
 - `hardhat.config.ts` — added `subura` (chainId 121222) and `esquiline` (chainId 121225) network entries; deduplicated the `marcus` block and added its explicit `chainId 121226`.

--- a/scripts/bridge/bootstrap-bridged-wrappers.ts
+++ b/scripts/bridge/bootstrap-bridged-wrappers.ts
@@ -1,0 +1,117 @@
+// scripts/bridge/bootstrap-bridged-wrappers.ts
+//
+// Registers the canonical bridged-asset SPL mints (USDC, WETH) on the
+// chain's ERC20SPLFactory. Run once after deploying the factory on a
+// fresh chain — the resulting `TokenCreated` events are what the
+// rome-ui backend's token watcher consumes to populate Portfolio /
+// Swap / TokenSelectModal. Wrappers deployed via direct
+// `new SPL_ERC20(...)` (e.g. legacy bridge redeploy scripts) bypass
+// this event and never appear in the UI; this script keeps the
+// canonical wrappers on the indexed path.
+//
+// Idempotent: skips mints that already have a wrapper registered
+// (`factory.token_by_mint(mint) != 0`).
+
+import fs from "node:fs";
+import hardhat from "hardhat";
+import { resolveERC20SPLFactoryAddress } from "../lib/deployments.js";
+import { base58ToBytes32 } from "../lib/pubkey.js";
+import { SPL_MINTS_DEVNET, SPL_MINTS_MAINNET } from "./constants.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+type WrapperSpec = {
+  key: string;          // deployments.json key (e.g. "SPL_ERC20_USDC")
+  mintBase58: string;   // SPL mint
+  name: string;         // ERC20 name
+  symbol: string;       // ERC20 symbol — must be unique within the factory
+};
+
+// Canonical bridged set. Symbols match rome-ui's gas-wrapper-split
+// convention: native gas = "USDC", wrapped = "wUSDC"; native chain =
+// nothing here (we don't wrap an EVM-native), wormhole-wrapped ETH =
+// "wETH". Tracked separately for devnet / mainnet because the mint
+// addresses differ.
+const DEVNET_SET: WrapperSpec[] = [
+  { key: "SPL_ERC20_USDC", mintBase58: SPL_MINTS_DEVNET.USDC_NATIVE,   name: "Rome USDC", symbol: "wUSDC" },
+  { key: "SPL_ERC20_WETH", mintBase58: SPL_MINTS_DEVNET.WETH_WORMHOLE, name: "Rome ETH",  symbol: "wETH"  },
+];
+
+const MAINNET_SET: WrapperSpec[] = [
+  { key: "SPL_ERC20_USDC", mintBase58: SPL_MINTS_MAINNET.USDC_NATIVE,   name: "Rome USDC", symbol: "wUSDC" },
+  { key: "SPL_ERC20_WETH", mintBase58: SPL_MINTS_MAINNET.WETH_WORMHOLE, name: "Rome ETH",  symbol: "wETH"  },
+];
+
+// Devnet networks use the devnet mint set; everything else uses
+// mainnet. Override via `BRIDGED_SET=devnet|mainnet` env var when the
+// network name doesn't match the convention (e.g. a one-off testnet).
+function resolveSet(networkName: string): WrapperSpec[] {
+  const override = process.env.BRIDGED_SET?.toLowerCase();
+  if (override === "devnet")  return DEVNET_SET;
+  if (override === "mainnet") return MAINNET_SET;
+  const isDevnet = ["local", "marcus", "monti_spl", "subura", "esquiline"].includes(networkName);
+  return isDevnet ? DEVNET_SET : MAINNET_SET;
+}
+
+type DeploymentsJson = Record<string, unknown>;
+
+function loadJson(path: string): DeploymentsJson {
+  return fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, "utf8")) as DeploymentsJson : {};
+}
+
+function saveJson(path: string, data: DeploymentsJson): void {
+  fs.writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+async function main() {
+  const { viem, networkName } = await hardhat.network.connect();
+  const [deployer] = await viem.getWalletClients();
+  if (!deployer?.account) throw new Error("No deployer wallet — set <NETWORK>_PRIVATE_KEY in the keystore");
+
+  const factoryAddress = resolveERC20SPLFactoryAddress(networkName);
+  const factory = await viem.getContractAt("ERC20SPLFactory", factoryAddress);
+  const publicClient = await viem.getPublicClient();
+  const set = resolveSet(networkName);
+
+  console.log(`[${networkName}] deployer: ${deployer.account.address}`);
+  console.log(`[${networkName}] factory:  ${factoryAddress}`);
+  console.log(`[${networkName}] mint set: ${set === DEVNET_SET ? "devnet" : "mainnet"} (${set.length} entries)\n`);
+
+  const deploymentsPath = `deployments/${networkName}.json`;
+  const deployments = loadJson(deploymentsPath);
+
+  for (const { key, mintBase58, name, symbol } of set) {
+    const mint = base58ToBytes32(mintBase58);
+    const existing = (await factory.read.token_by_mint([mint])) as `0x${string}`;
+
+    if (existing.toLowerCase() !== ZERO_ADDRESS) {
+      console.log(`  ${symbol}: already registered → ${existing}`);
+      deployments[key] = { address: existing, mintId: mintBase58, name, symbol };
+      continue;
+    }
+
+    console.log(`  ${symbol}: registering mint ${mintBase58} ...`);
+    const txHash = await factory.write.add_spl_token_no_metadata([mint, name, symbol]);
+    await publicClient.waitForTransactionReceipt({ hash: txHash });
+    const wrapperAddress = (await factory.read.token_by_mint([mint])) as `0x${string}`;
+    if (wrapperAddress.toLowerCase() === ZERO_ADDRESS) {
+      throw new Error(`add_spl_token_no_metadata for ${symbol} landed but token_by_mint is still zero`);
+    }
+    console.log(`           tx: ${txHash}`);
+    console.log(`           wrapper: ${wrapperAddress}`);
+
+    deployments[key] = {
+      address: wrapperAddress,
+      mintId: mintBase58,
+      name,
+      symbol,
+      deployedAt: Math.floor(Date.now() / 1000),
+      via: "ERC20SPLFactory.add_spl_token_no_metadata",
+    };
+  }
+
+  saveJson(deploymentsPath, deployments);
+  console.log(`\nSaved → ${deploymentsPath}`);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary

Adds `scripts/bridge/bootstrap-bridged-wrappers.ts` — a one-shot, idempotent script that registers the canonical bridged-asset SPL mints (USDC, WETH) on a chain's `ERC20SPLFactory` via `add_spl_token_no_metadata`.

The factory's `TokenCreated` event is what the rome-ui backend's token watcher consumes to populate Portfolio / Swap / TokenSelectModal. Wrappers deployed by direct `new SPL_ERC20(...)` (e.g. `scripts/bridge/redeploy-wrappers-and-withdraw.ts` from PR #65, since closed) bypass that event and stay invisible in the UI.

This is precisely what bit Marcus on the current redeploy: the script-deployed wrapper at `0x1f7dfaf9...46195` carries the auto-ATA fix from PR #63 and works on-chain — but the UI cannot see it, so user balances still render against the old factory wrapper at `0x1be9bC...533533`.

## What it does

- Reads `ERC20SPLFactory` address from `deployments/<network>.json`.
- For each canonical mint (USDC, WETH from `scripts/bridge/constants.ts`), checks `factory.token_by_mint(mint)`. If non-zero, skips. Otherwise calls `factory.add_spl_token_no_metadata(mint, name, symbol)`, waits for the receipt, and reads the deployed wrapper address back via `token_by_mint`.
- Writes the resulting wrapper addresses into `deployments/<network>.json` under `SPL_ERC20_USDC` / `SPL_ERC20_WETH`.
- Mint set is auto-selected per network (`local` / `marcus` / `monti_spl` / `subura` / `esquiline` → devnet; everything else → mainnet). Override via `BRIDGED_SET=devnet|mainnet`.

## Why now

The next Marcus rotation is a fresh chain id + fresh contract deploy. Running this script after `scripts/deploy_erc20spl_factory.ts` means the rome-ui backend picks up the canonical bridged wrappers automatically on its next token sync — no `chains.yaml` manual swap, no MetaMask custom-token import.

## Test plan

- [ ] Type-checks clean (`npx tsc --noEmit -p .` shows no new errors)
- [ ] On next Marcus deploy: run after factory deploy, verify `deployments/marcus.json` gets `SPL_ERC20_USDC` / `SPL_ERC20_WETH` blocks with `via: "ERC20SPLFactory.add_spl_token_no_metadata"`
- [ ] Verify rome-ui backend picks up `TokenCreated` events and the wrappers appear in Portfolio without manual config
- [ ] Re-run on same chain → script reports "already registered → 0x..." for each, no duplicate tx

## Notes for the next-Marcus deployer

`scripts/bridge/deploy.ts` still deploys its own `SPL_ERC20` wrappers via direct `viem.deployContract("SPL_ERC20", ...)` — those are bridge-internal and bypass the factory. To get a clean single-wrapper-per-mint setup on the new chain, ideally `deploy.ts` should be modified to consume factory-registered wrappers; flagged as a follow-up since it's a larger refactor and orthogonal to landing this script.

🤖 _This response was generated by Claude Code._