### PR TITLE
feat(erc20spl,bridge): UserPda.ata → cpi.derive_user_ata at 5 sites

### DIFF
--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -222,7 +222,9 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         // a freshly-deployed wrapper — `wrapper.getAta(user)` would return
         // `bytes32(0)` and CCTP's deposit_for_burn would revert with
         // Anchor `AccountOwnedByWrongProgram` (3007) on burn_token_account.
-        bytes32 userAta = UserPda.ata(user, usdcMint);
+        // Uses the `derive_user_ata` precompile shortcut: one syscall vs the
+        // 2× findPda chain in `UserPda.ata` (~80k CU saved per call).
+        bytes32 userAta = CpiProgram.derive_user_ata(user, usdcMint);
 
         // Unified-PDA model (rome-solidity 0acabea): the user has ONE PDA.
         // Wherever the pre-0acabea code passed PAYER_PDA (salt-derived sub-PDA
@@ -313,8 +315,9 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         address user = _msgSender();
 
         bytes32 userPda = RomeEVMAccount.pda(user);
-        // Canonical user-ATA — see comment in burnUSDC for rationale.
-        bytes32 userAta = UserPda.ata(user, wethMint);
+        // Canonical user-ATA via `derive_user_ata` precompile shortcut — see
+        // comment in burnUSDC for rationale.
+        bytes32 userAta = CpiProgram.derive_user_ata(user, wethMint);
 
         bytes32[] memory emptySigners = new bytes32[](0);
         (, ICrossProgramInvocation.AccountMeta[] memory approveMetas, bytes memory approveIx) =
@@ -363,8 +366,9 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         }
 
         bytes32 userPda  = RomeEVMAccount.pda(user);
-        // Canonical user-ATA — see comment in burnUSDC for rationale.
-        bytes32 userAta  = UserPda.ata(user, wethMint);
+        // Canonical user-ATA via `derive_user_ata` precompile shortcut — see
+        // comment in burnUSDC for rationale.
+        bytes32 userAta  = CpiProgram.derive_user_ata(user, wethMint);
 
         // Unified-PDA model: the user's single PDA fills both `payer`
         // (metas[0]) and `from_owner` (metas[3]). Wherever the pre-0acabea

--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -94,7 +94,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     ///      after any wrapper-mediated mutation). New callers should treat
     ///      this as the canonical lookup.
     function getAta(address user) external view returns (bytes32) {
-        return UserPda.ata(user, mint_id);
+        return ICrossProgramInvocation(cpi_program).derive_user_ata(user, mint_id);
     }
 
     error ERC20InvalidApprover(address approver);
@@ -202,7 +202,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
      *      mediated flows like Romeswap addLiquidity.
      */
     function get_token_account(address user) public view returns (bytes32) {
-        return UserPda.ata(user, mint_id);
+        return ICrossProgramInvocation(cpi_program).derive_user_ata(user, mint_id);
     }
 
     function name() public view virtual returns (string memory) {


### PR DESCRIPTION
## Summary

Fourth in the CPI-shortcut series. Replaces every remaining `UserPda.ata(user, mint)` (= 2× `find_program_address`: EXTERNAL_AUTHORITY → unified PDA → ATA-of-PDA) with `cpi.derive_user_ata(user, mint)` — one syscall doing the same composition in Rust. Saves ~80k CU per call.

## Sites

| File | Function | Notes |
|---|---|---|
| `contracts/erc20spl/erc20spl.sol` | `getAta(user)` | external view; called by rome-ui's portfolio reads |
| `contracts/erc20spl/erc20spl.sol` | `get_token_account(user)` | called by `_transfer`'s source-ATA derive, `allowance`, `approve`, `transferFrom` |
| `contracts/bridge/RomeBridgeWithdraw.sol` | `burnUSDC` | every CCTP outbound |
| `contracts/bridge/RomeBridgeWithdraw.sol` | `burnETH` (approve step) | every Wormhole approve step |
| `contracts/bridge/RomeBridgeWithdraw.sol` | `burnETH` (burn step) | every Wormhole burn step |

Compounds with #109 (balanceOf), #110 (ensure_token_account), and #111 (_transfer + bridgeOutToSolana). All the remaining `UserPda.ata`-call-inside-write-path sites are now off the slow EVM-side derivation.

## What's NOT replaced

`UserPda.ataForKey(rawSolanaPubkey, mint)` is left in place — the precompile is EVM-user-specific (takes `address evm_user`); raw-key ATAs (recipient pubkeys, fee receivers) keep using the Solidity helper since their second findPda is the same cost either way.

`UserPda` library stays in place — `pda()`, `ataForKey()`, and `ataWithProgram()` still have callers (CPI templates, bridge helpers).

## Compile

`npx hardhat compile` clean; only pre-existing warnings.

## Selector

`derive_user_ata(address,bytes32)` = canonical keccak256(sig)[..4] = 0xc654e119 per rome-evm-private PR #319+#320 (master @ 350a8725). Live on the new devnet primary `romedpkFKEu3JJrYujtNUferyEv47UxvjZe2QcdPwN8`.

## Companion PRs queued

W5 (totalSupply + allowance via account_u64_at + account_data_at), W6 (oracle adapters via account_data_at).