### PR TITLE
chore(hardhat): drop maximus network (chain decommissioned)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,13 +63,6 @@ export default defineConfig({
       url: "https://esquiline.devnet.romeprotocol.xyz/",
       accounts: [configVariable("ESQUILINE_PRIVATE_KEY")],
     },
-    maximus: {
-      type: "http",
-      chainType: "l1",
-      chainId: 121215,
-      url: "https://maximus.devnet.romeprotocol.xyz/",
-      accounts: [configVariable("MAXIMUS_PRIVATE_KEY")],
-    },
     cassius: {
       type: "http",
       chainType: "l1",


### PR DESCRIPTION
Maximus (chain 121215, devnet, dedicated Meta-Hook E2E proving ground) was decommissioned 2026-05-01 — registry flipped to `retired`, infrastructure torn down, rome-evm program closed. The hardhat network entry is unreachable now (DNS NXDOMAIN on `https://maximus.devnet.romeprotocol.xyz/`); removing it prevents accidental `--network maximus` usage.

The `MAXIMUS_PRIVATE_KEY` configVariable is no longer read; can be deleted from any keystore on next rotation.

Companion to: rome-protocol/registry#14 (status: retired).