### PR TITLE
fix(erc20users): restore ensure_user PDA-funding at rent-exempt floor

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -13,37 +13,32 @@ import {Convert} from "../convert.sol";
 contract ERC20Users {
     mapping (address => bytes32) private users;
 
-    /// @notice Idempotent registration of the user's unified PDA in the
-    ///         wrapper's `users` mapping.
+    /// @notice Lamports the proxy operator transfers to a user PDA on its
+    ///         first registration. Sized to the rent-exempt floor for an
+    ///         empty system-owned account (`(128 + 0) * 3480 * 2`).
+    uint64 private constant CREATE_PAYER_LAMPORTS = 890_880;
+
+    /// @notice Idempotent registration + PDA activation.
     /// @dev    Registers the caller-derived `external_auth(user)` PDA as
-    ///         the wrapper's record of `user`. The mapping is consulted
-    ///         by `approve` / `transferFrom` when treating the spender's
-    ///         PDA as an SPL Token delegate. Repeat calls are no-ops.
+    ///         the wrapper's record of `user`. On the first call for a
+    ///         given EVM address the operator-funded
+    ///         `RomeEVMAccount.create_payer` CPI transfers
+    ///         `CREATE_PAYER_LAMPORTS` to the PDA so it exists as a real
+    ///         Solana account at the rent-exempt floor — sufficient for
+    ///         it to act as `Signer<'info>` and hold rent for downstream
+    ///         operations (CCTP/Wormhole event accounts, etc.). Repeat
+    ///         calls are no-ops (`create_payer` short-circuits when the
+    ///         PDA already has ≥ requested lamports).
     ///
-    ///         **No PDA funding here.** PDA activation (turning the
-    ///         seed-derived address into a real Solana account with SOL
-    ///         lamports for rent-payer roles) is handled exclusively by
-    ///         `PdaActivator.activate{value: cost}()`, which charges the
-    ///         user from their gas balance via the WUSDC↔WSOL Romeswap
-    ///         pool and closes the resulting wSOL ATA into the user's
-    ///         PDA. The earlier operator-subsidized
-    ///         `RomeEVMAccount.create_payer(user, 50_000_000)` call has
-    ///         been removed — Sybil-vulnerable and antithetical to the
-    ///         "user pays for activation" design.
-    ///
-    ///         Most wrapper operations (transfer / approve / transferFrom
-    ///         / balanceOf / swap / liquidity) work without the PDA
-    ///         being activated — SPL Token signatures don't require the
-    ///         signer to hold lamports. Only operations that designate
-    ///         the user PDA as **rent payer** for new account creation
-    ///         (CCTP outbound's `messageSentEventData`, Wormhole
-    ///         outbound's message account, etc.) need a funded PDA. The
-    ///         UI surfaces an Activate button before those flows.
+    ///         The funding is operator-subsidized via
+    ///         `SystemProgram.operator()`, the same proxy SOL wallet
+    ///         that already pays `wrap_gas_to_spl`'s ATA-create rent.
     function ensure_user(address user) public returns (bytes32) {
         bytes32 existing_user = users[user];
         if (existing_user == bytes32(0)) {
             bytes32 new_user = RomeEVMAccount.get_payer(user);
             users[user] = new_user;
+            RomeEVMAccount.create_payer(user, CREATE_PAYER_LAMPORTS);
             return new_user;
         } else {
             return existing_user;


### PR DESCRIPTION
## Summary

One-line restore of the operator-funded \`RomeEVMAccount.create_payer\` call inside \`ERC20Users.ensure_user\` that was removed in commit \`5162a3c\` (the operator-subsidy cleanup).

On the first call for a given EVM address, the proxy operator transfers **\`CREATE_PAYER_LAMPORTS = 890,880\`** (the rent-exempt floor for an empty system-owned account) to the user's unified PDA, making it a real Solana account immediately. Subsequent calls are no-ops (\`create_payer\` short-circuits when the PDA already has ≥ requested lamports).

## Why

The \`5162a3c\` cleanup removed this funding under the assumption that \`PdaActivator.activate{value}()\` would replace it via a user-paid WUSDC↔WSOL Meteora swap. End-to-end testing today (debug-portal probe + \`cast estimate\`) exposed that \`PdaActivator\` **can't actually self-bootstrap**:

- Meteora's swap requires the destination WSOL ATA to exist on-chain.
- Creating that ATA needs ~2M lamports of SOL rent.
- The activator's PDA has 0 lamports — no SOL on Solana side.
- \`msg.value\` is in the chain's gas mint (USDC), not SOL.
- → Circular without the same operator subsidy the cleanup tried to drop.

The simplest, smallest path to a working flow is to restore the funding. **No new pool, no new subsidy mechanism — same proxy SOL wallet that already pays \`wrap_gas_to_spl\`'s ATA-create rent.**

## What changes

1 file, +19/−24 (mostly comment refresh; one line of new code):

\`\`\`diff
+    uint64 private constant CREATE_PAYER_LAMPORTS = 890_880;
+
     function ensure_user(address user) public returns (bytes32) {
         bytes32 existing_user = users[user];
         if (existing_user == bytes32(0)) {
             bytes32 new_user = RomeEVMAccount.get_payer(user);
             users[user] = new_user;
+            RomeEVMAccount.create_payer(user, CREATE_PAYER_LAMPORTS);
             return new_user;
         } else {
             return existing_user;
         }
     }
\`\`\`

## Sybil cost

Bounded to **one 890,880-lamport (~$0.00018) transfer per fresh EVM address** — the same shape as the pre-\`5162a3c\` model. Operator wallet sized accordingly. Mainnet operators can budget for it the same way they budget for \`wrap_gas_to_spl\`'s ATA-create rent today (already operator-subsidized).

If Sybil concerns ever escalate, the user-paid layer can sit *on top* of this floor (e.g. an Activate button that adds extra lamports beyond the floor) — but the floor itself has to come from somewhere, and the operator pool is the only place SOL can come from at first contact.

## Companion follow-ups (not in this PR)

- \`PdaActivator\` becomes redundant for the activation purpose. Keeping it as a no-op for now; can be deprecated/removed in a follow-up PR alongside cleaning up the WSOL wrapper / Meteora-pool wiring that only existed to feed it.
- \`ERC20DAMMv1Pool.swapExactTokensForTokens\` doesn't need the destination-ATA prep change discussed earlier — the activator's own WSOL ATA was the only blocker, and the activator is no longer the activation path.
- rome-ui's Activate CTA can stay (still useful as a UX prompt for the user's first interaction) but its underlying call can target any wrapper write — \`approve(0x0, 0)\` is one line — that triggers \`ensure_user\`.

## Test plan after merge

1. Redeploy \`ERC20Users\` on Marcus (or per-chain wherever this is consumed).
2. Trigger a fresh-EVM-address wrapper interaction (e.g. \`usdcWrapper.approve(some_addr, 0)\` from a never-activated EVM address).
3. \`solana account <derived_pda> --url <marcus solana rpc>\` — confirm exists with ≥ 890,880 lamports.
4. \`cast estimate\` on subsequent activation-gated flows (CCTP outbound, Wormhole outbound) — should no longer revert with PDA-not-funded errors.