### PR TITLE
feat(erc20spl): balanceOf no-revert + ensure_user auto-register on every entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed — `SPL_ERC20` is fully self-bootstrapping; `balanceOf` never reverts
+- `SPL_ERC20.balanceOf` is now total — returns `0` for unregistered or unfunded accounts instead of reverting with `"Token account does not exist"`. Resolves the ATA via the cache (`_accounts[account]`) when present, otherwise via deterministic derivation, and short-circuits to `0` when the underlying SPL token account hasn't been created on Solana yet. Standard ERC20 contract consumers (DEX routers, allowance checks, wallet UIs) hit `balanceOf` constantly; the prior revert leaked Rome-specific lifecycle into anything that simulated a balance read for a brand-new wallet.
+- `transfer`, `transferFrom`, `approve`, `mint_to`, and `ensure_token_account` now call `_users.ensure_user(msg.sender)` (or `_users.ensure_user(spender)` for `transferFrom`) instead of `get_user`. A first-time caller — never bridged, never wrapped, never registered in `ERC20Users` — gets auto-registered on the first call instead of needing an out-of-band setup tx. Same self-bootstrap model as Phantom and every other Solana wallet.
+- New `SPL_ERC20.derive_token_account(address)` view — the deterministic ATA address for a user (matches `create_token_account`'s salted PDA derivation). Used by the new `balanceOf` fallback; useful to off-chain code that wants the canonical ATA without reading or mutating the cache.
+- View functions (`allowance`, `get_token_account`) still use `_users.get_user` — view functions can't write state, and the sender side already requires a registered user.
+- Existing wrapper deployments (factory-deployed before this change) retain pre-fix bytecode; the fix lands when a fresh chain redeploys the factory or `factory.add_spl_token_no_metadata` is called for a new mint after the upgrade.
+
 ### Added — Bridged-wrapper bootstrap script
 - `scripts/bridge/bootstrap-bridged-wrappers.ts` — registers the canonical bridged SPL mints (USDC, WETH) on a chain's `ERC20SPLFactory` via `add_spl_token_no_metadata`. The factory's `TokenCreated` event is what the rome-ui backend's token watcher consumes to populate Portfolio / Swap / TokenSelectModal; wrappers deployed by direct `new SPL_ERC20(...)` (legacy bridge redeploy scripts) bypass that event and stay invisible in the UI. Run after `scripts/deploy_erc20spl_factory.ts` on a fresh chain — the script is idempotent (skips mints with a non-zero `token_by_mint`) and writes resulting wrapper addresses into `deployments/<network>.json` under `SPL_ERC20_USDC` / `SPL_ERC20_WETH`. Mint set is auto-selected per network (devnet vs mainnet); override via `BRIDGED_SET=devnet|mainnet` for one-offs.
 

--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -53,6 +53,20 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         return _accounts[user];
     }
 
+    /// Derives the deterministic PDA-owned ATA for a user without
+    /// reading or writing the local `_accounts` cache. Wallet derivation
+    /// matches `create_token_account`'s — the salted PDA from
+    /// `RomeEVMAccount.pda_with_salt(user, _users.payer_salt())` — so
+    /// the derived ATA equals the address `_accounts[user]` would cache
+    /// once `ensure_token_account` runs. Used by `balanceOf` so reads
+    /// for unregistered users return 0 instead of reverting.
+    function derive_token_account(address user) public view returns (bytes32) {
+        bytes32 wallet = RomeEVMAccount.pda_with_salt(user, _users.payer_salt());
+        return AssociatedSplToken.get_associated_token_address_with_program_id(
+            wallet, mint_id, SplTokenLib.SPL_TOKEN_PROGRAM, associated_token_program_id
+        );
+    }
+
     error ERC20InvalidApprover(address approver);
     error ERC20InvalidSpender(address spender);
     error ERC20InsufficientAllowance(address spender, uint256 currentAllowance, uint256 requiredAllowance);
@@ -111,7 +125,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      * @return associated_account_address The address of the associated token account created or existing for the user
      */
     function ensure_token_account(address user) public returns (bytes32) {
-        bytes32 payer = _users.get_user(msg.sender);
+        // ensure_user (not get_user) so a brand-new caller — never
+        // bridged, never wrapped, never registered in ERC20Users — gets
+        // auto-registered on the first call. Self-bootstrapping; no
+        // out-of-band setup tx required.
+        bytes32 payer = _users.ensure_user(msg.sender);
         bytes32 token_account = _accounts[user];
         if (token_account == bytes32(0)) {
             return create_token_account(user, payer);
@@ -144,13 +162,28 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         return uint256(mint.supply);
     }
 
+    /// ERC20 `balanceOf` — never reverts. Resolves the ATA in this order:
+    ///   1. cached `_accounts[account]` (fast path — populated by
+    ///      `ensure_token_account`, called by transfer / approve /
+    ///      mint_to / inbound bridge worker);
+    ///   2. deterministic derivation via `derive_token_account` (fallback
+    ///      so brand-new wallets read 0 instead of reverting).
+    /// If the underlying SPL token account hasn't been created yet,
+    /// `account_info` returns empty data; we short-circuit to 0.
     function balanceOf(address account) public view virtual returns (uint256) {
-        bytes32 token_account = get_token_account(account);
-        return uint256(SplTokenLib.load_token_amount(token_account, cpi_program));
+        bytes32 token_account = _accounts[account];
+        if (token_account == bytes32(0)) {
+            token_account = derive_token_account(account);
+        }
+        (,,,,, bytes memory data) = ICrossProgramInvocation(cpi_program).account_info(token_account);
+        if (data.length == 0) {
+            return 0;
+        }
+        return uint256(SplTokenLib.parse_token_account_amount(data));
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {
-        return _transfer(_users.get_user(msg.sender), msg.sender, to, value);
+        return _transfer(_users.ensure_user(msg.sender), msg.sender, to, value);
     }
 
     /**
@@ -218,8 +251,8 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {
-        bytes32 ownerUser = _users.get_user(msg.sender);
-        bytes32 spenderUser = _users.get_user(spender);
+        bytes32 ownerUser = _users.ensure_user(msg.sender);
+        bytes32 spenderUser = _users.ensure_user(spender);
 
         (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) = 
         SplTokenLib.approve(
@@ -246,13 +279,13 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
 
     function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
         address spender = msg.sender;
-        return _transfer(_users.get_user(spender), from, to, value);
+        return _transfer(_users.ensure_user(spender), from, to, value);
     }
 
     function mint_to(address to, uint256 value) public virtual returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
 
-        bytes32 user = _users.get_user(msg.sender);
+        bytes32 user = _users.ensure_user(msg.sender);
         // Mint to a fresh address: ensure the recipient's PDA-owned
         // ATA exists before the SPL mint_to_checked CPI. Same
         // idempotent pattern as `_transfer` above — no-op when the


### PR DESCRIPTION
## Summary

Closes the residual scope of PR #66 by porting it onto current master (master refactored \`ERC20Users\` from struct to single \`bytes32\` after #66 was opened, leaving #66 conflicted; this PR is the bytes32-aligned rewrite).

Two related changes that finish the \`SPL_ERC20\` self-bootstrap story PR #63 started:

1. **\`balanceOf\` is now total — never reverts.** Resolves the ATA via the cache when populated, otherwise via deterministic derivation (\`RomeEVMAccount.pda_with_salt\` + ATA derivation), and short-circuits to \`0\` when the underlying SPL token account hasn't been created on Solana. Standard ERC20 consumers (DEX routers, allowance checks, wallet UIs) hit \`balanceOf\` constantly; the prior revert leaked Rome-specific lifecycle into anything that simulated a balance read for a brand-new wallet.

2. **\`transfer\` / \`transferFrom\` / \`approve\` / \`mint_to\` / \`ensure_token_account\` now call \`_users.ensure_user(msg.sender)\` (or \`_users.ensure_user(spender)\` for \`transferFrom\`) instead of \`get_user\`.** First-time callers — never bridged, never wrapped — get auto-registered in \`ERC20Users\` on the first call instead of needing an out-of-band setup tx. Same model as Phantom and every other Solana wallet.

3. **New \`derive_token_account(address)\` public view** — the deterministic ATA address for a user (matches \`create_token_account\`'s salted PDA derivation). Used by \`balanceOf\`'s fallback path and exposed for off-chain code that wants the canonical ATA without reading or mutating cache state.

\`allowance\` and \`get_token_account\` stay on \`get_user\` — views can't write state, and the sender side already requires a registered user.

## Test plan

- [x] \`npx hardhat compile\` clean (default + production profile)
- [x] \`npx hardhat test tests/oracle/PythPullParser.test.ts\` — 14 passing (network-independent build sanity)
- [ ] After merge + deploy on next Marcus rotation, verify on-chain via \`eth_call\`:
  - \`balanceOf(<fresh wallet>)\` returns \`0x...00\` instead of reverting
  - \`transfer(<fresh recipient>, 1)\` from a registered wallet succeeds (PR #63 behavior preserved)
  - \`transfer(...)\` from a brand-new wallet that just received tokens via direct SPL deposit succeeds (no prior \`ensure_user\` required)

## Notes

- Existing wrapper deployments (factory-deployed before this change) retain pre-fix bytecode; the fix lands on the next factory redeploy or first \`add_spl_token_no_metadata\` call on a fresh chain. Pairs naturally with the bootstrap script from #68.
- Default profile shows a 79-byte contract-size overage on \`ERC20SPLFactory\` (24655 / 24576). Production profile (viaIR + optimizer) compiles clean — that's what deploys actually use, so non-blocking.
- Supersedes #66 (stacked on PR #52's struct-based branch; this is the bytes32-aligned rewrite onto master).

🤖 _This response was generated by Claude Code._