### PR TITLE
fix(activator): point at SPL_ERC20_USDC/SPL_ERC20_WSOL keys + add WSOL to bootstrap

### DIFF
--- a/scripts/activation/deploy-simple-activator.ts
+++ b/scripts/activation/deploy-simple-activator.ts
@@ -34,7 +34,7 @@ const TOKEN_ACCOUNTS_COST_WEI = 500_000_000_000_000_000n;
 
 type AddressDep = {
   envVar: string;
-  deploymentsKey: "WUSDC" | "WSOL" | "ERC20SPLFactory";
+  deploymentsKey: "SPL_ERC20_USDC" | "SPL_ERC20_WSOL" | "ERC20SPLFactory";
   bootstrapHint: string;
 };
 
@@ -72,13 +72,13 @@ async function main() {
 
   const usdcWrapper = resolveAddress(networkName, {
     envVar: "USDC_WRAPPER",
-    deploymentsKey: "WUSDC",
+    deploymentsKey: "SPL_ERC20_USDC",
     bootstrapHint: "run scripts/bridge/bootstrap-bridged-wrappers.ts on this chain first",
   });
   const wsolWrapper = resolveAddress(networkName, {
     envVar: "WSOL_WRAPPER",
-    deploymentsKey: "WSOL",
-    bootstrapHint: "run scripts/bridge/deploy-wsol-v9.ts (or the canonical wSOL bootstrap) on this chain first",
+    deploymentsKey: "SPL_ERC20_WSOL",
+    bootstrapHint: "run scripts/bridge/bootstrap-bridged-wrappers.ts on this chain first (registers WSOL alongside USDC/WETH since 2026-05-13)",
   });
   const factory = resolveAddress(networkName, {
     envVar: "ERC20_SPL_FACTORY",

--- a/scripts/bridge/bootstrap-bridged-wrappers.ts
+++ b/scripts/bridge/bootstrap-bridged-wrappers.ts
@@ -35,18 +35,20 @@ type WrapperSpec = {
 const DEVNET_SET: WrapperSpec[] = [
   { key: "SPL_ERC20_USDC", mintBase58: SPL_MINTS_DEVNET.USDC_NATIVE,   name: "Rome USDC", symbol: "wUSDC" },
   { key: "SPL_ERC20_WETH", mintBase58: SPL_MINTS_DEVNET.WETH_WORMHOLE, name: "Rome ETH",  symbol: "wETH"  },
+  { key: "SPL_ERC20_WSOL", mintBase58: SPL_MINTS_DEVNET.WSOL_NATIVE,   name: "Rome SOL",  symbol: "wSOL"  },
 ];
 
 const MAINNET_SET: WrapperSpec[] = [
   { key: "SPL_ERC20_USDC", mintBase58: SPL_MINTS_MAINNET.USDC_NATIVE,   name: "Rome USDC", symbol: "wUSDC" },
   { key: "SPL_ERC20_WETH", mintBase58: SPL_MINTS_MAINNET.WETH_WORMHOLE, name: "Rome ETH",  symbol: "wETH"  },
+  { key: "SPL_ERC20_WSOL", mintBase58: SPL_MINTS_MAINNET.WSOL_NATIVE,   name: "Rome SOL",  symbol: "wSOL"  },
 ];
 
 // Networks targeting Solana DEVNET use SPL_MINTS_DEVNET; mainnet networks use
 // SPL_MINTS_MAINNET. Update this list whenever a new chain is brought up.
 // Override via `BRIDGED_SET=devnet|mainnet` env var for one-off cases.
 const DEVNET_NETWORKS = new Set([
-  "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "local",
+  "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "augustus", "local",
 ]);
 
 function resolveSet(networkName: string): WrapperSpec[] {

--- a/scripts/bridge/constants.ts
+++ b/scripts/bridge/constants.ts
@@ -30,9 +30,15 @@ export const SOLANA_PROGRAM_IDS_DEVNET = {
 } as const;
 
 // Canonical Phase 1 mainnet mints (Solana mainnet-beta) — used on mainnet deploys.
+// WSOL_NATIVE is the canonical wrapped-SOL mint — same pubkey on devnet AND
+// mainnet because it's effectively a one-off "wrap SOL → SPL" mint owned by
+// the SPL Token program itself. Included alongside USDC/WETH so
+// SimpleActivator's `WSOL_WRAPPER` + Romeswap's wSOL pool seeding have a
+// wrapper to point at after bring-up.
 export const SPL_MINTS_MAINNET = {
   USDC_NATIVE: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
   WETH_WORMHOLE: "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+  WSOL_NATIVE: "So11111111111111111111111111111111111111112",
 } as const;
 
 // Devnet mints — USDC is Circle's devnet USDC; wETH is the canonical
@@ -44,6 +50,7 @@ export const SPL_MINTS_MAINNET = {
 export const SPL_MINTS_DEVNET = {
   USDC_NATIVE: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
   WETH_WORMHOLE: "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs",
+  WSOL_NATIVE: "So11111111111111111111111111111111111111112",
 } as const;
 
 // Default export — points at devnet for now since active deploys target

--- a/scripts/lib/deployments.ts
+++ b/scripts/lib/deployments.ts
@@ -51,6 +51,16 @@ export type DeploymentsFile = {
     MeteoraDAMMv1Pools?: PoolDeployment[];
     ERC20SPLFactory?: ERC20SPLFactoryDeployment;
     SimpleActivator?: SimpleActivatorDeployment;
+    // Canonical bridged-asset wrapper keys written by
+    // scripts/bridge/bootstrap-bridged-wrappers.ts. Names match what other
+    // scripts (deploy-withdraw-on-existing-paymaster, redeploy-withdraw-*)
+    // already consume so the type stays consistent across the repo.
+    SPL_ERC20_USDC?: WrapperDeployment;
+    SPL_ERC20_WETH?: WrapperDeployment;
+    SPL_ERC20_WSOL?: WrapperDeployment;
+    // Legacy aliases kept for back-compat with hand-edited deployments
+    // produced before the SPL_ERC20_* convention. Don't write new code
+    // against these.
     WUSDC?: WrapperDeployment;
     WSOL?: WrapperDeployment;
 };


### PR DESCRIPTION
## Summary

After #140 dropped hardcoded Marcus fallbacks from `deploy-simple-activator.ts`, the script reads `WUSDC.address` / `WSOL.address` from `deployments/<network>.json`. Neither key is written by any canonical bootstrap script:

- `bootstrap-bridged-wrappers.ts` writes `SPL_ERC20_USDC` + `SPL_ERC20_WETH` (consumed by `deploy-withdraw-on-existing-paymaster.ts` + `redeploy-withdraw-*.ts` since bridge phase shipped).
- WSOL has no canonical bootstrap path at all — `deploy-wsol-v9.ts` deploys a bare `SPL_ERC20` but never writes a deployments entry.

So `npx hardhat run scripts/activation/deploy-simple-activator.ts` errored with `Cannot resolve WUSDC address for ...` on every chain except marcus (which had legacy hand-edited `WUSDC`/`WSOL` keys). Caught during the 2026-05-13 testnet rehearsal of Augustus.

## Changes

1. **`scripts/bridge/bootstrap-bridged-wrappers.ts`**: adds `SPL_ERC20_WSOL` to `DEVNET_SET` + `MAINNET_SET`, using canonical wSOL mint `So11111111111111111111111111111111111111112` (same on devnet+mainnet — it's the SPL Token program's own one-off wrap mint). `DEVNET_NETWORKS` adds `augustus` so the testnet env picks `DEVNET_SET` without a `BRIDGED_SET=devnet` env override. The bootstrap is idempotent — re-running on chains that already have wUSDC/wETH no-ops for those and adds wSOL fresh.

2. **`scripts/bridge/constants.ts`**: adds `WSOL_NATIVE` to both `SPL_MINTS_DEVNET` + `SPL_MINTS_MAINNET`.

3. **`scripts/activation/deploy-simple-activator.ts`**: switches the deployments-file lookup keys from `WUSDC` → `SPL_ERC20_USDC` and `WSOL` → `SPL_ERC20_WSOL`. The env-var precedence (`USDC_WRAPPER` / `WSOL_WRAPPER`) is unchanged.

4. **`scripts/lib/deployments.ts`**: widens `DeploymentsFile` with `SPL_ERC20_{USDC,WETH,WSOL}`; keeps `WUSDC`/`WSOL` aliases for back-compat with hand-edited marcus files.

## Bring-up impact

`rome-protocol/rome-ops#369` (separately) runs `bootstrap-bridged-wrappers.ts` + passes wrapper addresses as env vars to `deploy-simple-activator.ts`. With this PR, the wSOL wrapper is created automatically by bootstrap, so the activator resolves both wrappers without operator intervention on the next chain bring-up.

## Test plan

- [x] `npx tsc --noEmit` clean for the touched files (pre-existing errors in `scripts/oracle/*.ts` + `tests/damm_v1_pool.integration.ts` are unrelated)
- [ ] Next augustus/aurelius bring-up runs bootstrap-bridged-wrappers and produces `SPL_ERC20_WSOL` entry in `deployments/<network>.json`
- [ ] `deploy-simple-activator.ts` no longer errors on `Cannot resolve WUSDC address`