### PR TITLE
feat(erc20spl): _transfer + bridgeOutToSolana via spl_transfer_checked_v1

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -264,24 +264,24 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // (paid by the sender / spender) when it's not. Same UX model
         // as Phantom and every other Solana wallet.
         bytes32 to_account = ensure_token_account(to);
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) =
-        SplTokenLib.transfer_checked(
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            get_token_account(from),
-            mint_id,
-            to_account,
-            user,
-            new bytes32[](0),
-            uint64(value),
-            decimals
-        );
 
-        // Only the unified user PDA signs (= `user` arg above) — auto-detected
-        // from metas. No salt-derived signer → use `invoke`.
+        // `spl_transfer_checked_v1` builds the AccountMeta[4] + 10-byte
+        // transfer_checked ix data in Rust (saves ~250k CU vs the
+        // Solidity-side SplTokenLib.transfer_checked marshaling) and
+        // signs as the precompile-caller's unified PDA when salts is
+        // empty. Delegatecall preserves caller = msg.sender, so:
+        //   - transfer(to, value): signer = unified_pda_of(msg.sender) =
+        //     source-ATA owner (`user` arg, kept for compatibility with
+        //     prior callers). Direct authority match.
+        //   - transferFrom(from, to, value): signer = unified_pda_of(spender),
+        //     which is the SPL Token delegate set by the prior approve()
+        //     call. SPL Token Classic accepts delegate-as-authority for
+        //     transfer_checked when delegated_amount ≥ amount.
+        user;  // arg is the unified PDA the precompile auto-derives — silenced
         (bool success, bytes memory result) = address(cpi_program).delegatecall(
             abi.encodeWithSignature(
-                "invoke(bytes32,(bytes32,bool,bool)[],bytes)",
-                program_id, accounts, data
+                "spl_transfer_checked_v1(bytes32,bytes32,bytes32,uint64,uint8,bytes32[])",
+                get_token_account(from), mint_id, to_account, uint64(value), decimals, new bytes32[](0)
             )
         );
 
@@ -398,32 +398,19 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // only) works reliably on chain.
         bytes32 to_ata = UserPda.ataForKey(solana_recipient, mint_id);
 
-        // SPL transfer_checked from AUTHORITY_PDA's ATA →
-        // recipient's ATA. Authority = AUTHORITY_PDA (owns the source
-        // ATA). Signed with empty seeds so the rome-evm CPI precompile
-        // signs as AUTHORITY_PDA (no salt — find_program_address
-        // ([EXTERNAL_AUTHORITY, evmAddr])).
-        (
-            bytes32 program_id,
-            ICrossProgramInvocation.AccountMeta[] memory accounts,
-            bytes memory data
-        ) = SplTokenLib.transfer_checked(
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            from_ata,
-            mint_id,
-            to_ata,
-            authority_pda,                  // owner of from_ata
-            new bytes32[](0),
-            uint64(value),
-            decimals
-        );
-
-        // The unified user PDA signs as `authority_pda` (owner of from_ata) —
-        // auto-detected from metas. No salt-derived signer → use `invoke`.
+        // SPL transfer_checked from AUTHORITY_PDA's ATA → recipient's ATA.
+        // `spl_transfer_checked_v1` builds the AccountMeta[4] + 10-byte ix
+        // data in Rust (saves ~250k CU vs the Solidity SplTokenLib helper)
+        // and signs as the precompile-caller's unified PDA when salts is
+        // empty. Delegatecall preserves caller = msg.sender, so the signer
+        // resolves to `external_auth(msg.sender)` = `authority_pda` =
+        // owner of `from_ata`. Direct authority match — no delegation,
+        // no salts.
+        authority_pda;  // owner of from_ata; precompile auto-derives same value
         (bool success, bytes memory result) = address(cpi_program).delegatecall(
             abi.encodeWithSignature(
-                "invoke(bytes32,(bytes32,bool,bool)[],bytes)",
-                program_id, accounts, data
+                "spl_transfer_checked_v1(bytes32,bytes32,bytes32,uint64,uint8,bytes32[])",
+                from_ata, mint_id, to_ata, uint64(value), decimals, new bytes32[](0)
             )
         );
         require(success, string(Convert.revert_msg(result)));


### PR DESCRIPTION
## Summary

Third in the CPI-shortcut series. **The big one** — saves ~500k CU per call by replacing the Solidity-side `SplTokenLib.transfer_checked` AccountMeta[4] + ix data marshaling with the new `spl_transfer_checked_v1` precompile, which builds the SPL Token Classic `transfer_checked` instruction in Rust and signs as the caller's unified PDA in one syscall.

## Why this matters

Per the rome-evm-private CU breakdown of `wrapper.transfer` (~687k CU above tx baseline), the actual SPL Token CPI itself costs **210 CU**. The remaining ~685k is EVM-side scaffolding around it. This PR moves that scaffolding into Rust:

- AccountMeta[4] construction in Solidity bytecode: ~250k → 0
- 10-byte ix data buffer construction: ~50k → 0
- `cpi.invoke` ABI roundtrip + auto-detect-signer: ~150k → bundled
- Total: ~500k saved per transfer call

This is the change that puts `pair.burn` (4× balanceOf + 2× wrapper.transfer + housekeeping, previously CU-busted at ~2.9M) under the 1.4M ceiling.

## Two call sites updated

`contracts/erc20spl/erc20spl.sol`:

- **`_transfer`** (used by `transfer` + `transferFrom`) — signer auto-resolves to caller's unified PDA via delegatecall caller preservation. `transferFrom` relies on the prior `approve()` having set the spender's PDA as SPL Token delegate; SPL Classic accepts delegate-as-authority for `transfer_checked` when delegated_amount ≥ amount.
- **`bridgeOutToSolana`** — signer auto-resolves to msg.sender's unified PDA = `authority_pda` = source-ATA owner. Direct authority match.

Both call sites pass `salts: []` to the precompile, which makes it sign as `external_auth(caller_h160)`. Through the `delegatecall` to the precompile, `caller_h160` is preserved as the original EVM tx sender (not the SPL_ERC20 contract address) — same convention as today's `cpi.invoke()` flow.

## Compile

`npx hardhat compile` clean; only pre-existing warnings.

## Selector

`spl_transfer_checked_v1(bytes32,bytes32,bytes32,uint64,uint8,bytes32[])` = canonical keccak256(sig)[..4] = 0x351aa22f per rome-evm-private PR #318+#320 (master @ 350a8725). Live on the new devnet primary `romedpkFKEu3JJrYujtNUferyEv47UxvjZe2QcdPwN8`.

## Companion PRs queued

W4 (UserPda.ata library-wide → derive_user_ata at 5 sites), W5 (totalSupply + allowance), W6 (oracle adapters via account_data_at).