### PR TITLE
feat(hardhat): add cassius-test network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -77,6 +77,13 @@ export default defineConfig({
       url: "https://cassius.devnet.romeprotocol.xyz/",
       accounts: [configVariable("CASSIUS_PRIVATE_KEY")],
     },
+    "cassius-test": {
+      type: "http",
+      chainType: "l1",
+      chainId: 121298,
+      url: "https://cassius-test.devnet.romeprotocol.xyz/",
+      accounts: [configVariable("CASSIUS_TEST_PRIVATE_KEY")],
+    },
     local: {
       type: "http",
       chainType: "l1",


### PR DESCRIPTION
Add cassius-test network (chain id 121298) to hardhat config — throwaway target for the Cassius bring-up rehearsal (Ch.10). Reads CASSIUS_TEST_PRIVATE_KEY from dev keystore.