### PR TITLE
feat(UserPda) + docs: route ata() through derive_user_ata precompile + document shortcut family

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,27 @@ The core abstraction layer. Rome-EVM exposes Solana programs as EVM precompiles 
 
 Global constants (`SplToken`, `AssociatedSplToken`, `SystemProgram`, `CpiProgram`, `Withdraw`) are pre-bound instances. Note: as of the rome-evm-private Mollusk refactor, `SplToken` and `AssociatedSplToken` no longer have dedicated precompile handlers — SPL operations are executed via Mollusk SVM in the emulator and CPI on-chain.
 
+**`CpiProgram` shortcut selectors** (rome-evm-private PRs #318 / #319 / #320, shipped 2026-05-06): the CPI precompile exposes six fast-path selectors that collapse common 2-3 syscall sequences into one:
+
+| Selector | Signature | Purpose |
+|---|---|---|
+| `0x593762e8` | `account_data_at(bytes32 pubkey, uint16 offset, uint16 length) → bytes` | Generic typed-slice read of any Solana account |
+| `0xb317d4c1` | `account_u64_at(bytes32 pubkey, uint16 offset) → uint64` | u64 LE read — saves ABI-encode roundtrip for the most common shape |
+| `0xde79ed54` | `account_lamports(bytes32 pubkey) → uint64` | Lamports-only probe — skips data buffer fetch |
+| `0x351aa22f` | `spl_transfer_checked_v1(src_ata, mint, dst_ata, amount, decimals, salts[]) → bool` | SPL Token Classic transfer signed by caller's unified PDA |
+| `0xc654e119` | `derive_user_ata(address evm_user, bytes32 mint) → bytes32` | Rome user PDA → SPL ATA in one syscall (replaces two `find_program_address` hops) |
+| `0x944336f8` | `pdas_batch_derive(bytes[][] seed_groups, bytes32 program_id) → (bytes32 pda, uint8 bump)[]` | N independent PDAs against one program in one dispatch (N ≤ 16, M ≤ 8 seeds) |
+
+Adoption status as of 2026-05-11:
+- **`derive_user_ata`**: live in production at 7 sites — `erc20spl.sol` (4: `getAta` / `_transfer` / `balanceOf` / `ensure_token_account`) and `RomeBridgeWithdraw.sol` (3: USDC + WETH burn paths). Verified on-chain against Marcus 121301: returns the correct ATA byte-for-byte vs off-chain two-hop derivation.
+- **`pdas_batch_derive`**: dispatched and verified on-chain (first-ever invocation on Marcus 121301 was 2026-05-11) but **zero production callers**. Cardo adapters that derive 3+ PDAs per call (Drift, Mango, Meteora, Raydium, Kamino) are the target consumers, as is the 12-findPda init sequence in `meteora/damm_v1_pool.sol _derive_permissionless_pool_with_config_keys`.
+- **v1 selectors** (`account_data_at`, `_u64_at`, `_lamports`, `spl_transfer_checked_v1`): adopted across `erc20spl` per rome-solidity PRs #109 / #110 / #112.
+- **`UserPda.ata(user, mint)`** library helper internally calls `derive_user_ata` — every consumer of the canonical helper inherits the saving without code changes.
+
+**Measured CU saving** (Marcus 121301, 3-sample average, 2026-05-11): a probe contract that does the OLD two-hop (`RomeEVMAccount.pda` + `AssociatedSplToken.get_associated_token_address_with_program_id`) consumed ~281K CU on Solana; the same probe via `CpiProgram.derive_user_ata` consumed ~129K CU — **~152K CU saved per call, 54 % reduction**. (PR #319's body claimed ~80K saving — measurement shows ~2 × more. EVM `gasUsed` is NOT a reliable proxy for Solana CU on Rome — use the Solana-side `computeUnitsConsumed` from the proxy's Solana tx receipt.) The bare `0xFF…07` `find_program_address` round-trip costs ~115K CU per hop end-to-end — far above the "1500 CU per `find_program_address` syscall" line in the [CU strategy spec](../rome-specs/active/technical/2026-04-25-rome-evm-cu-and-multi-hop-cpi-strategy.md), because of the EVM-side ABI marshaling + Solana atomic-tx wrapper overhead.
+
+When writing new wrappers or adapters, prefer these selectors over `0xFF…07` two-hop PDA derivation or `account_info` round-trips for individual field reads.
+
 ### Contract Layers
 
 - **`contracts/cpi/`** — Cardo CPI Foundation (library + templates). Shared Solidity helpers every Cardo app adapter builds on top of: `AccountMetaBuilder`, `AnchorInstruction`, `Cpi`, `PdaDeriver`, `SolanaConstants`, `UserPda`, `CostEstimate`, `CostEstimator`, `ICostView`, and the Pillar B cost-transparency trio. Also ships `templates/CpiAdapterBase.sol` (Ownable+Pausable+ReentrancyGuard+backend pointer scaffold) and `templates/CpiProgramWrapper.sol` (prose scaffold for golden-vector wrappers). See `contracts/cpi/README.md` for the adapter authoring guide, the three-layer pattern, and the `tx.origin`/`msg.sender` rule. Canonical spec: `rome-specs/active/technical/cardo-foundation.md`.

--- a/contracts/cpi/UserPda.sol
+++ b/contracts/cpi/UserPda.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {ISystemProgram, SystemProgram} from "../interface.sol";
+import {ISystemProgram, SystemProgram, ICrossProgramInvocation, CpiProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {AssociatedSplToken} from "../spl_token/associated_spl_token.sol";
 import {SolanaConstants} from "./SolanaConstants.sol";
@@ -28,14 +28,19 @@ library UserPda {
     /// classic SPL Token program (Tokenkeg...). Token-2022 ATAs use a
     /// different derivation; adapters that support Token-2022 call
     /// `ataWithProgram` directly.
+    ///
+    /// Delegates to the `derive_user_ata` CPI shortcut selector
+    /// (rome-evm-private #319, dispatched at `0xc654e119`) which combines
+    /// the Rome unified-user PDA + SPL ATA derivation into a single
+    /// syscall. Behavior is byte-identical to the prior two-hop path
+    /// through `0xFF…07` — verified on-chain against Marcus 121301 on
+    /// 2026-05-11 with EVM address `0xC777…2DAc` and USDC mint
+    /// `4zMMC9sr…ncDU` (resulting ATA `FkFYez2a…n8vw`).
+    ///
+    /// Saves ~152K Solana CU per call vs the two-hop path (3-sample
+    /// average on Marcus 121301: 281K → 129K, 54 % reduction).
     function ata(address user, bytes32 mint) internal view returns (bytes32) {
-        bytes32 owner = pda(user);
-        return AssociatedSplToken.get_associated_token_address_with_program_id(
-            owner,
-            mint,
-            SolanaConstants.SPL_TOKEN_PROGRAM,
-            SolanaConstants.ASSOCIATED_TOKEN_PROGRAM
-        );
+        return CpiProgram.derive_user_ata(user, mint);
     }
 
     /// Derive an ATA for a raw Solana pubkey (pool-side, fee receiver, etc.).


### PR DESCRIPTION
## Summary

Two changes:

1. **\`contracts/cpi/UserPda.sol\`** — \`UserPda.ata(user, mint)\` now delegates to the \`CpiProgram.derive_user_ata\` shortcut (rome-evm-private [#319](https://github.com/rome-protocol/rome-evm-private/pull/319), selector \`0xc654e119\`). Replaces the prior two-hop derivation (\`RomeEVMAccount.pda(user)\` + \`AssociatedSplToken.get_associated_token_address_with_program_id(...)\`) — single \`0xFF…08\` dispatch vs two \`0xFF…07\` round-trips.
2. **\`CLAUDE.md\`** — new \"CpiProgram shortcut selectors\" section enumerating all six selectors (\`account_data_at\`, \`account_u64_at\`, \`account_lamports\`, \`spl_transfer_checked_v1\`, \`derive_user_ata\`, \`pdas_batch_derive\`) with adoption status + measured saving. Surfaces the family so new adapter authors don't re-do the slow \`0xFF…07\` two-hop dance.

## Correctness

Behavior is byte-identical to the prior path. Verified on-chain against Marcus 121301 on 2026-05-11:
- EVM address \`0xC777e98a3e1F87c33E2A8F46c45E27d7Df022DAc\`
- USDC mint \`4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU\`
- Both \`UserPda.ata\` and direct off-chain two-hop return ATA \`FkFYez2ad2Wzf4p1R7mFg8VQNGVRP5xoXRGPM1tZn8vw\` = bytes32 \`0xdb1809e96dac71bf35af2b5aadaba53094d58ccf6da13700bad0501fbb0a501c\`

## Measured CU saving

A probe contract was deployed on Marcus 121301 with two functions: \`probe_two_hop\` (uses \`RomeEVMAccount.pda\` + \`AssociatedSplToken.get_associated_token_address_with_program_id\`) and \`probe_shortcut\` (uses \`CpiProgram.derive_user_ata\`). 3-sample average:

| Path | Solana CU (avg) |
|---|---|
| Two-hop via 0xFF…07 | **~281K** |
| Shortcut via 0xFF…08 | **~129K** |
| **Saving** | **~152K CU per call (54%)** |

PR [#319](https://github.com/rome-protocol/rome-evm-private/pull/319) body claimed ~80K saving — actual is ~2× higher. EVM \`gasUsed\` is NOT a faithful proxy for Solana CU on Rome (it reports either an estimate or a flat default depending on path); the numbers above come from the corresponding Solana tx receipts' \`computeUnitsConsumed\`.

## Adoption status (existing production code, unchanged)

\`derive_user_ata\` is already directly called at 7 sites without going through \`UserPda\`:
- \`erc20spl.sol\` (4): \`getAta\` / \`_transfer\` / \`balanceOf\` / \`ensure_token_account\`
- \`RomeBridgeWithdraw.sol\` (3): USDC + 2× WETH burn paths

The only caller of \`UserPda.ata\` today is \`contracts/cpi/test/UserPdaWrapper.sol\`. The library flip is defensive — closes the slow-path footgun for future adapter authors who pick up the canonical helper.

\`pdas_batch_derive\` has **zero production callers anywhere**. CLAUDE.md flags \`meteora/damm_v1_pool.sol _derive_permissionless_pool_with_config_keys\` (12 sequential \`find_program_address\` calls during pool init) as a target consumer for a follow-up PR.

## Companion PRs

- monorepo CLAUDE.md surface: https://github.com/rome-protocol/rome/pull/152
- rome-evm-private docs + stale-comment fix: https://github.com/rome-protocol/rome-evm-private/pull/345
- compound-on-rome-comet \`AtaDeriver\` library flip (follow-up)

## Test plan

- [x] \`npx hardhat compile\` — 69 Solidity files, clean
- [x] \`npx hardhat test tests/cpi/UserPda.test.ts\` — 3/3 passing
- [ ] Live Marcus / Aurelius wrapper smoke (existing flows unaffected since prod sites bypass \`UserPda.ata\`)