### PR TITLE
feat(hardhat): add cassius network (devnet, chain id 121227)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -70,6 +70,13 @@ export default defineConfig({
       url: "https://maximus.devnet.romeprotocol.xyz/",
       accounts: [configVariable("MAXIMUS_PRIVATE_KEY")],
     },
+    cassius: {
+      type: "http",
+      chainType: "l1",
+      chainId: 121227,
+      url: "https://cassius.devnet.romeprotocol.xyz/",
+      accounts: [configVariable("CASSIUS_PRIVATE_KEY")],
+    },
     local: {
       type: "http",
       chainType: "l1",


### PR DESCRIPTION
## Summary

- Adds the `cassius` network entry to `hardhat.config.ts` (chain id 121227, RPC `https://cassius.devnet.romeprotocol.xyz/`).
- Reads `CASSIUS_PRIVATE_KEY` via `configVariable(...)`, matching the per-network secret naming used by `marcus` / `subura` / `esquiline` / `maximus`.

## Why

Pre-wires the Cassius bring-up rehearsal target so the new `deploy-rome-chain` reviewer-gated workflow in `contract-deploys` can target it. Cassius itself is not yet registered on-chain or in `rome-protocol/registry` — both land alongside Cassius going live (Chapter 11 of the bring-up plan).

Spec: `rome-specs/active/technical/2026-04-28-rome-chain-bring-up-runbook-plan.md`, Chapter 5.

## Test plan

- [ ] `npx hardhat compile` passes on this branch.
- [ ] `npx hardhat run scripts/setup-local.ts --network local` still works (no regression to other networks).
- [ ] Cassius rehearsal will exercise the deploy path end-to-end once the chain is live.