### PR TITLE
chore(marcus): reconcile deployments/marcus.json against registry v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed — `deployments/marcus.json` reconciled against the canonical registry (rome-protocol/registry@v0.4.9)
+- `deployments/marcus.json` — bulk address refresh to match the now-corrected registry entries for chain 121226-marcus. The file had drifted to track an earlier deploy that was superseded on 2026-04-21 (oracle stack) and again on 2026-04-29 (`SPL_ERC20` wrappers + `ERC20SPLFactory`). The local artefact and the registry are now identical for every live address. Cross-link: `rome-protocol/registry#21`.
+- `OracleGatewayV2.OracleAdapterFactory`: `0x98d2a1eeafd4595b9df1ad791625d0fb16b081b5` → `0x454f0cde265ecf530a01c5c1bfd1f40d9e0672af`. The previous factory was deployed with `defaultMaxStaleness = 300` which caused USDC and USDT Pyth feeds to revert when their on-chain publish lag exceeded five minutes; the live factory uses `defaultMaxStaleness = 86400` and re-clones every adapter via EIP-1167.
+- `OracleGatewayV2.PythPullAdapterImpl`: `0x79380864f61fa5c08bfc98b93d5a55bd71afad35` → `0x23f27d84c5fd53a32baaa52270a22f7b13f241da`.
+- `OracleGatewayV2.SwitchboardV3AdapterImpl`: `0xb766b12d163a16ad1f7c1f1bb913e398029e0787` → `0x827a045a8fd1973859ac57df8e801e658e9ed78b`.
+- `OracleGatewayV2.BatchReader`: `0x8bc2d008c8fb61daec1ce81276c01f1f234572f3` → `0x0796e4cfdba2acb9aab32abd1722e7845c87acf1`.
+- `OracleGatewayV2.defaultMaxStaleness`: `300` → `86400` (matches the live factory).
+- `OracleGatewayV2.feeds.pyth[*]` — all 5 adapter clones (SOL/USD, BTC/USD, ETH/USD, USDC/USD, USDT/USD) refreshed to the addresses produced by the new factory; underlying Solana pubkeys unchanged.
+- `OracleGatewayV2.feeds.switchboard[0]` (SOL/USD) — adapter refreshed.
+- `OracleGatewayV2.feedsVerified[*]` — adapter addresses refreshed to match the new clones for SOL/BTC/ETH so the verified set stays internally consistent.
+- `SPL_ERC20_USDC`: `0x6ed2944bba4cb5b1cb295541f315c648658dd67c` → `0x7B4b0bE747AbD982b0E4de5E4a4479FfaC18a81c` (v2, via `ERC20SPLFactory@v2`).
+- `SPL_ERC20_WETH`: `0x3e52cfb38ca1639f3c95aef6dccff2b36c230f22` → `0x613b22c098b1058d91731dcb15beaa781b45783e` (v2, with `ensureRecipientAta`).
+- `SPL_ERC20_WSOL` (new): `0x1b23b52d9c991d580ae6df1b936aff09a5f794a2`, mint `So11111111111111111111111111111111111111112`. Previously absent from the file; canonical wSOL wrapper.
+- `RomeBridgeWithdraw`: `0x513f76e39cfd7008f1e143ae37148608cddfcaaf` → `0x325d62dc31be2b2a6e19e6e5773586e552f7c938` (matches registry `live` entry).
+- `ERC20Users`: `0x803f6923bcc776db1d0aa6fcdbd8ceddf35ad6f3` → `0x6a71c3dccc356abe3ffe37e07ed2afb5b3831ce5`.
+- `archive` block extended with the previous addresses for `RomeBridgeWithdraw`, `ERC20Users`, `SPL_ERC20_USDC` (v1), `SPL_ERC20_WETH` (v1), and `OracleAdapterFactory` (300s-staleness deploy) so the file retains provenance for the superseded deploys. Mirrors the existing `RomeBridgeWithdrawPrevious` / `RomeBridgeInboundPrevious` convention; no schema changes.
+
 ### Changed — `scripts/bridge/deploy.ts` parameterized per-chain via `USDC_MINT` / `WETH_MINT` env vars; `r` symbols swapped to `W`
 - `scripts/bridge/deploy.ts` — `loadSolanaPdas` and `main()` no longer read `SPL_MINTS.USDC_NATIVE` / `SPL_MINTS.WETH_WORMHOLE` (Marcus's mints) regardless of target. Both now require explicit `USDC_MINT` / `WETH_MINT` env vars at invocation; the script skips the corresponding `SPL_ERC20` wrapper if a mint is unset. `RomeBridgeWithdraw` deploys only when **both** mints are set, since its constructor takes both wrappers and the per-mint Wormhole / CCTP PDAs cannot be derived without them — chains with no Ethereum-origin bridge target therefore get paymaster + ERC20Users + (optional) wrappers, with no broken withdraw artefact written. Surfaced during the cassius-test (121298) bring-up rehearsal — `rome-specs/active/technical/2026-04-28-rome-chain-bring-up-runbook-plan.md` Chapter 10.4 — where the previous default deployed Marcus's mints onto cassius-test as throwaway wrappers.
 - `scripts/bridge/deploy.ts` — `deployWithdraw(...)` signature gained two trailing string params (`usdcMintBase58`, `wethMintBase58`) so PDAs are derived from the actual deploy-time mints rather than a global. The single in-tree caller (`scripts/setup-local.ts`) updated.

--- a/deployments/marcus.json
+++ b/deployments/marcus.json
@@ -4,65 +4,98 @@
     "deployedAt": 1776718058
   },
   "ERC20Users": {
-    "address": "0x803f6923bcc776db1d0aa6fcdbd8ceddf35ad6f3"
+    "address": "0x6a71c3dccc356abe3ffe37e07ed2afb5b3831ce5"
   },
   "SPL_ERC20_USDC": {
-    "address": "0x6ed2944bba4cb5b1cb295541f315c648658dd67c",
-    "mintId": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    "address": "0x7B4b0bE747AbD982b0E4de5E4a4479FfaC18a81c",
+    "mintId": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    "version": "2.0.0",
+    "deployedAt": "2026-04-29T00:00:00Z"
   },
   "SPL_ERC20_WETH": {
-    "address": "0x3e52cfb38ca1639f3c95aef6dccff2b36c230f22",
-    "mintId": "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs"
+    "address": "0x613b22c098b1058d91731dcb15beaa781b45783e",
+    "mintId": "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs",
+    "version": "2.0.0",
+    "deployedAt": "2026-04-29T00:00:00Z"
+  },
+  "SPL_ERC20_WSOL": {
+    "address": "0x1b23b52d9c991d580ae6df1b936aff09a5f794a2",
+    "mintId": "So11111111111111111111111111111111111111112",
+    "version": "1.0.0",
+    "deployedAt": "2026-04-29T00:00:00Z"
   },
   "RomeBridgeWithdraw": {
-    "address": "0x513f76e39cfd7008f1e143ae37148608cddfcaaf",
-    "deployedAt": 1776768105
+    "address": "0x325d62dc31be2b2a6e19e6e5773586e552f7c938",
+    "deployedAt": 1777593600
   },
   "archive": {
-    "RomeBridgeWithdrawPrevious": null,
+    "RomeBridgeWithdrawPrevious": {
+      "address": "0x513f76e39cfd7008f1e143ae37148608cddfcaaf",
+      "archivedAt": 1777593600
+    },
     "RomeBridgeInboundPrevious": {
       "address": "0x3972795F001d3c3e562009b3f5B5581e305152d2",
       "archivedAt": 1777090061
+    },
+    "ERC20UsersPrevious": {
+      "address": "0x803f6923bcc776db1d0aa6fcdbd8ceddf35ad6f3",
+      "archivedAt": 1777593600
+    },
+    "SPL_ERC20_USDC_v1": {
+      "address": "0x6ed2944bba4cb5b1cb295541f315c648658dd67c",
+      "archivedAt": 1777593600,
+      "replacedBy": "0x7B4b0bE747AbD982b0E4de5E4a4479FfaC18a81c"
+    },
+    "SPL_ERC20_WETH_v1": {
+      "address": "0x3e52cfb38ca1639f3c95aef6dccff2b36c230f22",
+      "archivedAt": 1777593600,
+      "replacedBy": "0x613b22c098b1058d91731dcb15beaa781b45783e"
+    },
+    "OracleAdapterFactoryPrevious": {
+      "address": "0x98d2a1eeafd4595b9df1ad791625d0fb16b081b5",
+      "archivedAt": 1777593600,
+      "replacedBy": "0x454f0cde265ecf530a01c5c1bfd1f40d9e0672af",
+      "reason": "300s staleness floor caused USDC/USDT feed reverts; replaced by 86400s factory"
     }
   },
   "OracleGatewayV2": {
-    "deployedAt": "2026-04-21T19:15:31.160Z",
-    "defaultMaxStaleness": 300,
+    "deployedAt": "2026-04-21T04:50:23Z",
+    "defaultMaxStaleness": 86400,
     "pythReceiverProgramId": "0x0cb7fabb52f7a648bb5b317d9a018b9057cb024774fafe01e6c4df98cc385881",
     "switchboardProgramId": "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90",
-    "PythPullAdapterImpl": "0x79380864f61fa5c08bfc98b93d5a55bd71afad35",
-    "SwitchboardV3AdapterImpl": "0xb766b12d163a16ad1f7c1f1bb913e398029e0787",
-    "OracleAdapterFactory": "0x98d2a1eeafd4595b9df1ad791625d0fb16b081b5",
-    "BatchReader": "0x8bc2d008c8fb61daec1ce81276c01f1f234572f3",
+    "PythPullAdapterImpl": "0x23f27d84c5fd53a32baaa52270a22f7b13f241da",
+    "SwitchboardV3AdapterImpl": "0x827a045a8fd1973859ac57df8e801e658e9ed78b",
+    "OracleAdapterFactory": "0x454f0cde265ecf530a01c5c1bfd1f40d9e0672af",
+    "BatchReader": "0x0796e4cfdba2acb9aab32abd1722e7845c87acf1",
     "feeds": {
       "pyth": [
         {
           "pair": "SOL/USD",
-          "adapter": "0x3Fc712e48F938a0f6C4C3689F953a280Af220fe1",
+          "adapter": "0xa9158A5B3964910656416a16C0De161143a89592",
           "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
           "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
         },
         {
           "pair": "BTC/USD",
-          "adapter": "0x748617Dc27e13F5e13D2829DEB7Ac53CE039e171",
+          "adapter": "0x3dB406f5e7e55a6d875452BbeA0C35F96e172C49",
           "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
           "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
         },
         {
           "pair": "ETH/USD",
-          "adapter": "0x501239dCe69BD362596dB2501dE530256A4D781E",
+          "adapter": "0xd61796eFF9e6D044C182aDa82049DC2930B58962",
           "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
           "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
         },
         {
           "pair": "USDC/USD",
-          "adapter": "0xe32EfcB28b3190B28Bf30aF0e8355806c4ec549e",
+          "adapter": "0xEFc29b15069835b844d35505832636890FBEF6b3",
           "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
           "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
         },
         {
           "pair": "USDT/USD",
-          "adapter": "0x3Df0fCde4033A1b006BD3c90b98428349DB0cD53",
+          "adapter": "0xd66f47f8E4CE5DEB509e1a665dD30AA0CD117e0E",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
         }
@@ -70,7 +103,7 @@
       "switchboard": [
         {
           "pair": "SOL/USD",
-          "adapter": "0xaF320D94e18046D0E8E043D80c38b9c418f0Ecac",
+          "adapter": "0xa79fd13A0fBB3D395Bf84a02ba30227dB7311000",
           "pubkey": "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
           "pubkeyBytes32": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a"
         }
@@ -80,17 +113,17 @@
       {
         "pair": "SOL / USD",
         "pythAccountBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243",
-        "adapter": "0x3Fc712e48F938a0f6C4C3689F953a280Af220fe1"
+        "adapter": "0xa9158A5B3964910656416a16C0De161143a89592"
       },
       {
         "pair": "BTC / USD",
         "pythAccountBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de",
-        "adapter": "0x748617Dc27e13F5e13D2829DEB7Ac53CE039e171"
+        "adapter": "0x3dB406f5e7e55a6d875452BbeA0C35F96e172C49"
       },
       {
         "pair": "ETH / USD",
         "pythAccountBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb",
-        "adapter": "0x501239dCe69BD362596dB2501dE530256A4D781E"
+        "adapter": "0xd61796eFF9e6D044C182aDa82049DC2930B58962"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Bring `deployments/marcus.json` back into alignment with the canonical registry entries for chain 121226-marcus. The local artefact had drifted to track an earlier deploy (oracle stack 2026-04-21, SPL wrappers + factory 2026-04-29) that was superseded.

The drift was flagged as anomaly #2 in the registry reconcile and fixed there in `rome-protocol/registry#21` (merged, tagged `v0.4.9`). This PR mirrors that update on the rome-solidity side.

### Why

The previous `OracleAdapterFactory` at `0x98d2a1ee…` was deployed with `defaultMaxStaleness = 300`. USDC and USDT Pyth feeds revert against that factory whenever their on-chain publish lag exceeds five minutes, which happens routinely for stablecoin feeds. The replacement factory at `0x454f0cde…` re-clones every adapter with `defaultMaxStaleness = 86400`; the on-chain artefact has been the live target since 2026-04-21 but the rome-solidity local file kept pointing at the broken deploy.

### Per-field changes

| Field | Old | New | Source |
|---|---|---|---|
| `OracleGatewayV2.OracleAdapterFactory` | `0x98d2a1ee…` (300s) | `0x454f0cde…` (86400s) | `chains/121226-marcus/oracle.json` (`factory`) |
| `OracleGatewayV2.defaultMaxStaleness` | `300` | `86400` | `chains/121226-marcus/oracle.json` |
| `OracleGatewayV2.PythPullAdapterImpl` | `0x79380864…` | `0x23f27d84…` | `chains/121226-marcus/contracts.json` (`PythPullAdapterImpl`, live) |
| `OracleGatewayV2.SwitchboardV3AdapterImpl` | `0xb766b12d…` | `0x827a045a…` | `chains/121226-marcus/contracts.json` (`SwitchboardV3Adapter`, live) |
| `OracleGatewayV2.BatchReader` | `0x8bc2d008…` | `0x0796e4cf…` | `chains/121226-marcus/contracts.json` (`BatchReader`, live) |
| `OracleGatewayV2.feeds.pyth[*]` | 5 stale clones | refreshed | `chains/121226-marcus/oracle.json` (`feeds.*-pyth.address`) |
| `OracleGatewayV2.feeds.switchboard[0]` | `0xaF320D94…` | `0xa79fd13A…` | `chains/121226-marcus/oracle.json` (`feeds.SOL/USD-switchboard.address`) |
| `SPL_ERC20_USDC.address` | `0x6ed2944b…` (v1) | `0x7B4b0bE7…` (v2) | `chains/121226-marcus/contracts.json` (`SPL_ERC20_USDC` v2, live) |
| `SPL_ERC20_WETH.address` | `0x3e52cfb3…` (v1) | `0x613b22c0…` (v2) | `chains/121226-marcus/contracts.json` (`SPL_ERC20_WETH` v2, live) |
| `SPL_ERC20_WSOL` | (absent) | `0x1b23b52d…` | `chains/121226-marcus/contracts.json` (`SPL_ERC20_WSOL`, live) |
| `RomeBridgeWithdraw.address` | `0x513f76e3…` | `0x325d62dc…` | `chains/121226-marcus/contracts.json` (`RomeBridgeWithdraw`, live) |
| `ERC20Users.address` | `0x803f6923…` | `0x6a71c3dc…` | `chains/121226-marcus/contracts.json` (`ERC20Users`, live) |

`OracleGatewayV2.feedsVerified[*]` adapter addresses also refreshed for SOL/BTC/ETH so the verified set stays internally consistent with the new clones.

### Schema preservation

No schema changes. The existing `archive` block (which already carried `RomeBridgeInboundPrevious`) was extended with the superseded addresses (`RomeBridgeWithdrawPrevious`, `ERC20UsersPrevious`, `SPL_ERC20_USDC_v1`, `SPL_ERC20_WETH_v1`, `OracleAdapterFactoryPrevious`) so the file retains provenance for the prior deploys.

`ERC20SPLFactory` (`0x9e595a6e…`) and `RomeBridgePaymaster` (`0xcaf1fbcf…`) and `RomeBridgeInbound` (`0x01d5cCfb…`) were already current.

### Test plan

- [x] JSON parses cleanly (`python3 -m json.tool deployments/marcus.json`)
- [x] Every live address matches the corresponding `status: live` entry in `rome-protocol/registry@v0.4.9/chains/121226-marcus/{contracts,oracle}.json`
- [ ] Downstream rome-ui's `chains.yaml` already consumes the registry, not this file, so no rome-ui change is required
- [ ] After merge, smoke `scripts/oracle/test-feeds-v2.ts --network marcus` to confirm USDC/USDT Pyth feeds no longer revert

Cross-link: rome-protocol/registry#21