### PR TITLE
restore(hardhat): aurelius RPC URL — real-testnet zone

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       type: "http",
       chainType: "l1",
       chainId: 30001,
-      url: "https://aurelius.testnet.romeprotocol.xyz/",
+      url: "https://aurelius.real-testnet.romeprotocol.xyz/",
       accounts: [configVariable("AURELIUS_PRIVATE_KEY")],
     },
 


### PR DESCRIPTION
## Summary
- Reverts #130.
- AWS Route 53 NS delegation for `real-testnet.romeprotocol.xyz` is now in place; Aurelius serves at `https://aurelius.real-testnet.romeprotocol.xyz` (`eth_chainId` 0x7531 verified).
- Points hardhat back at that hostname.

## Test plan
- [x] `curl https://aurelius.real-testnet.romeprotocol.xyz` returns 30001 chain id.