### PR TITLE
ops(aurelius): register wUSDC + wSOL wrappers on Aurelius

### DIFF
--- a/deployments/aurelius.json
+++ b/deployments/aurelius.json
@@ -2,5 +2,21 @@
   "ERC20SPLFactory": {
     "address": "0xd15c0c4ec4e997a044308a6c710222a69d909468",
     "cpiContractAddress": "0xFF00000000000000000000000000000000000008"
+  },
+  "WUSDC": {
+    "address": "0x8c9e878433657b894c5cd74be9e522f54dad7796",
+    "mint": "EYsSA3ncqiiT3GzVEYf3AHb3Fi8SiWNXEDWia54PSjtR",
+    "mintBytes32": "0xc951f5f196c671888529d8b3948aa93fac61c982847d0a30f7616a474ce2c836",
+    "name": "Rome USDC",
+    "symbol": "wUSDC",
+    "deployTx": "0x306367f0a2821e127284655004cd0865d30bbb2f3559006f73c487d6581bba81"
+  },
+  "WSOL": {
+    "address": "0x598eb42a8d6648d06e39839d3edd303b95ab6ec8",
+    "mint": "So11111111111111111111111111111111111111112",
+    "mintBytes32": "0x069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001",
+    "name": "Rome SOL",
+    "symbol": "wSOL",
+    "deployTx": "0x1c52ee83e891fad9df3b8d9fdce85c78098ce159d5c419ccc32b3c460a5984b5"
   }
 }


### PR DESCRIPTION
## Summary

Adds wUSDC + wSOL wrapper addresses to \`deployments/aurelius.json\` after bootstrapping them on Aurelius via \`factory.add_spl_token_no_metadata\`. Both required as constructor params for the upcoming SimpleActivator deploy.

| Wrapper | Address | Underlying mint | Deploy tx |
|---|---|---|---|
| wUSDC | \`0x8c9e878433657b894c5cd74be9e522f54dad7796\` | \`EYsSA3ncqiiT3GzVEYf3AHb3Fi8SiWNXEDWia54PSjtR\` (Aurelius gas) | [\`0x30636…\`](https://aurelius.real-testnet.romeprotocol.xyz/) |
| wSOL  | \`0x598eb42a8d6648d06e39839d3edd303b95ab6ec8\` | \`So11111111111111111111111111111111111111112\` (canonical) | [\`0x1c52e…\`](https://aurelius.real-testnet.romeprotocol.xyz/) |

Both registered from the real-testnet-aurelius deployer (\`0x611101385Cf27ccAd096D18991DFd94E002Ca8f1\`) using \`cast send\` with \`--gas-limit 100000000 --gas-price 1\` (the proxy's eth_estimateGas rejected the original viem call with a duplicate-data JSON parse error, so we override).

## Why not via the bootstrap script

\`scripts/bridge/bootstrap-bridged-wrappers.ts\` has hardcoded devnet mints (\`4zMMC9srt5…\` for USDC, Wormhole WETH on devnet) that don't match Aurelius's gas mint or Solana testnet. Calling the factory directly was the cleanest workaround for now; a follow-up should refactor the script to read mints from a per-chain config so future Aurelius-shaped bring-ups get one-command bootstrap.

## Unblocks

\`activation-deploy\` workflow against real-testnet-aurelius — reads \`.WUSDC.address\` + \`.WSOL.address\` from this file.