### PR TITLE
perf(erc20spl): route bridgeOutToSolana source-ATA through derive_user_ata — ~145K CU

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -394,24 +394,29 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         require(value <= type(uint64).max, "Bridge amount exceeds uint64");
         require(solana_recipient != bytes32(0), "Solana recipient cannot be zero");
 
-        // Single unified user PDA per EVM address (post-0acabea):
-        //   userPda = find_program_address([EXTERNAL_AUTHORITY, evmAddr])
-        // Signs CPIs, owns ATAs (bridged-in and wrap-funded land here),
-        // and pays rent for new accounts. Pre-existing wrappers may
-        // expose a legacy `_users.get_user` mapping that historically
-        // returned PAYER_PDA (a salted sub-PDA); under the unified
-        // model, that mapping returns userPda — same value as
-        // RomeEVMAccount.pda(msg.sender). bridgeOutToSolana takes the
-        // direct path via RomeEVMAccount.pda to skip the mapping lookup.
-        bytes32 authority_pda = RomeEVMAccount.pda(msg.sender);
-        bytes32 from_ata = UserPda.ataForKey(authority_pda, mint_id);
+        // Source ATA = unified-user-PDA's ATA for this mint. Single CPI
+        // via the `derive_user_ata` shortcut selector (`0xc654e119` on
+        // the CPI precompile at `0xFF…08`), which composes
+        //   find_program_address([EXTERNAL_AUTHORITY, evmAddr], rome_evm)
+        // and
+        //   find_program_address([ownerPda, SPL_TOKEN, mint], ata_program)
+        // into one syscall. Replaces the prior two-hop derivation
+        // (`RomeEVMAccount.pda(msg.sender)` + `UserPda.ataForKey(...)`)
+        // — measured saving of ~145K Solana CU per call on Marcus 121301
+        // (controlled probe 2026-05-11: 270K → 125K). Byte-identical to
+        // the prior path: the shortcut runs the same two
+        // `find_program_address` syscalls in native Rust, returning the
+        // same `(ATA, bump)` for a given `(user, mint)`.
+        bytes32 from_ata = ICrossProgramInvocation(cpi_program).derive_user_ata(msg.sender, mint_id);
 
         // Recipient ATA — derive only. Caller must pre-create on Solana
         // if it doesn't exist (use ensureRecipientAta below as a separate
         // tx). Adding the in-tx ATA-create CPI failed on rome-evm's
         // CPI emulator (the two-CPI sequence reverts at sim time even
         // though the contract logic is correct). Single CPI (transfer
-        // only) works reliably on chain.
+        // only) works reliably on chain. Stays on `UserPda.ataForKey`
+        // because `solana_recipient` is a raw Solana pubkey (not an
+        // EVM-mapped address) — `derive_user_ata` doesn't apply.
         bytes32 to_ata = UserPda.ataForKey(solana_recipient, mint_id);
 
         // SPL transfer_checked from AUTHORITY_PDA's ATA → recipient's ATA.
@@ -419,10 +424,9 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // data in Rust (saves ~250k CU vs the Solidity SplTokenLib helper)
         // and signs as the precompile-caller's unified PDA when salts is
         // empty. Delegatecall preserves caller = msg.sender, so the signer
-        // resolves to `external_auth(msg.sender)` = `authority_pda` =
-        // owner of `from_ata`. Direct authority match — no delegation,
+        // resolves to `external_auth(msg.sender)` — the same unified PDA
+        // that owns `from_ata`. Direct authority match — no delegation,
         // no salts.
-        authority_pda;  // owner of from_ata; precompile auto-derives same value
         (bool success, bytes memory result) = address(cpi_program).delegatecall(
             abi.encodeWithSignature(
                 "spl_transfer_checked_v1(bytes32,bytes32,bytes32,uint64,uint8,bytes32[])",


### PR DESCRIPTION
## Summary

\`SPL_ERC20.bridgeOutToSolana\` (\`contracts/erc20spl/erc20spl.sol\`) was the last slow-path call site in this file. It derived the source ATA via two separate precompile calls — \`RomeEVMAccount.pda(msg.sender)\` + \`UserPda.ataForKey(authority_pda, mint_id)\`, both routed through the system precompile at \`0xFF…07\`. Every other erc20spl call site (\`getAta\`, \`_transfer\`, \`balanceOf\`, \`ensure_token_account\` — 4 sites) already uses the \`derive_user_ata\` shortcut at \`0xc654e119\`. This PR closes the gap.

## Correctness

Behavior is byte-identical. The shortcut runs the same two \`find_program_address\` syscalls in native Rust and returns the same \`(ATA, bump)\` for a given \`(msg.sender, mint_id)\`. The unified PDA the SPL transfer signs as (\`external_auth(msg.sender)\`) is unchanged. No ABI change; rome-ui's [\`useOutboundSplBridge\`](https://github.com/rome-protocol/rome-ui/blob/main/src/features/bridge/hooks/useOutboundSplBridge.ts) is unaffected.

The recipient ATA at line 415 stays on \`UserPda.ataForKey(solana_recipient, mint_id)\` because \`solana_recipient\` is a raw Solana pubkey, not an EVM-mapped address — \`derive_user_ata\` doesn't apply.

## Measured CU saving

Marcus 121301 devnet, controlled fresh-input pairs, 2026-05-11:

| Path | Solana CU |
|---|---|
| Two-hop (current \`bridgeOutToSolana\`) | **~270K** |
| Shortcut (this PR) | **~125K** |
| **Saved per outbound bridge tx** | **~145K CU (~54%)** |

Measurement: a probe contract on Marcus 121301 with the OLD pattern (\`RomeEVMAccount.pda + UserPda.ataForKey\`) and the NEW pattern (\`CpiProgram.derive_user_ata\`), each fired 3+ times with distinct \`(user, mint)\` inputs, \`computeUnitsConsumed\` read from the Solana tx receipts. Cache effects ruled out via reversed-order and fresh-user scenarios — the saving holds in every ordering.

## User-visible impact

After this PR lands AND the wrappers on Marcus are redeployed, rome-ui's "Rome → Solana wrapper bridge" flow (every wrapper, including wUSDC / wETH / future native ERC20-SPL wrappers) drops ~145K Solana CU per outbound tx.

Wrappers on Marcus currently deployed at:
- \`SPL_ERC20_USDC\` \`0xddbb7d989b70ed93ca0849c0b9a007f6e0009359\`
- \`SPL_ERC20_WETH\` \`0x1551cb2767291d033da2e242fd69bc86428c5d64\`

Both need to be redeployed against the post-merge bytecode for users to see the saving on the live chain. Same redeploy script as before (\`scripts/bridge/deploy.ts --network marcus\`), and the new addresses land in the registry via the existing per-chain \`/publish-registry-pr\` flow. rome-ui picks up the new addresses on the next backend cache cycle.

## What this does NOT change

- \`RomeEVMAccount.pda(msg.sender)\` callers in other paths (e.g., \`RomeBridgeWithdraw\` uses it for CPI signer seeds, not for ATA) — those still need the unified PDA as a value, and there's no precompile shortcut for "just hop 1" today.
- The \`solana_recipient\` ATA derivation (line 415) — raw pubkey input, \`derive_user_ata\` is EVM-address-typed and doesn't apply.

## Test plan

- [x] \`npx hardhat compile\` — 69 Solidity files, clean
- [x] \`npx hardhat test tests/cpi/UserPda.test.ts\` — 3/3 passing (unaffected)
- [ ] Live Marcus verification post-redeploy: fire one \`wrapper.bridgeOutToSolana\` from rome-ui, read \`computeUnitsConsumed\` from the Solana receipt, compare to a pre-redeploy baseline tx. Expected delta: -145K CU.

## References

- \`derive_user_ata\` shortcut family + measured-CU note: \`CLAUDE.md\` "CpiProgram shortcut selectors" section (#129)
- AtaDeriver-flip sibling in compound-on-rome-comet: rome-protocol/compound-on-rome-comet#11