### PR TITLE
feat(erc20spl): auto-register users on first ERC20 mutation

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -128,7 +128,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      * @return associated_account_address The address of the associated token account created or existing for the user
      */
     function ensure_token_account(address user) public returns (bytes32) {
-        bytes32 payer = _users.get_user(msg.sender);
+        // ensure_user (not get_user) so a brand-new caller — never
+        // bridged, never wrapped, never registered in ERC20Users — gets
+        // auto-registered on the first call. Self-bootstrapping; no
+        // out-of-band setup tx required. Idempotent for repeat callers.
+        bytes32 payer = _users.ensure_user(msg.sender);
         bytes32 token_account = _accounts[user];
         if (token_account == bytes32(0)) {
             return create_token_account(user, payer);
@@ -175,7 +179,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {
-        return _transfer(_users.get_user(msg.sender), msg.sender, to, value);
+        return _transfer(_users.ensure_user(msg.sender), msg.sender, to, value);
     }
 
     /**
@@ -244,8 +248,8 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {
-        bytes32 ownerUser = _users.get_user(msg.sender);
-        bytes32 spenderUser = _users.get_user(spender);
+        bytes32 ownerUser = _users.ensure_user(msg.sender);
+        bytes32 spenderUser = _users.ensure_user(spender);
 
         (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) = 
         SplTokenLib.approve(
@@ -273,7 +277,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
 
     function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
         address spender = msg.sender;
-        return _transfer(_users.get_user(spender), from, to, value);
+        return _transfer(_users.ensure_user(spender), from, to, value);
     }
 
     /// @notice Move this wrapper's underlying SPL out of the caller's
@@ -335,7 +339,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // answer for bridged-in tokens. bridgeOutToSolana takes the
         // direct path.
         bytes32 authority_pda = RomeEVMAccount.pda(msg.sender);
-        bytes32 payer_pda = _users.get_user(msg.sender);
+        // ensure_user (not get_user) so users who only have bridged-in
+        // tokens (never called create_user) can still bridge out — the
+        // first outbound auto-registers. payer_pda is read for
+        // potential future ATA-create reintroduction (see comment below).
+        bytes32 payer_pda = _users.ensure_user(msg.sender);
 
         bytes32 from_ata = UserPda.ataForKey(authority_pda, mint_id);
 
@@ -420,7 +428,9 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     {
         require(solana_recipient != bytes32(0), "Solana recipient cannot be zero");
 
-        bytes32 payer_pda = _users.get_user(msg.sender);
+        // ensure_user (not get_user) so users with bridged-in tokens
+        // who never called create_user can still ensure recipient ATAs.
+        bytes32 payer_pda = _users.ensure_user(msg.sender);
 
         (
             bytes32 program_id,
@@ -464,7 +474,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     function mint_to(address to, uint256 value) public virtual returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
 
-        bytes32 user = _users.get_user(msg.sender);
+        bytes32 user = _users.ensure_user(msg.sender);
         // Mint to a fresh address: ensure the recipient's PDA-owned
         // ATA exists before the SPL mint_to_checked CPI. Same
         // idempotent pattern as `_transfer` above — no-op when the


### PR DESCRIPTION
## Summary

\`SPL_ERC20\` now calls \`_users.ensure_user(...)\` instead of \`_users.get_user(...)\` on every mutation entry point. First-time callers — never bridged via the legacy path, never called \`factory.create_user\` — get auto-registered on their first \`transfer\` / \`approve\` / \`mint_to\` / \`bridgeOutToSolana\` instead of reverting with \"User does not exist\".

Same self-bootstrap model as Phantom: the wallet appears the moment you use it.

## Why this surfaced now

Post-rome-evm-program rotation, users with bridged-in WUSDC / WETH (canonical wrappers, never deployed via factory) have no \`ERC20Users\` entry. Calling \`approve()\` to set up a Romeswap pool reverts at \`_users.get_user(msg.sender)\` with \"User does not exist\". The work-around is clicking \"Activate\" in Portfolio (which calls \`ERC20SPLFactory.create_user\`) before any wrapper interaction. With this fix the first interaction self-registers — no out-of-band setup tx.

## Affected entry points (8 call sites in \`erc20spl.sol\`)

- \`ensure_token_account(user)\` — payer for ATA-create
- \`transfer(to, value)\` — sender's payer
- \`approve(spender, value)\` — **both owner AND spender** (the underlying SPL approve CPI requires both PDAs to exist)
- \`transferFrom(from, to, value)\` — spender (msg.sender)
- \`bridgeOutToSolana(...)\` — sender (was a register-gate even though \`payer_pda\` is unused on the AUTHORITY_PDA-signed path)
- \`ensureRecipientAta(recipient)\` — sender's payer for the create-ATA CPI
- \`mint_to(to, value)\` — sender's authority

## Left unchanged

- \`allowance(owner, spender)\` — view function, can't write state
- \`get_user\` function definition itself — still useful for view-only reads
- All non-\`SPL_ERC20\` consumers of \`ERC20Users\`

## Cost

\`ensure_user\` is idempotent — repeat callers see the existing PDA returned. Gas-neutral after first use. First call adds one mapping write + the underlying \`get_payer\` PDA derivation; cost is small relative to the SPL CPI itself.

## Relationship to closed PR #69

This is the auto-register half of [#69](https://github.com/rome-protocol/rome-solidity/pull/69), redone clean against current master. The other half of #69 — \`balanceOf\` no-revert via \`_accounts\` mapping rewrite — was superseded by #82's UserPda migration and is intentionally NOT part of this PR. \`balanceOf\` already short-circuits to 0 for unfunded accounts via \`UserPda.ata\` + on-chain account-info empty-data check.

## Test plan

- [x] \`npx hardhat compile\` clean
- [ ] After merge: redeploy WUSDC + WETH wrappers + RomeBridgeWithdraw on Marcus 121301
- [ ] Browser smoke: a fresh user (no prior \`create_user\` call, no prior wrapper interaction) bridges in via Wormhole, then directly creates a Romeswap pool — \`approve\` succeeds without \"User does not exist\"
- [ ] Browser smoke: an already-registered user re-runs the same flow — no behavior change, same gas