### PR TITLE
fix: parameterize USDC/WSOL wrappers from deployments, remove hardcoded marcus addresses (Closes #125)

### DIFF
--- a/scripts/activation/deploy-simple-activator.ts
+++ b/scripts/activation/deploy-simple-activator.ts
@@ -8,7 +8,8 @@
 //   - wsolWrapper     (SPL_ERC20)     — canonical wSOL wrapper
 //   - users           (ERC20Users)    — shared users mapping (from factory.users())
 //
-// Reads the wrapper + users addresses from env / sensible defaults.
+// Reads the wrapper + users addresses from deployments/<network>.json
+// (env vars as override). Hardcoded chain defaults removed — see issue #125.
 //
 // Writes deployment record to deployments/<network>.json under the
 // SimpleActivator key, matching the bridge / oracle / meteora convention. The
@@ -16,7 +17,13 @@
 // rome-solidity master after a CI deploy.
 
 import hardhat from "hardhat";
-import { readDeployments, writeDeployments } from "../lib/deployments.js";
+import {
+  readDeployments,
+  writeDeployments,
+  resolveWusdcWrapperAddress,
+  resolveWsolWrapperAddress,
+  resolveERC20SPLFactoryAddress,
+} from "../lib/deployments.js";
 
 // Three-call activation: 1 USDC for activate(), 0.5 USDC for each
 // ATA-create call. Total user cost = 1 + 0.5 + 0.5 = 2 USDC,
@@ -32,16 +39,13 @@ async function main() {
     throw new Error("No deployer wallet — set <NETWORK>_PRIVATE_KEY");
   }
 
-  // Marcus 121301 defaults — override via env for other chains.
-  const usdcWrapper =
-    (process.env.USDC_WRAPPER as `0x${string}`) ||
-    "0x39844f1d605a11acd87f766494291bbd11b406f4";
-  const wsolWrapper =
-    (process.env.WSOL_WRAPPER as `0x${string}`) ||
-    "0xc180a9133770d48f33cBDe630205a7B7DDA48fF6";
-  const factory =
-    (process.env.ERC20_SPL_FACTORY as `0x${string}`) ||
-    "0xbd0a59183cd4178b8b000036c64c7aeef4619be1";
+  // Resolve wrapper + factory addresses from deployments/<network>.json.
+  // Falls back to env vars (USDC_WRAPPER / WSOL_WRAPPER / ERC20_SPL_FACTORY_ADDRESS).
+  // Aborts with a clear error if neither source is available — no more
+  // hardcoded chain defaults (see #125).
+  const usdcWrapper = resolveWusdcWrapperAddress(networkName);
+  const wsolWrapper = resolveWsolWrapperAddress(networkName);
+  const factory = resolveERC20SPLFactoryAddress(networkName);
 
   // Read users() from the factory.
   const factoryContract = await viem.getContractAt("ERC20SPLFactory", factory);

--- a/scripts/lib/deployments.ts
+++ b/scripts/lib/deployments.ts
@@ -26,6 +26,24 @@ export type ERC20SPLFactoryDeployment = {
     cpiContractAddress?: string;
 };
 
+export type WusdcDeployment = {
+    address: string;
+    mint: string;
+    mintBytes32: string;
+    name: string;
+    symbol: string;
+    deployTx: string;
+};
+
+export type WsolDeployment = {
+    address: string;
+    mint: string;
+    mintBytes32: string;
+    name: string;
+    symbol: string;
+    deployTx: string;
+};
+
 export type SimpleActivatorDeployment = {
     address: string;
     activationCostWei: string;
@@ -41,6 +59,8 @@ export type DeploymentsFile = {
     MeteoraDAMMv1Router?: RouterDeployment;
     MeteoraDAMMv1Pools?: PoolDeployment[];
     ERC20SPLFactory?: ERC20SPLFactoryDeployment;
+    WUSDC?: WusdcDeployment;
+    WSOL?: WsolDeployment;
     SimpleActivator?: SimpleActivatorDeployment;
 };
 
@@ -254,5 +274,77 @@ export function resolveERC20SPLFactoryAddress(networkName: string): `0x${string}
 
     throw new Error(
         `ERC20SPLFactory address not found. Set ERC20_SPL_FACTORY_ADDRESS or create deployments/${networkName}.json`,
+    );
+}
+
+export function readWusdcWrapperAddressFromDeployments(networkName: string): `0x${string}` | null {
+    const parsed = readDeployments(networkName);
+    const address = parsed.WUSDC?.address;
+
+    if (!address) {
+        return null;
+    }
+
+    if (!isAddress(address)) {
+        throw new Error(
+            `Invalid WUSDC.address in deployments/${networkName}.json: ${address}`,
+        );
+    }
+
+    return getAddress(address);
+}
+
+export function resolveWusdcWrapperAddress(networkName: string): `0x${string}` {
+    const envAddress = process.env.USDC_WRAPPER;
+    if (envAddress) {
+        if (!isAddress(envAddress)) {
+            throw new Error(`Invalid USDC_WRAPPER: ${envAddress}`);
+        }
+        return getAddress(envAddress);
+    }
+
+    const fromFile = readWusdcWrapperAddressFromDeployments(networkName);
+    if (fromFile) {
+        return fromFile;
+    }
+
+    throw new Error(
+        `WUSDC wrapper address not found. Set USDC_WRAPPER env var or deploy WUSDC via bootstrap-bridged-wrappers.ts (writes deployments/${networkName}.json).`,
+    );
+}
+
+export function readWsolWrapperAddressFromDeployments(networkName: string): `0x${string}` | null {
+    const parsed = readDeployments(networkName);
+    const address = parsed.WSOL?.address;
+
+    if (!address) {
+        return null;
+    }
+
+    if (!isAddress(address)) {
+        throw new Error(
+            `Invalid WSOL.address in deployments/${networkName}.json: ${address}`,
+        );
+    }
+
+    return getAddress(address);
+}
+
+export function resolveWsolWrapperAddress(networkName: string): `0x${string}` {
+    const envAddress = process.env.WSOL_WRAPPER;
+    if (envAddress) {
+        if (!isAddress(envAddress)) {
+            throw new Error(`Invalid WSOL_WRAPPER: ${envAddress}`);
+        }
+        return getAddress(envAddress);
+    }
+
+    const fromFile = readWsolWrapperAddressFromDeployments(networkName);
+    if (fromFile) {
+        return fromFile;
+    }
+
+    throw new Error(
+        `WSOL wrapper address not found. Set WSOL_WRAPPER env var or deploy WSOL via bootstrap-bridged-wrappers.ts (writes deployments/${networkName}.json).`,
     );
 }


### PR DESCRIPTION
## Summary

Fixes #125 by removing hardcoded marcus-chain addresses from `deploy-simple-activator.ts` and reading wrapper/factory addresses from `deployments/<network>.json` instead.

## Problem

`scripts/activation/deploy-simple-activator.ts` had hardcoded marcus-chain addresses as fallbacks for `usdcWrapper`, `wsolWrapper`, and `factory`. On non-marcus chains (e.g., augustus), the script crashes when calling `users()` against an address that doesn't exist on that chain.

## Fix

### `scripts/lib/deployments.ts`
- Added `WusdcDeployment` and `WsolDeployment` types matching the bridge deployment record format.
- Added `WUSDC` and `WSOL` to `DeploymentsFile` type.
- Added `resolveWusdcWrapperAddress()` and `resolveWsolWrapperAddress()` helpers (env var -> deployments file -> clear error).

### `scripts/activation/deploy-simple-activator.ts`
- Replaced hardcoded address fallbacks with `resolveWusdcWrapperAddress(networkName)`, `resolveWsolWrapperAddress(networkName)`, and `resolveERC20SPLFactoryAddress(networkName)`.
- Removed the hardcoded marcus addresses entirely.
- The script now aborts with a clear error message naming the missing deployment entry instead of crashing with an opaque RPC revert.

## Workaround for new chains

Bootstrap the wrappers first via `scripts/bridge/bootstrap-bridged-wrappers.ts` (which writes `WUSDC` / `WSOL` entries to `deployments/<network>.json`), or export `USDC_WRAPPER` + `WSOL_WRAPPER` + `ERC20_SPL_FACTORY_ADDRESS` env vars before running the activator deploy.

Closes #125