### PR TITLE
test(interface): ISplTransfer for new precompile (0xFF…09) [RED]

### DIFF
--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -35,6 +35,33 @@ interface IWrapGasToSpl {
     function wrap_gas_to_spl(uint256 amount) external;
 }
 
+// SPL Transfer Precompile (0xFF…09). High-level Solidity entry point for
+// SPL Token + Token-2022 transfers. The precompile auto-derives source ATA
+// from msg.sender's unified PDA, derives dest ATA from destWallet, reads
+// decimals from the mint, idempotently creates the dest ATA if missing,
+// and resolves Token-2022 TransferHook accounts in the emulator pre-pass.
+//
+// CALLING CONVENTION: invoke via `delegatecall` so msg.sender flows through
+// to the unified-PDA derivation. See SPEC-spl-transfer-precompile.md
+// §Conformance and the erc20spl.sol:285-290 reference pattern.
+//
+// CPI-DEPTH CONSTRAINT (v1, per SPEC §Constraints & Limits): only safe to
+// invoke from a top-level (RheaTx-entered) Solidity contract. Calling from
+// inside another CPI context (RemusTx outer instruction, precompile-from-
+// precompile chain) will exceed Solana's 4-level CPI ceiling once a
+// Token-2022 TransferHook fires. Documented; not runtime-checked.
+//
+// COMPUTE BUDGET: when the mint may carry a TransferHook extension, the
+// caller MUST issue SetComputeUnitLimit(>= 400_000) — Token-2022 + hook +
+// DoEvmCallback can push past the default 200k CU.
+interface ISplTransfer {
+    // Transfer `amount` of `mint` from msg.sender's PDA-owned ATA to
+    // destWallet's ATA. Reverts on any failure (InvalidMintOwner,
+    // SourceAtaMissing, InsufficientBalance, HookRejected, AtaCreateFailed,
+    // Token2022UnsupportedExtension).
+    function splTransfer(bytes32 mint, bytes32 destWallet, uint64 amount) external;
+}
+
 interface ICrossProgramInvocation {
     struct AccountMeta {
         bytes32 pubkey;
@@ -77,12 +104,14 @@ interface ICrossProgramInvocation {
 
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);
 address constant cpi_program_address = address(0xFF00000000000000000000000000000000000008);
+address constant spl_transfer_address = address(0xFF00000000000000000000000000000000000009);
 address constant withdraw_address = address(0x4200000000000000000000000000000000000016);
 address constant unwrap_spl_to_gas_address = address(0x4200000000000000000000000000000000000017);
 address constant wrap_gas_to_spl_address = address(0x4200000000000000000000000000000000000018);
 
 ISystemProgram constant SystemProgram = ISystemProgram(system_program_address);
 ICrossProgramInvocation constant CpiProgram = ICrossProgramInvocation(cpi_program_address);
+ISplTransfer constant SplTransfer = ISplTransfer(spl_transfer_address);
 IWithdraw constant Withdraw = IWithdraw(withdraw_address);
 IUnwrapSplToGas constant UnwrapSplToGas = IUnwrapSplToGas(unwrap_spl_to_gas_address);
 IWrapGasToSpl constant WrapGasToSpl = IWrapGasToSpl(wrap_gas_to_spl_address);


### PR DESCRIPTION
## Summary

Adds the Solidity ABI surface for the new SPL Transfer Precompile at \`0xFF…09\`. Single-selector interface plus the \`SplTransfer\` global instance, slotted into the centralized \`contracts/interface.sol\` next to the existing precompile bindings.

\`\`\`solidity
interface ISplTransfer {
    function splTransfer(bytes32 mint, bytes32 destWallet, uint64 amount) external;
}
address constant spl_transfer_address = address(0xFF00000000000000000000000000000000000009);
ISplTransfer constant SplTransfer = ISplTransfer(spl_transfer_address);
\`\`\`

Comments document three v1 constraints from the spec:
1. **\`delegatecall\` convention** — preserves \`msg.sender\` for unified-PDA derivation. Mirrors \`erc20spl.sol:285-290\`.
2. **CPI-depth ceiling** — only safe from a top-level (RheaTx-entered) Solidity contract. Calling from within another CPI exceeds Solana's 4-level limit once a Token-2022 hook fires.
3. **Compute budget** — caller MUST issue \`SetComputeUnitLimit(>= 400_000)\` for any tx that may invoke this against a hook-bearing mint.

## What this does NOT do

- No implementation — the precompile itself is still \`todo!()\` in [rome-protocol/rome-evm-private](https://github.com/rome-protocol/rome-evm-private). Any contract that \`delegatecall\`s \`SplTransfer.splTransfer\` will revert until that PR lands.
- No helper library (\`SplTransfer.sol\`) — deferred; a single-method interface doesn't justify one yet.

## Companion PRs

- Spec: https://github.com/rome-protocol/rome-specs/pull/65 (draft)
- Precompile impl: rome-protocol/rome-evm-private (sibling PR)
- Integration tests: rome-protocol/tests (sibling PR)

## Test plan

- [x] Diff is mechanical and modeled exactly on the existing \`IWithdraw\` / \`ICrossProgramInvocation\` / \`IUnwrapSplToGas\` shape immediately above
- [ ] \`npx hardhat compile\` (npm install required first; not run locally — deferred to \`/implement\`)
- [ ] Cross-check against rome-evm-private's deployed precompile address before mainnet

🤖 _This response was generated by Claude Code._