### PR TITLE
fix(erc20spl): emit IERC20 Transfer/Approval on standard mutating functions

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -212,6 +212,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         );
 
         require (success, string(Convert.revert_msg(result)));
+        emit Transfer(from, to, value);
         return true;
     }
 
@@ -250,6 +251,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         );
 
         require (success, string(Convert.revert_msg(result)));
+        emit Approval(msg.sender, spender, value);
         return true;
     }
 
@@ -473,6 +475,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         );
 
         require (success, string(Convert.revert_msg(result)));
+        emit Transfer(address(0), to, value);
         return true;
     }
 }

--- a/deployments/marcus.json
+++ b/deployments/marcus.json
@@ -97,5 +97,9 @@
   "RomeBridgeInbound": {
     "address": "0x01d5cCfb9349F051A2a78bA75285168cbA0D206a",
     "deployedAt": 1777090061
+  },
+  "ERC20SPLFactory": {
+    "address": "0x9e595a6ee33525ceefdec545567260946f2009fb",
+    "cpiContractAddress": "0xFF00000000000000000000000000000000000008"
   }
 }


### PR DESCRIPTION
## Summary

`SPL_ERC20` inherits `IERC20 + IERC20Metadata` but `_transfer`, `approve`, and `mint_to` never emitted the events those interfaces require. Downstream consumers were silently blind:

- `rome-via-enrich/holders.rs` filters by `topic0 = 0xddf252ad…` and registered zero rows for any wrapper despite real SPL transfers.
- `eth_getLogs` against any wrapper returned empty for all topics in all blocks.
- wagmi `useContractEvent('Transfer')` subscribers in rome-ui never fire.

This PR adds the three missing emits, each placed after the SPL CPI's `require(success, …)` so the event reflects committed state.

```solidity
// _transfer  (line 215)
emit Transfer(from, to, value);

// approve    (line 254)
emit Approval(msg.sender, spender, value);

// mint_to    (line 478)
emit Transfer(address(0), to, value);
```

## Bytecode-level proof on Marcus (chain_id 121226)

Verified by `eth_getCode` + topic-hash search across each wrapper's deployed bytecode. The IERC20 event signatures must be embedded as immediate constants for any LOG3 to fire them.

| Wrapper | Bytecode | Transfer topic | Approval topic |
|---|---|---|---|
| Old (pre-fix) `0x6ed2944b…` | 16356 B | **0 occurrences** | **0 occurrences** |
| New (post-fix) `0x69D7791a…` | 11815 B | **2 occurrences** | **1 occurrence** |

Zero occurrences in the old bytecode is direct proof that no compiled `LOG` opcode anywhere in its execution path can fire an IERC20 event. The two `Transfer` and one `Approval` occurrences in the new wrapper correspond exactly to the three new emit sites. The smaller post-fix size comes from the Wave 1 UserPda refactor (#82).

## Marcus deployments captured this session

- New `ERC20SPLFactory`: [`0x9e595a6e…`](https://marcus.devnet.romeprotocol.xyz) (also added to `deployments/marcus.json`)
- New WUSDC wrapper (existing mint): `0x7B4b0bE7…`
- Fresh test mint + wrapper: `0x69D7791a…` (used for bytecode evidence)

## Migration impact

Existing Marcus WUSDC (`0x6ed2944b…`) and WETH (`0x3e52cfb3…`) are immutable and stay event-less. The fix takes effect for:
- Future chain deployments (new factory pre-emit-fix is gone)
- Any wrapper redeploy from the new `ERC20SPLFactory` at `0x9e595a6e…`

Pre-production Marcus context per project policy: dev tokens may be replaced; no user-balance migration needed. Updating `deployments/marcus.json` to point at the new factory is sufficient for downstream config consumers.

## Test plan

- [x] `npx hardhat test tests/cpi/*.test.ts tests/oracle/*.test.ts` — 144 passing
- [x] Marcus bytecode verification (above)
- [x] New factory + new wrapper deployed on Marcus, addresses captured
- [ ] Live `mint_to` / `transfer` Marcus capture — deferred. Preflight returns "Cannot revert cross-program invocation" which per `feedback_program_proxy_hercules_lockstep` is a proxy/hercules ↔ Rome program version drift signal, independent of this PR. Bytecode evidence is decisive.

## Closes audit finding

> 🔴 SPL_ERC20 wrapper emits no IERC20 events — breaks indexers / event-driven UIs