### PR TITLE
fix(meteora): append prog_dynamic_amm as trailing meta on Rome CPI

### DIFF
--- a/contracts/meteora/damm_v1_pool.sol
+++ b/contracts/meteora/damm_v1_pool.sol
@@ -823,12 +823,25 @@ library DAMMv1Lib {
         return bytes32(0);
     }
 
-    function build_swap_account_metas(SwapAccountsInput memory a)
+    /// @dev The 16th account (`prog_dynamic_amm`) is a Rome-EVM emulator
+    ///      workaround required by `rome-evm-private/emulator/src/state.rs`'s
+    ///      `ix_store` filter — see `contracts/bridge/ICCTP.sol:27-59` for the
+    ///      same pattern applied to CCTP outbound. The Meteora Anchor IDL
+    ///      stops at 15 accounts; trailing entries are ignored by the on-chain
+    ///      Anchor account-validation (per Solana's standard CPI ABI) but are
+    ///      required so Mollusk's `load_elf` can find the AMM program in the
+    ///      per-ix store during `eth_estimateGas`. Without it, gas-estimate
+    ///      reverts with `program account not found: <amm-id>` before
+    ///      reaching the actual swap dispatcher.
+    function build_swap_account_metas(
+        SwapAccountsInput memory a,
+        bytes32 prog_dynamic_amm
+    )
     internal
     pure
     returns (ICrossProgramInvocation.AccountMeta[] memory metas)
     {
-        metas = new ICrossProgramInvocation.AccountMeta[](15);
+        metas = new ICrossProgramInvocation.AccountMeta[](16);
 
         metas[0] = ICrossProgramInvocation.AccountMeta(a.pool, false, true);
         metas[1] = ICrossProgramInvocation.AccountMeta(
@@ -881,6 +894,11 @@ library DAMMv1Lib {
             false,
             false
         );
+        metas[15] = ICrossProgramInvocation.AccountMeta(
+            prog_dynamic_amm,
+            false,
+            false
+        );
     }
 
     function build_swap_ix_data(uint64 in_amount, uint64 minimum_out_amount)
@@ -891,12 +909,18 @@ library DAMMv1Lib {
         return abi.encodePacked(SWAP_PREFIX, Convert.u64le(in_amount), Convert.u64le(minimum_out_amount));
     }
 
-    function build_balance_liquidity_account_metas(BalanceLiquidityAccountsInput memory a)
+    /// @dev The 17th account (`prog_dynamic_amm`) is the same Rome-EVM
+    ///      emulator workaround applied in `build_swap_account_metas` —
+    ///      see comment there for the full rationale.
+    function build_balance_liquidity_account_metas(
+        BalanceLiquidityAccountsInput memory a,
+        bytes32 prog_dynamic_amm
+    )
     internal
     pure
     returns (ICrossProgramInvocation.AccountMeta[] memory metas)
     {
-        metas = new ICrossProgramInvocation.AccountMeta[](16);
+        metas = new ICrossProgramInvocation.AccountMeta[](17);
 
         metas[0] = ICrossProgramInvocation.AccountMeta(a.pool, false, true);
         metas[1] = ICrossProgramInvocation.AccountMeta(a.lp_mint, false, true);
@@ -914,6 +938,7 @@ library DAMMv1Lib {
         metas[13] = ICrossProgramInvocation.AccountMeta(a.user, true, false);
         metas[14] = ICrossProgramInvocation.AccountMeta(a.vault_program, false, false);
         metas[15] = ICrossProgramInvocation.AccountMeta(a.token_program, false, false);
+        metas[16] = ICrossProgramInvocation.AccountMeta(prog_dynamic_amm, false, false);
     }
 
     function build_add_balance_liquidity_ix_data(
@@ -1473,7 +1498,8 @@ contract ERC20DAMMv1Pool {
             internal_pool.make_swap_accounts_from_pool(
                 user,
                 in_token
-            )
+            ),
+            internal_pool.prog_dynamic_amm()
         );
 
         bytes memory data = DAMMv1Lib.build_swap_ix_data(uint64(amount_in), uint64(min_amount_out));
@@ -1505,7 +1531,8 @@ contract ERC20DAMMv1Pool {
 
         ICrossProgramInvocation.AccountMeta[] memory accounts =
             DAMMv1Lib.build_balance_liquidity_account_metas(
-                internal_pool.make_balance_liquidity_accounts_from_pool(user)
+                internal_pool.make_balance_liquidity_accounts_from_pool(user),
+                internal_pool.prog_dynamic_amm()
             );
 
         bytes memory data = DAMMv1Lib.build_remove_balance_liquidity_ix_data(
@@ -1545,7 +1572,8 @@ contract ERC20DAMMv1Pool {
                 internal_pool.make_balance_liquidity_accounts_from_pool_and_user_accounts(
                     user,
                     user_accounts
-                )
+                ),
+                internal_pool.prog_dynamic_amm()
             );
 
         bytes memory data = DAMMv1Lib.build_add_balance_liquidity_ix_data(


### PR DESCRIPTION
## Summary

`DAMMv1Pool.swapExactTokensForTokens` / `addLiquidity` / `removeLiquidity` build the inner Meteora ix's account-metas list strictly per Meteora's Anchor IDL (15 accounts for swap, 16 for liquidity), without the AMM program ID itself. The on-chain Solana CPI handles this fine — `ix.program_id` is implicit per Solana's standard CPI ABI and the runtime auto-loads the program — but the Rome EVM emulator's `ix_store` filter (`rome-evm-private/emulator/src/state.rs:565-582`) keeps only accounts that appear in the inner ix's metas list. The AMM program is therefore absent from the per-ix store handed to Mollusk, and `load_elf` returns `program account not found: <amm-id>` during `eth_estimateGas`.

This is the documented Rome convention since rome-evm-private #266 — see [`contracts/bridge/ICCTP.sol:27-59`](https://github.com/rome-protocol/rome-solidity/blob/master/contracts/bridge/ICCTP.sol#L27-L59) where `CCTPLib` appends a trailing emulator-workaround account for the same reason. `DAMMv1Pool` was the last meta-builder still violating it, which broke `PdaActivator.activate(...)` at gas-estimate time on every Rome chain.

## What changes

- `DAMMv1Lib.build_swap_account_metas` now takes `bytes32 prog_dynamic_amm` and writes it as `metas[15]` (size 15 → 16).
- `DAMMv1Lib.build_balance_liquidity_account_metas` now takes `bytes32 prog_dynamic_amm` and writes it as `metas[16]` (size 16 → 17).
- 3 callers in `DAMMv1Pool` (`swapExactTokensForTokens`, `addLiquidity`, `removeLiquidity`) updated to pass `internal_pool.prog_dynamic_amm()`.

Trailing accounts past the IDL count are ignored by Anchor's account-validation, so the on-chain Meteora swap is unaffected.

## End-to-end verification

Reproduced + verified on Marcus (post-revert proxy at SHA `5ccf53d`):

| Test | Inner-ix accounts | Result |
|---|---|---|
| Reproduces activate failure | `prog=AMM, metas=[non-AMM]` | `"program account not found: Eo7…UaB"` (matches activate flow) |
| Verifies fix path | `prog=AMM, metas=[AMM]` | `"mollusk Custom(100)"` — Meteora's own dispatch error, past `load_elf`, proves the filter passes the program through |

This change applies the same pattern to the real `DAMMv1Pool` callers.

## Companion / context

- [rome-evm-private #325](https://github.com/rome-protocol/rome-evm-private/pull/325) — the previous (incorrect) attempt to "fix" this in the emulator, which has been reverted by [#330](https://github.com/rome-protocol/rome-evm-private/pull/330). Marcus proxy + hercules already redeployed on the post-revert image (digest `sha256:221066b29d…`).

## Test plan

After merge:

1. Redeploy `DAMMv1Pool` (the chain's gas-pricing pool wrapper) on Marcus via existing deploy script.
2. Update Marcus registry entry with new pool address (or re-pin if same proxy/factory).
3. `cast estimate` on `PdaActivator.activate(0)` against Marcus — should now return a non-zero gas number.
4. End-to-end MetaMask flow: click Activate, sign tx, confirm PDA gets ≥ rent-exempt floor on Solana side.

## Cross-repo notes

- No ABI breakage for rome-ui — `swapExactTokensForTokens` / `addLiquidity` / `removeLiquidity` external signatures unchanged.
- Library function signatures changed (internal) — only `DAMMv1Pool` itself uses them.