### PR TITLE
fix(erc20spl): emit TokenCreated in _register_contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed — `ERC20SPLFactory.TokenCreated` event was declared but never emitted
+- `contracts/erc20spl/erc20spl_factory.sol` — `_register_contract` (called from both `add_spl_token_with_metadata` and `add_spl_token_no_metadata`) now emits `TokenCreated(creator, mint, wrapper, name, symbol, nonce)` after writing the `token_by_mint` / `mint_by_symbol_hash` / `token_by_symbol_hash` mappings. Previously the event was declared on lines 26-33 but had zero `emit` sites — so the rome-ui backend's token-discovery indexer (which watches `TokenCreated` per the cross-repo deps note in `CLAUDE.md`) never populated wrappers deployed via this factory. The bootstrap-bridged-wrappers script added in a prior session was relying on an event the factory wasn't emitting; this fix completes that loop. `nonce` carries the creator's current `creator_nonce[msg.sender]` at registration time.
+- Surfaced during the cassius-test (121298) bring-up rehearsal — `rome-specs/active/technical/2026-04-28-rome-chain-bring-up-runbook-plan.md` Chapter 10.4 lessons.
+
 ### Added — Generic Marcus → Solana SPL outbound (`SPL_ERC20.bridgeOutToSolana` + `ensureRecipientAta`)
 - `contracts/erc20spl/erc20spl.sol` — new `bridgeOutToSolana(bytes32 recipient, uint256 value) → bool`: single CPI `transfer_checked` from `getATA(AUTHORITY_PDA, mint)` → recipient ATA, signed as `AUTHORITY_PDA = find_program_address([EXTERNAL_AUTHORITY, evmAddr])` with empty seeds. Generic outbound for any wrapper deployed by the factory — one method covers WUSDC/WETH/WSOL today and every future Solana-native SPL. Emits `BridgedOutToSolana`.
 - `contracts/erc20spl/erc20spl.sol` — new `ensureRecipientAta(bytes32 recipient) → bytes32`: idempotent single-CPI ATA-create on Solana, paid by sender's pre-funded PAYER PDA. Companion to `bridgeOutToSolana`; the single-tx two-CPI variant fails rome-evm's `eth_call` simulation, so the flow is split. Emits `RecipientAtaEnsured`.

--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -53,6 +53,8 @@ contract ERC20SPLFactory {
         token_by_mint[mint] = address(new_contract);
         mint_by_symbol_hash[symbolHash] = mint;
         token_by_symbol_hash[symbolHash] = address(new_contract);
+
+        emit TokenCreated(msg.sender, mint, address(new_contract), name, symbol, creator_nonce[msg.sender]);
         return address(new_contract);
     }
 


### PR DESCRIPTION
## Summary
Adds the `emit TokenCreated(...)` statement that should always have been in `_register_contract` but never was. The event has been declared on the factory since first version; both `add_spl_token_with_metadata` and `add_spl_token_no_metadata` go through `_register_contract` to produce the wrapper, so this single emit covers both flows.

## Why
rome-ui's backend token-discovery indexer subscribes to `TokenCreated` (per the cross-repo deps note in `CLAUDE.md`'s "Cross-repo dependencies — rome-ui" section). Without the emit, every wrapper deployed via the factory was invisible to the indexer — `useChainTokenBalances` wouldn't see them, `/api/tokens` wouldn't list them, the Portfolio / TokenSelectModal wouldn't render them.

A prior PR added `scripts/bridge/bootstrap-bridged-wrappers.ts` whose docstring explicitly references the `TokenCreated` watcher as the indexer pathway — that script has been a no-op from the indexer's perspective, again because the factory wasn't emitting. This PR completes that loop.

Surfaced during the cassius-test (121298) bring-up rehearsal — `rome-specs/active/technical/2026-04-28-rome-chain-bring-up-runbook-plan.md` Chapter 10.4 lessons.

## Files
- `contracts/erc20spl/erc20spl_factory.sol` — adds `emit TokenCreated(msg.sender, mint, address(new_contract), name, symbol, creator_nonce[msg.sender]);` after the registration mappings are written. `creator_nonce` is the existing per-creator counter (already incremented by `create_token_mint` for user-created mints; for wrapper-only registration it stays at whatever the prior value was — semantics unchanged).
- `CHANGELOG.md` — `### Fixed` entry under `## Unreleased`.

## Validation
- [x] `npx hardhat compile` — clean
- [x] `npx hardhat test tests/oracle/PythPullParser.test.ts tests/oracle/SwitchboardParser.test.ts` — 22/22 oracle parser tests pass (these are the CI-gated unit tests per `CLAUDE.md`; integration tests run only against `local`/`monti_spl`)
- [ ] Integration test on `local` — not exercised in this PR; the existing `tests/erc20spl_factory.integration.ts` exercises `add_spl_token_no_metadata` and can be extended in a follow-up to assert the event fires (out of scope here per "minimal change" — pure bug fix, no new behavior beyond the missing emit)

## Note for reviewers
- ABI is unchanged (event already declared, no signature change). Indexer subscriptions on existing deployments continue to receive nothing until the factory is **redeployed** with this fix; existing on-chain wrappers won't retroactively emit. That's a redeploy-coordinated change, not a backfill.
- Could add an integration test that calls `add_spl_token_no_metadata` and asserts `TokenCreated` is in the receipt's `logs[]`. Held back to keep the PR scope minimal; happy to add if reviewers prefer.