### PR TITLE
fix(bridge): restore marcus check on Wormhole targetChain in deploy.ts

### DIFF
--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -179,8 +179,13 @@ export async function deployWithdraw(
     sequence:           pdas.wormholeSequence,
     wrappedMeta:        pdas.wormholeWrappedMeta,
     // Wormhole destination chain id — 2 for Ethereum mainnet, 10002 for Sepolia.
-    // Pick based on the Ethereum-side target for this Rome deployment.
-    targetChain:        networkName === "<chain>" || networkName === "local" ? 10002 : 2,
+    // All current Rome chains target Sepolia (devnet). When a mainnet Rome
+    // chain is brought up, fold its networkName into the mainnet branch (or
+    // replace this block with a `chain.bridge.sourceEvm.chainId` lookup from
+    // the registry). The earlier `"<chain>"` placeholder was a leftover from
+    // PR #97's marcus-sweep — it never matched any real network and silently
+    // routed Marcus's outbound Wormhole to Ethereum mainnet.
+    targetChain:        networkName === "marcus" || networkName === "local" ? 10002 : 2,
   };
 
   const withdraw = await viem.deployContract("RomeBridgeWithdraw", [


### PR DESCRIPTION
## Summary

PR #97's marcus-sweep replaced \`networkName === \"marcus\"\` with the literal placeholder \`\"<chain>\"\` on line 183 of \`scripts/bridge/deploy.ts\`. The placeholder never matches a real network — every devnet redeploy after the sweep silently fell through to the mainnet branch (\`targetChain: 2\` instead of \`10002\`).

## Why

The current Marcus 121301 \`RomeBridgeWithdraw\` at \`0x911ea410…\` was deployed after the regression. Its on-chain Wormhole config encodes \`target_chain: 2\` (Ethereum mainnet). When a user calls \`burnETH\`, the resulting VAA gets attested by Wormhole guardians but the wrapped Sepolia WETH has no representation on Ethereum mainnet, so the redemption side fails. Outbound Wormhole on 121301 has been silently broken since the chain stood up.

Inbound Wormhole + outbound CCTP are unaffected (different code paths; \`targetChain\` is only consumed by \`burnETH\`).

## Scope

- One conditional restored, comment expanded with regression history
- Compile clean (67 files, solc 0.8.28)
- Blocks the upcoming \`scripts/bridge/deploy.ts --network marcus\` redeploy that bundles the rome-solidity #99 \`getAta\` fix — the new RomeBridgeWithdraw needs the correct \`targetChain\` constant baked in, since it's a constructor arg

## Followup (not this PR)

Replace the conditional with a registry-driven lookup: read \`bridge.json#sourceEvm.chainId\` for the active chain and translate to the Wormhole chain id (Sepolia 11155111 → 10002, mainnet 1 → 2). Avoids growing another branch every time a new chain is brought up.

## Test plan

- [x] \`npx hardhat compile\` clean
- [ ] After merge: \`USDC_MINT=… WETH_MINT=… npx hardhat run scripts/bridge/deploy.ts --network marcus\` produces a RomeBridgeWithdraw whose Wormhole \`targetChain\` is \`10002\` (verified via \`cast call\` on the new address)