### PR TITLE
revert: canonical-ATA fallback (#106) — owner mismatch revealed deeper issue

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -74,26 +74,10 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     ERC20Users private _users;
     mapping(address => bytes32) private _accounts;
 
-    /// @notice Public reader for the SPL token account address owned by
-    /// this EVM user — the canonical AUTHORITY_PDA-owned ATA where this
-    /// wrapper's underlying SPL tokens land for that user.
-    /// @dev Cache fast-path: returns `_accounts[user]` when populated.
-    /// Fallback: deterministic derivation via `UserPda.ata` — same
-    /// address `create_token_account` would compute and cache, also
-    /// where `wrap_gas_to_spl`, Wormhole `complete_transfer_wrapped`,
-    /// and any inbound flow deposits tokens. Returning the canonical
-    /// address even for users whose `_accounts` mapping was never
-    /// populated keeps `getAta` aligned with `balanceOf` and unblocks
-    /// `RomeBridgeWithdraw.burnUSDC` / `burnETH` for users with wrap-
-    /// or bridge-funded balance. The address may exist on Solana even
-    /// when `_accounts` is unset; downstream SPL CPIs handle the
-    /// "ATA initialized?" check loud-and-early. Never reverts.
+    /// @notice Public reader for the SPL token account owned by this EVM user.
+    /// @dev Returns the cached ATA; callers may treat a zero return as "not yet initialized".
     function getAta(address user) external view returns (bytes32) {
-        bytes32 cached = _accounts[user];
-        if (cached != bytes32(0)) {
-            return cached;
-        }
-        return UserPda.ata(user, mint_id);
+        return _accounts[user];
     }
 
     error ERC20InvalidApprover(address approver);
@@ -171,25 +155,10 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      * @param user EVM address of the user whose associated token account address to retrieve
      * @return associated_account_address The address of the associated token account for the user
      */
-    /// @dev Internal reader used by mutation paths (transfer, approve,
-    /// transferFrom). Cache fast-path: returns `_accounts[user]` when
-    /// populated. Fallback: deterministic derivation via `UserPda.ata`
-    /// — same address `create_token_account` would compute and cache,
-    /// also where `wrap_gas_to_spl` / Wormhole `complete_transfer_wrapped`
-    /// / native-deposit flows land tokens. Never reverts.
-    ///
-    /// Without the fallback, users with bridge- or wrap-funded balance
-    /// (whose `_accounts[user]` was never written through a wrapper-
-    /// mediated `ensure_token_account` flow) couldn't transfer / approve
-    /// even though `balanceOf` correctly showed their balance and the
-    /// underlying ATA was on-chain. Aligning the read to match
-    /// `balanceOf` closes that gap.
     function get_token_account(address user) public view returns (bytes32) {
-        bytes32 cached = _accounts[user];
-        if (cached != bytes32(0)) {
-            return cached;
-        }
-        return UserPda.ata(user, mint_id);
+        bytes32 token_account = _accounts[user];
+        require(token_account != bytes32(0), "Token account does not exist");
+        return token_account;
     }
 
     function name() public view virtual returns (string memory) {


### PR DESCRIPTION
Reverts [#106](https://github.com/rome-protocol/rome-solidity/pull/106).

#106's fallback returns \`UserPda.ata(user, mint)\` — the AUTHORITY_PDA-owned ATA. But the wrapper's mutation paths sign SPL ops as PAYER_PDA(msg.sender) via \`[payer_salt]\` seeds. The signer doesn't match the source ATA owner — sim now fails with mollusk \`Custom(4)\` (SPL OwnerMismatch) for approve, \`Custom(1)\` (Insufficient Funds) for transfer / burnUSDC.

Note: \`approveBurnETH\` succeeded post-#106 (21000 gas) — that one path doesn't need to authorize an SPL transfer at sim time, so the mismatch didn't surface. Mixed result is what made #106 look like progress when it wasn't.

#106 + the working-test-of-#106 prove the cache-vs-canonical addresses are NOT the same. \`_accounts[user]\` historically stored a PAYER_PDA-owned ATA (the \`new_user.owner\` field in the original User struct was AUTHORITY_PDA, but \`create_token_account\` deliberately created the SPL ATA with a different owner — needs detective work to confirm).

Reverting puts master back at the known-good post-#105 baseline. Detective work happens next session against the local stack, not on Marcus.