### PR TITLE
fix(activation): write SimpleActivator deploy to deployments/<network>.json

### DIFF
--- a/scripts/activation/deploy-simple-activator.ts
+++ b/scripts/activation/deploy-simple-activator.ts
@@ -9,8 +9,14 @@
 //   - users           (ERC20Users)    — shared users mapping (from factory.users())
 //
 // Reads the wrapper + users addresses from env / sensible defaults.
+//
+// Writes deployment record to deployments/<network>.json under the
+// SimpleActivator key, matching the bridge / oracle / meteora convention. The
+// contract-deploys activation-deploy.yml workflow PRs this file back to
+// rome-solidity master after a CI deploy.
 
 import hardhat from "hardhat";
+import { readDeployments, writeDeployments } from "../lib/deployments.js";
 
 // Three-call activation: 1 USDC for activate(), 0.5 USDC for each
 // ATA-create call. Total user cost = 1 + 0.5 + 0.5 = 2 USDC,
@@ -59,11 +65,28 @@ async function main() {
   ]);
   console.log(`  address: ${activator.address}`);
 
+  // Persist deployment record to deployments/<network>.json so the
+  // contract-deploys activation-deploy.yml workflow PR-back step has a
+  // non-empty diff. Matches bridge / oracle / meteora convention.
+  const existing = readDeployments(networkName);
+  existing.SimpleActivator = {
+    address: activator.address,
+    activationCostWei: ACTIVATION_COST_WEI.toString(),
+    tokenAccountsCostWei: TOKEN_ACCOUNTS_COST_WEI.toString(),
+    usdcWrapper,
+    wsolWrapper,
+    users: usersAddr,
+    deployedAt: Math.floor(Date.now() / 1000),
+  };
+  writeDeployments(networkName, existing);
+  console.log(`  recorded in deployments/${networkName}.json`);
+
   console.log("\nNext steps:");
-  console.log(`  1. Update debug-portal/activate.html simpleActivator default.`);
-  console.log(`  2. From a fresh EVM address: UI fires activate() (1 USDC), createWusdcAta() (0.5 USDC), createWsolAta() (0.5 USDC) sequentially.`);
-  console.log(`  3. Verify on-chain: PDA exists with 890,880 lamports, WUSDC + WSOL ATAs both exist owned by PDA.`);
-  console.log(`  4. Then: try a Meteora swap from the same wallet — destination ATA exists now, should succeed.`);
+  console.log(`  1. Merge the contract-deploys PR-back to rome-solidity master.`);
+  console.log(`  2. Update chain.contracts.simpleActivator in registry/chains/<id>-<slug>/contracts.json.`);
+  console.log(`  3. Bump rome_ui_registry_ref in the chain's rome-ui inventory + redeploy rome-ui so ActivationGate picks up the new address.`);
+  console.log(`  4. From a fresh EVM address: UI fires activate() (1 USDC), createWusdcAta() (0.5 USDC), createWsolAta() (0.5 USDC) sequentially.`);
+  console.log(`  5. Verify on-chain: PDA exists with 890,880 lamports, WUSDC + WSOL ATAs both exist owned by PDA.`);
 }
 
 main().catch((err) => {

--- a/scripts/lib/deployments.ts
+++ b/scripts/lib/deployments.ts
@@ -26,11 +26,22 @@ export type ERC20SPLFactoryDeployment = {
     cpiContractAddress?: string;
 };
 
+export type SimpleActivatorDeployment = {
+    address: string;
+    activationCostWei: string;
+    tokenAccountsCostWei: string;
+    usdcWrapper: string;
+    wsolWrapper: string;
+    users: string;
+    deployedAt: number;
+};
+
 export type DeploymentsFile = {
     MeteoraDAMMv1Factory?: FactoryDeployment;
     MeteoraDAMMv1Router?: RouterDeployment;
     MeteoraDAMMv1Pools?: PoolDeployment[];
     ERC20SPLFactory?: ERC20SPLFactoryDeployment;
+    SimpleActivator?: SimpleActivatorDeployment;
 };
 
 export function deploymentsFilePath(networkName: string): string {


### PR DESCRIPTION
## Summary

Latent bug uncovered while tracing why \`/deploy-solidity SimpleActivator --via-ci\` doesn't end-to-end produce a registry-ready PR.

\`scripts/activation/deploy-simple-activator.ts\` prints the activator address to stdout but never writes a record to \`deployments/<network>.json\`. The contract-deploys \`activation-deploy.yml\` workflow (shipped in #10) has an \`add-paths: deployments/<network>.json\` step on the PR-back — with the script silent on disk, that PR-back produced an empty diff and no canonical record landed in master.

Fix matches the bridge / oracle / meteora convention:

- Extends \`DeploymentsFile\` in \`scripts/lib/deployments.ts\` with a \`SimpleActivator\` entry (address + cost params + wrapper refs + resolved users() + deployedAt).
- Reads existing \`deployments/<network>.json\` (or treats as empty), merges in the SimpleActivator block, writes back via the helper.

Also refreshes the stale "Next steps" copy: drops the \`debug-portal/activate.html\` reference (the rome-ui \`ActivationGate\` is the production consumer; debug-portal is a debug page), adds the registry + rome-ui follow-up steps the operator owns post-merge.

## Test plan

- [x] Compile: \`npx hardhat compile\` (touches script-side imports only; ABI unchanged)
- [ ] Run end-to-end via CI workflow against \`testnet-marcus\` or \`real-testnet-aurelius\` once merged; verify the PR-back to rome-solidity has a non-empty diff
- [ ] Verify the deployments/<network>.json shape is consumable by tooling that reads it (e.g. registry add-chain CLI)

## Companion PRs

- \`rome-protocol/rome-ops\` — \`scripts/deploy-solidity.sh\` \`contract_workflow\` lookup maps \`SimpleActivator → activation-deploy.yml\`
- \`rome-protocol/rome\` — \`/deploy-solidity\` SKILL flips the "local-only" badge for SimpleActivator