### PR TITLE
fix(erc20spl): balanceOf returns 0 for missing ATA instead of reverting

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -218,6 +218,17 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // call) would mismatch and report 0 for any user whose tokens
         // arrived via a non-wrapper path.
         bytes32 ata = ICrossProgramInvocation(cpi_program).derive_user_ata(account, mint_id);
+        // ERC20-standard total: an address that has never received the
+        // token has balance 0, not a revert. When the user's ATA hasn't
+        // been initialized on Solana yet, account_u64_at(ata, 64) would
+        // revert with `account_u64_at: offset 64 + 8 out of 0 bytes`,
+        // forcing every consumer (DEX routers, allowance checks, wallet
+        // UIs that simulate balance reads on first-time wallets) to wrap
+        // balanceOf in try/catch. account_lamports is cheap (no data
+        // buffer pull) and returns 0 when the account doesn't exist.
+        if (ICrossProgramInvocation(cpi_program).account_lamports(ata) == 0) {
+            return 0;
+        }
         // SPL TokenAccount.amount is a u64 LE at offset 64.
         return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(ata, 64));
     }


### PR DESCRIPTION
## Summary
- Add a lamports==0 short-circuit to `SPL_ERC20.balanceOf` before the `account_u64_at(ata, 64)` read
- ERC20 standard semantics: an address with no tokens has balance 0, not a revert

## The bug
When the user's PDA-owned ATA hasn't been initialized on Solana yet, `account_u64_at` reverts with:
```
account_u64_at: offset 64 + 8 out of 0 bytes
```
Every consumer that simulates a balance read on a brand-new wallet (DEX routers, allowance checks, wallet UIs, indexers, third-party tools) has to wrap `balanceOf` in try/catch. That's leaking Rome-specific lifecycle into the standard ERC20 surface.

Discovered while building the chain-validation harness in rome-protocol/rome-ui#199 — the harness ships a `safeBalanceOf` workaround that this fix replaces upstream.

## The fix
Same pattern `ensure_token_account` already uses (lines 159-168) — probe `account_lamports` (cheap, no data buffer pull) and short-circuit when the account doesn't exist:

```solidity
if (ICrossProgramInvocation(cpi_program).account_lamports(ata) == 0) {
    return 0;
}
return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(ata, 64));
```

## Compatibility / no-regression
- The guard is purely additive: when `lamports != 0`, the existing read path is unchanged. Callers reading initialized ATAs see no behavior change.
- The guard catches only the previously-reverting case and returns 0 per ERC20 spec.
- Existing wrapper deployments retain pre-fix bytecode (CREATE2-immutable on the pair side, immutable wrappers on the SPL_ERC20 side). The fix lands on the next factory redeploy / first `add_spl_token_no_metadata` call on a fresh chain.
- Marcus's existing WUSDC + wETH wrappers stay buggy (per operator decision 2026-05-08 — no Marcus wrapper redeploy churn). New chains get clean ERC20 semantics from day one.

## Test plan
- [x] `npx hardhat compile` clean
- [x] Oracle parser unit tests pass
- [ ] After merge: any next chain bring-up's harness can drop the safeBalanceOf workaround for fresh-wallet runs

## Related
- rome-protocol/rome-ui#199 — chain-validation harness (merged) ships safeBalanceOf workaround that this fix replaces upstream
- PR #69 (closed) — predecessor with broader scope (balanceOf no-revert + ensure_user auto-register on every entry point); this PR is the minimal balanceOf-only fix