### PR TITLE
refactor(erc20spl): use UserPda helper for two-hop AUTHORITY_PDA → ATA derivation

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -7,6 +7,7 @@ import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {AssociatedSplToken} from "../spl_token/associated_spl_token.sol";
 import {ISystemProgram, ICrossProgramInvocation, CpiProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
+import {UserPda} from "../cpi/UserPda.sol";
 import {Convert} from "../convert.sol";
 
 contract ERC20Users {
@@ -153,13 +154,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // populated only after a wrapper-mediated `ensure_token_account`
         // call) would mismatch and report 0 for any user whose tokens
         // arrived via a non-wrapper path.
-        bytes32 authority_pda = RomeEVMAccount.pda(account);
-        bytes32 ata = AssociatedSplToken.get_associated_token_address_with_program_id(
-            authority_pda,
-            mint_id,
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            associated_token_program_id
-        );
+        bytes32 ata = UserPda.ata(account, mint_id);
         return uint256(SplTokenLib.load_token_amount(ata, cpi_program));
     }
 
@@ -324,24 +319,14 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         bytes32 authority_pda = RomeEVMAccount.pda(msg.sender);
         bytes32 payer_pda = _users.get_user(msg.sender);
 
-        bytes32 from_ata = AssociatedSplToken.get_associated_token_address_with_program_id(
-            authority_pda,
-            mint_id,
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            associated_token_program_id
-        );
+        bytes32 from_ata = UserPda.ataForKey(authority_pda, mint_id);
 
         // Recipient ATA — derive only. Caller must pre-create on Solana
         // if it doesn't exist. Adding the in-tx ATA-create CPI failed
         // on rome-evm's CPI emulator (the two-CPI sequence reverts at
         // sim time even though the contract logic is correct). Single
         // CPI (transfer only) works reliably on chain.
-        bytes32 to_ata = AssociatedSplToken.get_associated_token_address_with_program_id(
-            solana_recipient,
-            mint_id,
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            associated_token_program_id
-        );
+        bytes32 to_ata = UserPda.ataForKey(solana_recipient, mint_id);
         // Suppress unused-var warning. payer_pda is read for potential
         // future ATA-create reintroduction once the emulator quirk is
         // fixed.


### PR DESCRIPTION
## Summary

Replace three inlined sites of the `EVM addr → AUTHORITY_PDA → ATA-of-PDA` derivation pattern in `SPL_ERC20` with calls to the existing `UserPda` library helpers. Behavior unchanged.

| Site | Before | After |
|---|---|---|
| `balanceOf` | `RomeEVMAccount.pda(account)` + `AssociatedSplToken.get_associated_token_address_with_program_id(...)` | `UserPda.ata(account, mint_id)` |
| `bridgeOutToSolana` from_ata | inlined ATA derive over `authority_pda` | `UserPda.ataForKey(authority_pda, mint_id)` |
| `bridgeOutToSolana` to_ata | inlined ATA derive over `solana_recipient` | `UserPda.ataForKey(solana_recipient, mint_id)` |

## Bytecode impact

Captured prefix (commit `cd6654d`) and postfix (this commit) `deployedBytecode` for SPL_ERC20, RomeBridgeWithdraw, DAMMv1Pool. Code-region SHA256 (excluding trailing CBOR metadata):

| Contract | Prefix | Postfix | Verdict |
|---|---|---|---|
| SPL_ERC20 | `e9bc60c0…` | `6e6ce436…` | 87 bytes smaller (optimizer dedup) |
| RomeBridgeWithdraw | `89532390…` | `89532390…` | Code identical (metadata-only diff) |
| DAMMv1Pool | `99addafb…` | `99addafb…` | Code identical (metadata-only diff) |

The 87-byte SPL_ERC20 reduction comes from collapsing the three two-hop sites into single helper invocations. The other two contracts weren't touched at the source level; their metadata hash differs only because the build context picked up the new `import {UserPda}` line.

## Constants verified equivalent

- `SplTokenLib.SPL_TOKEN_PROGRAM` (`0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9`) ≡ `SolanaConstants.SPL_TOKEN_PROGRAM`
- `erc20spl.associated_token_program_id` (`0x8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859`) ≡ `SolanaConstants.ASSOCIATED_TOKEN_PROGRAM`

`UserPda.ata` and `UserPda.ataForKey` use `SolanaConstants` internally. Same Tokenkeg + ATokenG bytes, different module path.

## Test plan

- [x] `npx hardhat test tests/cpi/*.test.ts tests/oracle/*.test.ts` — 144 passing, 0 failing
- [x] `npx hardhat test tests/cpi/UserPda.test.ts` — 3 passing (tx.origin guard + signature checks + live-stack-skip)
- [x] Bytecode prefix/postfix diff localized to refactored contract
- [ ] Marcus integration smoke (optional — bytecode change is small + already covered by unit tests)

## Closes audit finding

> "Two-hop pattern (EVM → Owner PDA → ATA-of-PDA) inlined 3x — refactor candidate" 🟠

The helper (`UserPda`) was already shipped; this PR just adopts it at the inlined sites in `SPL_ERC20`.