### PR TITLE
feat: add Aurelius real-testnet network to hardhat config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,6 +22,14 @@ export default defineConfig({
     },
   },
   networks: {
+    aurelius: {
+      type: "http",
+      chainType: "l1",
+      chainId: 30001,
+      url: "https://aurelius.real-testnet.romeprotocol.xyz/",
+      accounts: [configVariable("AURELIUS_PRIVATE_KEY")],
+    },
+
     augustus: {
       type: "http",
       chainType: "l1",


### PR DESCRIPTION
## Summary

First chain in the new `real-testnet` env (Rome on real Solana testnet, distinct from the existing `testnet` env which runs on Solana devnet). `chain_id 30001`.

Mirrors the augustus shape. RPC URL not reachable yet — GCP infra still pending (Phase 0 GCP project created, Phase 1 Terraform apply blocked on billing-account IAM).

## Background

- Rome EVM program: `RPTAqWeyJk1RFV3E4eDe1eMK9thPVoav7NBcFmmh2JP` (on Solana testnet)
- Chain registered on-chain: `OwnerInfo { chain: 30001, mint: EYsSA3ncqi…(test USDC), single_state: true }`
- Registry entries: rome-protocol/registry PR #68 (merged)
- bring-up-environment.sh accepts the new env: rome-protocol/rome-ops PR #322 (merged)

## Test plan

- [ ] `npx hardhat compile` passes (no functional change to contracts)
- [ ] Adding aurelius doesn't break the existing augustus/marcus/local/sepolia paths
- [ ] Once GCP infra lands and the RPC is reachable: `AURELIUS_PRIVATE_KEY=<key> npx hardhat run scripts/oracle/deploy.ts --network aurelius`
