### PR TITLE
fix(erc20spl): getAta returns canonical AUTHORITY_PDA-derived ATA (matches balanceOf, fixes outbound bridge)

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -48,10 +48,26 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     ERC20Users private _users;
     mapping(address => bytes32) private _accounts;
 
-    /// @notice Public reader for the SPL token account owned by this EVM user.
-    /// @dev Returns the cached ATA; callers may treat a zero return as "not yet initialized".
+    /// @notice Canonical SPL token account address for `user` against this
+    /// wrapper's mint.
+    /// @dev Pure derivation. Returns
+    /// `ata(AUTHORITY_PDA(user), mint_id, splTokenProgram)` — same ATA
+    /// `balanceOf` reads (line below at 158) and same destination
+    /// `wrap_gas_to_spl` deposits to and Wormhole `complete_transfer_wrapped`
+    /// lands at. Always non-zero, no per-user activation required.
+    ///
+    /// Pre-#82 this returned `_accounts[user]` (a PAYER_PDA-owned ATA cached
+    /// on first wrapper-mediated call). After #82 migrated `balanceOf` to
+    /// the AUTHORITY_PDA-derived ATA, this reader stayed on the legacy
+    /// mapping — internally inconsistent: `balanceOf(user)` could return a
+    /// non-zero amount while `getAta(user)` returned `bytes32(0)` for any
+    /// user whose tokens arrived via wrap / inbound bridge (which never
+    /// write to `_accounts`). RomeBridgeWithdraw consumed this reader for
+    /// the CCTP / Wormhole burn account; the inconsistency surfaced as
+    /// `mollusk error: Failure(Custom(3007))` from CCTP's depositForBurn
+    /// when fed an empty-or-zero burnTokenAccount.
     function getAta(address user) external view returns (bytes32) {
-        return _accounts[user];
+        return UserPda.ata(user, mint_id);
     }
 
     error ERC20InvalidApprover(address approver);


### PR DESCRIPTION
## Why

Pre-#82, the wrapper was internally consistent: \`balanceOf\` and \`getAta\` both read \`_accounts[user]\` — a PAYER_PDA-owned ATA cached on first wrapper-mediated call. PR #82 migrated \`balanceOf\` to the AUTHORITY_PDA-derived ATA (the same location \`wrap_gas_to_spl\` deposits to and Wormhole \`complete_transfer_wrapped\` lands at) — but left \`getAta\` reading the legacy \`_accounts\` mapping. The wrapper has been internally inconsistent ever since.

For any user whose tokens arrived via wrap or inbound bridge (neither writes to \`_accounts\`):

\`\`\`
balanceOf(user) → 5_000_000        // AUTHORITY_PDA ATA, real balance
getAta(user)    → bytes32(0)       // legacy mapping, never populated
\`\`\`

\`RomeBridgeWithdraw.{burnUSDC, burnETH, approveBurnETH}\` consumes \`wrapper.getAta(user)\` for the CCTP / Wormhole burn account. The inconsistency surfaces as \`mollusk error: Failure(Custom(3007))\` from CCTP's \`depositForBurn\` when fed an empty-or-zero \`burnTokenAccount\`.

### Verified end-to-end on Marcus 121301

Account \`0x3403e0De09Bc76Ca7d74762F264e4F6B649A0562\`:
- \`WUSDC.balanceOf\` returned \`5_000_000\` (5 WUSDC, at AUTHORITY_PDA's ATA \`6uVarAi…\`, deposited via \`wrap_gas_to_spl\`)
- \`WUSDC.getAta\` returned \`bytes32(0)\` (legacy \`_accounts\` never populated for this user)
- Marcus → Sepolia bridge: \`burnUSDC\` reverted with \`mollusk error: Failure(Custom(3007))\`

## Fix

\`getAta\` derives via the existing \`UserPda.ata(user, mint_id)\` library function — the same one \`balanceOf\` and \`bridgeOutToSolana\` already use. Pure derivation, always non-zero, no per-user activation required. The wrapper becomes internally consistent: \`getAta\` always points at where \`balanceOf\` reads.

Two-line change. No new function, no new library — \`UserPda.ata\` is already imported.

## Operational deploy

1. Merge this PR (rome-solidity master).
2. Re-deploy WUSDC + WETH + RomeBridgeWithdraw on Marcus via \`scripts/bridge/deploy.ts\`. Wrapper addresses change. RomeBridgeWithdraw's constructor takes wrapper addresses as immutables, so the bridge contract must redeploy with the new wrapper addresses too.
3. Existing user balances carry through derivationally — SPL custody is on Solana at \`ata(AUTHORITY_PDA, mint)\`, the new wrapper's \`balanceOf\` reads the same ATA.
4. Update \`rome-protocol/registry\` \`chains/121301-marcus/{tokens,contracts}.json\` with new wrapper + bridge-withdraw addresses.
5. rome-ui \`REGISTRY_REF\` bump → ansible-redeploy. \`useOutboundCctpSend\` / \`useOutboundWhSend\` read \`chain.contracts.bridgeWithdraw\` which gets the new address via the registry update — no rome-ui code change required.

## Test plan

- [x] \`npx hardhat compile\` clean
- [ ] Re-deploy on Marcus, retry \`burnUSDC\` end-to-end (Marcus → Sepolia outbound CCTP). Currently fails with \`Custom(3007)\`; should succeed after redeploy.

## Cross-repo

- rome-ui (no code change): consumes \`bridgeWithdraw\` via registry merger; new address propagates via registry-ref bump.
- registry: chain entries for redeployed chains will need new \`splWrappers.{wusdc, weth}\` + \`RomeBridgeWithdraw\` addresses.

Closes the \`mollusk error: Failure(Custom(3007))\` Marcus → Sepolia outbound bridge regression introduced when #82 left the wrapper half-migrated.