### PR TITLE
feat(hardhat): add maximus devnet network (chainId 121215)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,6 +63,13 @@ export default defineConfig({
       url: "https://esquiline.devnet.romeprotocol.xyz/",
       accounts: [configVariable("ESQUILINE_PRIVATE_KEY")],
     },
+    maximus: {
+      type: "http",
+      chainType: "l1",
+      chainId: 121215,
+      url: "https://maximus.devnet.romeprotocol.xyz/",
+      accounts: [configVariable("MAXIMUS_PRIVATE_KEY")],
+    },
     local: {
       type: "http",
       chainType: "l1",


### PR DESCRIPTION
## Summary
- Adds the `maximus` Hardhat network entry (chainId `121215`, RPC `https://maximus.devnet.romeprotocol.xyz/`).
- Resolves the deploy key via `configVariable("MAXIMUS_PRIVATE_KEY")` — same pattern as `subura` / `marcus` / `esquiline`.
- No new dependencies, no contract changes.

## Why
We don't have a `maximus` entry yet, so any deploy script invoked with `--network maximus` fails out before we can target the chain.

## Test plan
- [x] `npx hardhat compile` succeeds locally.
- [ ] After merge, a manual deploy run targeting `maximus` lands `deployments/maximus.json`.