### PR TITLE
feat(hardhat): add marcus (chain 121301) network entry

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -42,5 +42,12 @@ export default defineConfig({
       url: "http://localhost:9090",
       accounts: [configVariable("LOCAL_PRIVATE_KEY")],
     },
+    marcus: {
+      type: "http",
+      chainType: "l1",
+      chainId: 121301,
+      url: "https://marcus.devnet.romeprotocol.xyz/",
+      accounts: [configVariable("MARCUS_PRIVATE_KEY")],
+    },
   },
 });


### PR DESCRIPTION
Per /bring-up-chain Row 6 — adds the per-chain Hardhat network for marcus.

- chainId: 121301
- url: https://marcus.devnet.romeprotocol.xyz/
- accounts: configVariable("MARCUS_PRIVATE_KEY")

Operator sets the keystore var before running deploy scripts.