### PR TITLE
fix(erc20spl): bootstrap PAYER_PDA SOL on first wrapper write

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -259,14 +259,47 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     /// because the legacy ATA had zero balance. This commit closes
     /// that gap; standard ERC20 `approve` + `transferFrom` works for
     /// any user whose tokens are in their canonical AUTHORITY_PDA ATA.
+    /// One-time bootstrap of the caller's PAYER_PDA on Solana.
+    /// `factory.create_user()` already does this (1M lamports from the
+    /// rome-evm operator), but bridged-in / wrap-funded users may never
+    /// have called it. `ensure_user` (the post-#101 auto-register) writes
+    /// the ERC20Users Rome-side mapping but does NOT fund the Solana
+    /// PAYER_PDA — so any wrapper write path that needs to allocate
+    /// recipient ATA rent hits mollusk Custom(1) (System Program
+    /// InsufficientFunds). This helper closes that gap. Idempotent: the
+    /// underlying `create_payer` returns immediately if the PDA already
+    /// has ≥ requested lamports.
+    function _ensurePayerFunded(address user) internal {
+        RomeEVMAccount.create_payer(user, 1_000_000, _users.payer_salt());
+    }
+
     function _transfer(address from, address to, uint256 value) internal returns (bool) {
         require(value <= type(uint64).max, "Transfer amount exceeds uint64");
 
         bytes32 from_authority_pda = UserPda.pda(from);
         bytes32 from_ata = UserPda.ataForKey(from_authority_pda, mint_id);
 
-        bytes32 sender_payer_pda = _users.ensure_user(msg.sender);
-        bytes32 to_ata = _ensureAuthorityAta(to, sender_payer_pda);
+        // Recipient-ATA create rent must be paid from a Solana account
+        // with non-zero lamports. We fund it from the value-originator's
+        // PAYER_PDA (`from` here, which is also tx.origin in the direct
+        // path or the user that signed the approve in the delegated
+        // path). Why `from` and not `msg.sender`:
+        //   * `msg.sender` may be a contract (router, paymaster, etc.)
+        //     whose PAYER_PDA was never funded — contracts don't go
+        //     through `factory.create_user`, and `ensure_user` only
+        //     writes the Rome-side mapping.
+        //   * `from` represents the value-originator; charging them rent
+        //     for downstream Solana state matches the Phantom-style
+        //     "sender pays for recipient" UX and the existing
+        //     `bridgeOutToSolana` precedent.
+        // Bootstrap their PAYER_PDA the first time it's used — same
+        // 1M-lamport floor as `factory.create_user`. Idempotent: no-op
+        // when already funded.
+        _ensurePayerFunded(from);
+        bytes32 from_payer_pda = _users.ensure_user(from);
+        // Register the spender too so other consumers see consistent state.
+        _users.ensure_user(msg.sender);
+        bytes32 to_ata = _ensureAuthorityAta(to, from_payer_pda);
 
         bytes32 authority;
         bytes32[] memory seeds;
@@ -274,7 +307,14 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
             authority = from_authority_pda;
             seeds = new bytes32[](0);
         } else {
-            authority = sender_payer_pda;
+            // Delegated path: signer = PAYER_PDA(spender) (matches the
+            // delegate set in `approve`). `[payer_salt]` seeds let the
+            // CPI sign as that PDA. The spender's PAYER_PDA needs to
+            // exist on-chain (just so the SPL token program can verify
+            // the signer matches the delegate field) but not be funded
+            // — recipient-ATA rent already came from `from`'s PDA above.
+            _ensurePayerFunded(msg.sender);
+            authority = _users.ensure_user(msg.sender);
             seeds = new bytes32[](1);
             seeds[0] = _users.payer_salt();
         }
@@ -516,6 +556,9 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
 
         // ensure_user (not get_user) so users with bridged-in tokens
         // who never called create_user can still ensure recipient ATAs.
+        // _ensurePayerFunded bootstraps the PAYER_PDA's SOL balance to
+        // 1M lamports — covers the ATA-create rent CPI below.
+        _ensurePayerFunded(msg.sender);
         bytes32 payer_pda = _users.ensure_user(msg.sender);
 
         (
@@ -560,6 +603,9 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     function mint_to(address to, uint256 value) public virtual returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
 
+        // Bootstrap the minter's PAYER_PDA on Solana so the recipient
+        // ATA-create CPI below has rent-funded source lamports. Idempotent.
+        _ensurePayerFunded(msg.sender);
         bytes32 user = _users.ensure_user(msg.sender);
         // Destination = AUTHORITY_PDA(to)'s ATA — the canonical ATA
         // `balanceOf(to)` reads. Pre-migration this minted into


### PR DESCRIPTION
## Summary

Closes mollusk \`Custom(1)\` on \`approve\`+\`transferFrom\` flows for users who never explicitly called \`factory.create_user()\`. Surfaced as **Romeswap pool creation failing at the second sign** for users funded via \`wrap_gas_to_spl\` / Wormhole / CCTP.

## Root cause

\`factory.create_user()\` is the only flow that funds \`PAYER_PDA(user)\` on Solana — transfers 1M lamports from the rome-evm operator account. Bridged-in / wrap-funded users skip this flow entirely. [#101](https://github.com/rome-protocol/rome-solidity/pull/101)'s \`ensure_user\` auto-register only writes the Rome-side ERC20Users mapping; it does NOT fund the Solana-side PDA.

When \`router.addLiquidity\` calls \`token.transferFrom(user, router, amt)\`, the wrapper's \`_ensureAuthorityAta(router, payer)\` issues a SystemProgram CPI to allocate the router's recipient ATA and pay rent (~0.002 SOL) from \`payer\`. If \`payer\` PDA has 0 lamports, mollusk surfaces SystemProgram \`ResultWithNegativeLamports\` as \`Failure(Custom(1))\` — generic enough to look identical to SPL Token \`InsufficientFunds\` (also Custom(1)).

\`approve\` itself succeeded because SPL approve just sets a delegate field on the existing source ATA — no new account allocation, no rent. Only the subsequent \`transferFrom\` triggers the recipient-ATA-create CPI.

**On-chain verification**: confirmed the router's WUSDC ATA does not exist on Solana for the user's first pool (\`solana account HqCZ…\` returns no-such-account). User's WUSDC ATA exists with 15 USDC ✓ — so the transfer source is fine; the destination is what's missing.

## What changes

New private \`_ensurePayerFunded(address user)\` helper wraps \`RomeEVMAccount.create_payer\` with a 1M-lamport floor (matching \`factory.create_user\`'s \`CREATE_PAYER_LAMPORTS\`). Idempotent: \`create_payer\` no-ops when the PDA already has ≥ requested lamports. Same source (rome-evm operator), same amount, same one-time-bootstrap UX as Activate.

Called from every write path that allocates Solana-side state:

- \`_transfer\` — bootstrap \`from\`'s PAYER_PDA (value originator pays for recipient ATA-create rent). Also bootstrap \`msg.sender\`'s PAYER_PDA on the delegated path so the spender can sign as their PDA against the delegate field.
- \`mint_to\` — bootstrap \`msg.sender\`'s PAYER_PDA before allocating the recipient ATA.
- \`ensureRecipientAta\` — bootstrap \`msg.sender\`'s PAYER_PDA before the Solana-side ATA-create CPI.

Behavior unchanged on read paths (\`balanceOf\`, \`getAta\`, \`allowance\`) and on \`approve\` (no rent allocation needed). \`transfer\` direct path with an already-existing recipient ATA stays single-CPI fast.

## Trade-off

Per the existing \`/rome-solidity/CLAUDE.md\` "no faucets" rule, the 1M-lamport bootstrap is **reused exactly as** \`factory.create_user\` does — we're not introducing a new subsidy, we're applying the existing one to non-Activate-clicked users so their first wrapper interaction works without an out-of-band setup tx. Same UX as Phantom: the wallet works the moment it's used.

Followup: when \`rome-evm-private\` gains a way for \`wrap_gas_to_spl\` / inbound bridges to fund PAYER_PDA at value-receive time, this bootstrap can move to that earlier ingress point and become a no-op here.

## Test plan

- [x] \`npx hardhat compile\` clean
- [ ] After merge: redeploy WUSDC + WETH + RomeBridgeWithdraw on Marcus 121301
- [ ] Browser smoke: a CCTP/Wormhole-bridged-in user (no prior \`create_user\`) creates a Romeswap pool — both signs succeed end-to-end
- [ ] Same user adds liquidity to existing pool — succeeds
- [ ] Same user removes liquidity — pair calls \`_safeTransfer\` (direct path) — succeeds
- [ ] Outbound bridges (CCTP + Wormhole + SPL) still work