### PR TITLE
feat(erc20spl): ensure_token_account fast path via derive_user_ata + account_lamports

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -163,8 +163,15 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // shortcut every wrapper.transfer would always do 2 CPIs (ATA
         // create + transfer_checked) and pair.burn (which makes 2× wrapper.
         // transfer back to the LP holder) exceeds Rome's per-tx CPI budget.
-        bytes32 ata = UserPda.ata(user, mint_id);
-        (uint64 lamports, , , , , ) = ICrossProgramInvocation(cpi_program).account_info(ata);
+        //
+        // Two precompile shortcuts (rome-evm-private PR #318 + #319):
+        //  - `derive_user_ata` collapses 2× findPda (EXTERNAL_AUTH → unified
+        //    PDA → ATA-of-PDA) into one syscall.
+        //  - `account_lamports` fetches lamports only — no data buffer pull,
+        //    no Borsh decoding. The fast-path here only needs lamports != 0
+        //    to confirm the account is initialized.
+        bytes32 ata = ICrossProgramInvocation(cpi_program).derive_user_ata(user, mint_id);
+        uint64 lamports = ICrossProgramInvocation(cpi_program).account_lamports(ata);
         if (lamports != 0) {
             // Account already exists on Solana — no CPI needed.
             // Cache write-through is optional; legacy callers checking


### PR DESCRIPTION
## Summary

Second in the CPI-shortcut series (after #109). Cuts ~230-280k CU from `SPL_ERC20.ensure_token_account`'s fast-path probe — every `wrapper.transfer`'s first interaction with a recipient ATA, every bridge-worker outbound flow's pre-flight existence check, every cardo adapter pre-flight gate.

## What changed

`SPL_ERC20.ensure_token_account` now uses two single-purpose precompile shortcuts in place of `UserPda.ata` (= 2× findPda) + full `cpi.account_info` (returns lamports + owner + 3 flags + full data buffer):

- `cpi.derive_user_ata(user, mint_id)` — one syscall composing EXTERNAL_AUTHORITY → unified PDA → ATA-of-PDA.
- `cpi.account_lamports(ata)` — returns just the lamports field from the AccountInfo header. Skips the data fetch + ABI-encode of the 6-tuple entirely. The fast path here only needs `lamports != 0` to confirm the account is initialized; pulling the data buffer is wasted work.

`contracts/erc20spl/erc20spl.sol:157-189`.

## CU savings

| Path | Before | After | Saving |
|---|---:|---:|---:|
| `ensure_token_account` fast-path probe | ~330k | ~50-100k | **~230-280k** |

Compounds with #109 (balanceOf): `pair.burn`'s 2× `wrapper.transfer` recipient-ATA probes drop ~460k CU on top of the 800k saved by 4× balanceOf.

## Compile

`npx hardhat compile` clean; only pre-existing warnings.

## Selectors

`derive_user_ata(address,bytes32)` = 0xc654e119 and `account_lamports(bytes32)` = 0xde79ed54 — canonical keccak256(sig)[..4] per rome-evm-private PR #319+#320 (master @ 350a8725). Live on the new devnet primary `romedpkFKEu3JJrYujtNUferyEv47UxvjZe2QcdPwN8`.

## Companion PRs queued

W3 (`spl_transfer_checked_v1` in `_transfer` + `bridgeOutToSolana` — the big one), W4 (UserPda.ata library-wide), W5 (totalSupply + allowance), W6 (oracle adapters via account_data_at).