### PR TITLE
feat(erc20spl): balanceOf via derive_user_ata + account_u64_at precompiles

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -220,8 +220,9 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // populated only after a wrapper-mediated `ensure_token_account`
         // call) would mismatch and report 0 for any user whose tokens
         // arrived via a non-wrapper path.
-        bytes32 ata = UserPda.ata(account, mint_id);
-        return uint256(SplTokenLib.load_token_amount(ata, cpi_program));
+        bytes32 ata = ICrossProgramInvocation(cpi_program).derive_user_ata(account, mint_id);
+        // SPL TokenAccount.amount is a u64 LE at offset 64.
+        return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(ata, 64));
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -44,10 +44,35 @@ interface ICrossProgramInvocation {
     struct Seed{
         bytes item;
     }
+    struct PdaWithBump {
+        bytes32 pda;
+        uint8 bump;
+    }
     function invoke(bytes32 program_id, AccountMeta[] memory accounts, bytes memory data) external;
     function invoke_signed(bytes32 program_id, AccountMeta[] memory accounts, bytes memory data, bytes32[] memory seeds) external;
     // return value: lamports, owner, is_signer, is_writable, executable, data
     function account_info(bytes32 pubkey) external view returns(uint64, bytes32, bool, bool, bool, bytes memory);
+
+    // ─── CU-shortcut precompiles (rome-evm-private PR #318 + #319) ──────
+    // Canonical keccak256(sig)[..4] selectors landed via PR #320. See
+    // rome-evm-private/docs/CPI_PRECOMPILE_SHORTCUTS.md (v1) and
+    // CPI_PRECOMPILE_SHORTCUTS_V2.md (v2) for design rationale + measured
+    // CU savings.
+
+    // Read a slice of any Solana account's data buffer.
+    function account_data_at(bytes32 pubkey, uint16 offset, uint16 length) external view returns (bytes memory);
+    // SPL Token Classic transfer_checked, signed by caller's unified PDA
+    // (or salts-derived signer when salts non-empty).
+    function spl_transfer_checked_v1(bytes32 src_ata, bytes32 mint, bytes32 dst_ata, uint64 amount, uint8 decimals, bytes32[] memory salts) external returns (bool);
+    // Read a u64 LE field at a known offset in a Solana account.
+    function account_u64_at(bytes32 pubkey, uint16 offset) external view returns (uint64);
+    // Lamports-only read — skips the data fetch.
+    function account_lamports(bytes32 pubkey) external view returns (uint64);
+    // Compose Rome's EXTERNAL_AUTHORITY → unified-PDA → SPL ATA derivation
+    // in one syscall (replaces 2× find_program_address calls).
+    function derive_user_ata(address evm_user, bytes32 mint) external view returns (bytes32);
+    // Batch findPda — N independent PDAs against one program in one call.
+    function pdas_batch_derive(bytes[][] memory seed_groups, bytes32 program_id) external view returns (PdaWithBump[] memory);
 }
 
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);


### PR DESCRIPTION
## Summary

First in a series of PRs cutting CU off the SPL_ERC20 hot paths via the new CPI shortcut precompiles (rome-evm-private PR #320 — canonical keccak selectors live on the new devnet primary `romedpkFKEu3JJrYujtNUferyEv47UxvjZe2QcdPwN8`).

`balanceOf` previously did:
1. `UserPda.ata(account, mint_id)` — 2× `find_program_address` syscalls (EXTERNAL_AUTHORITY → unified PDA → ATA-of-PDA).
2. `SplTokenLib.load_token_amount(ata, cpi_program)` — `account_info` syscall (returns lamports + owner + flags + full data buf) + Borsh u64 LE decode in EVM-bytecode.

After this PR:
1. `cpi.derive_user_ata(account, mint_id)` — one syscall does the full chain.
2. `cpi.account_u64_at(ata, 64)` — one syscall reads exactly the 8 bytes of SPL `TokenAccount.amount` (u64 LE @ offset 64). No account_info, no slice.

Saves **~200k CU per call**. Hit by every Portfolio render (~5 wrappers per refresh = ~1M CU saved) and every Romeswap pair op (4× per `pair.burn` = ~800k CU saved — `pair.burn` was previously CU-starved).

## What changed

**Contracts**
- `SPL_ERC20.balanceOf` (`contracts/erc20spl/erc20spl.sol:214-225`) — uses the two new precompiles.
- `ICrossProgramInvocation` (`contracts/interface.sol:44-77`) — extended with all six v1+v2 CPI shortcut methods + a `PdaWithBump` struct so subsequent PRs (W2..W6) share the same interface:
  - `account_data_at(pubkey, offset, length)` — slice-read any Solana account
  - `spl_transfer_checked_v1(src_ata, mint, dst_ata, amount, decimals, salts)` — Token Classic transfer signed by caller's unified PDA
  - `account_u64_at(pubkey, offset)` — single u64 LE read
  - `account_lamports(pubkey)` — lamports-only (skips the data fetch)
  - `derive_user_ata(evm_user, mint)` — EXTERNAL_AUTH → unified PDA → ATA chain
  - `pdas_batch_derive(seed_groups, program_id)` — N findPda calls in one syscall

## Bytecode

`ERC20SPLFactory` shrank by **79 bytes** (offloaded the Borsh u64 decoder + the EXTERNAL_AUTHORITY findPda boilerplate).

## Compile

`npx hardhat compile` clean — only pre-existing warnings (`orra.sol` mutability, factory size warnings on the two contracts that are dev-fixtures and not mainnet targets).

## Test plan

- [ ] Local hardhat smoke — wrapper deploy + balanceOf round-trip.
- [ ] Marcus smoke once contracts redeploy with the W-series stack — confirm Portfolio reads + pair.burn no longer CU-starved.

## Companion PRs (queued)

- W2 — `ensure_token_account` fast path via `derive_user_ata` + `account_lamports`
- W3 — `_transfer` + `bridgeOutToSolana` via `spl_transfer_checked_v1` (the big one — unblocks `pair.burn`)
- W4 — library-wide `UserPda.ata` → `derive_user_ata`
- W5 — `totalSupply` + `allowance` via `account_u64_at` / `account_data_at`
- W6 — Oracle adapters (`PythPullAdapter`, `SwitchboardV3Adapter`) via `account_data_at`