### PR TITLE
fix(hardhat): force legacy tx type on maximus (EIP-1559 incompatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed — Maximus devnet deploys: force legacy tx type
+- `hardhat.config.ts` — added `gasPrice: 1_000_000_000` to the `maximus` network entry. Maximus's RPC currently rejects EIP-1559 (type-2) txs with a generic `-32000` error; setting `gasPrice` forces hardhat-viem to build legacy (type-0) txs, which the RPC accepts. Verified via `eth_getBlockByNumber → transactions[0].type` on each Rome devnet: maximus blocks contain only type-0 txs while marcus / subura / esquiline contain type-2, so the override is intentionally narrow to maximus only.
+
 ### Added — Bridged-wrapper bootstrap script
 - `scripts/bridge/bootstrap-bridged-wrappers.ts` — registers the canonical bridged SPL mints (USDC, WETH) on a chain's `ERC20SPLFactory` via `add_spl_token_no_metadata`. The factory's `TokenCreated` event is what the rome-ui backend's token watcher consumes to populate Portfolio / Swap / TokenSelectModal; wrappers deployed by direct `new SPL_ERC20(...)` (legacy bridge redeploy scripts) bypass that event and stay invisible in the UI. Run after `scripts/deploy_erc20spl_factory.ts` on a fresh chain — the script is idempotent (skips mints with a non-zero `token_by_mint`) and writes resulting wrapper addresses into `deployments/<network>.json` under `SPL_ERC20_USDC` / `SPL_ERC20_WETH`. Mint set is auto-selected per network (devnet vs mainnet); override via `BRIDGED_SET=devnet|mainnet` for one-offs.
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,6 +69,11 @@ export default defineConfig({
       chainId: 121215,
       url: "https://maximus.devnet.romeprotocol.xyz/",
       accounts: [configVariable("MAXIMUS_PRIVATE_KEY")],
+      // Maximus's RPC currently rejects EIP-1559 (type-2) txs with a generic
+      // -32000 error. Setting gasPrice forces hardhat-viem to build legacy
+      // (type-0) txs, which the RPC accepts. Other Rome devnets (marcus,
+      // subura, esquiline) accept EIP-1559 and don't need this override.
+      gasPrice: 1_000_000_000,
     },
     local: {
       type: "http",


### PR DESCRIPTION
## Summary

Maximus's RPC rejects EIP-1559 (type-2) transactions with a generic `-32000` error while accepting legacy (type-0) transactions. Adding an explicit `gasPrice` to the maximus network entry tells hardhat-viem to build legacy txs, which the RPC accepts.

## Verified evidence

Probing each Rome devnet for the latest block's first transaction type:

| Network | chainId | `latest_block.transactions[0].type` | EIP-1559 accepted? |
|---|---|---|---|
| **maximus** | 121215 | **0x0** | **❌ no** |
| marcus | 121226 | 0x2 | ✅ yes |
| subura | 121222 | 0x2 | ✅ yes |
| esquiline | 121225 | 0x2 | ✅ yes |

All four return `web3_clientVersion = "proxy-version"` and reject `eth_sendTransaction` with `-32601 Method not found` identically — so it's the same proxy software. The asymmetry is in which tx types are accepted, not which RPC methods are exposed. Maximus's `eth_feeHistory` returns successfully (with placeholder data), which is enough to make viem 2.x auto-build EIP-1559 txs by default.

## Fix

Add `gasPrice: 1_000_000_000` (1 gwei, matches maximus's `eth_gasPrice`) to the maximus network entry. When `gasPrice` is set, hardhat-viem builds legacy (type-0) txs.

The override is intentionally narrow to maximus only — marcus, subura, and esquiline accept EIP-1559 and don't need this.

## Reproduces

Before this PR:

```
$ npx hardhat run scripts/oracle/deploy-v2-polish.ts --network maximus
1/4 Deploying PythPullAdapter implementation...
TransactionExecutionError: Missing or invalid parameters.
  from:  0xc5dd0c5d2bd6814b9f0314cf508c0930a7f03950
  data:  0x6080...
  code: -32000
```

Same error reproduces locally and in the contract-deploys CI workflow ([failed run](https://github.com/rome-protocol/contract-deploys/actions/runs/25028458732)).

## Follow-ups (not in this PR)

- Long-term, Rome's proxy should accept EIP-1559 on all chains (or signal non-support via not implementing `eth_feeHistory`). That's a rome-apps / rome-evm-private fix, not a rome-solidity fix.
- Other source repos that deploy to maximus (rome-uniswap-v2, future Cardo adapters) will need the same `gasPrice` override in their respective hardhat configs when they add maximus.

## Test plan

- [ ] `npx hardhat run scripts/oracle/deploy-v2-polish.ts --network maximus` succeeds locally.
- [ ] Re-dispatch `Oracle Gateway V2 — Deploy` workflow in `rome-protocol/contract-deploys` against `devnet-maximus`, `source_ref: master`. Confirm deploy succeeds and PR back to rome-solidity opens with a populated `deployments/maximus.json`.
- [ ] No regression on marcus / subura / esquiline (no config change for those).