### PR TITLE
fix(hardhat): aurelius RPC URL — testnet zone (drops real-testnet)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       type: "http",
       chainType: "l1",
       chainId: 30001,
-      url: "https://aurelius.real-testnet.romeprotocol.xyz/",
+      url: "https://aurelius.testnet.romeprotocol.xyz/",
       accounts: [configVariable("AURELIUS_PRIVATE_KEY")],
     },
 


### PR DESCRIPTION
## Summary

Follow-up to registry PR rome-protocol/registry#70 reverting the `real-testnet` namespace separation for Aurelius. The chain is internal-only and now lives in the existing `testnet` Rome env / DNS zone.

`url: aurelius.real-testnet.romeprotocol.xyz → aurelius.testnet.romeprotocol.xyz`

chain_id 30001, Solana cluster testnet, program RPTAqWey… all unchanged — just the DNS subdomain shifts to the existing testnet zone (saves the one-time AWS Route 53 NS delegation that the real-testnet zone would have needed).
