### PR TITLE
Add transfer_spl(bytes32,bytes32,uint64,bytes32) overload to IHelperProgram

### DIFF
--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -78,6 +78,13 @@ interface IHelperProgram {
     function transfer_spl(address to, uint64 tokens, bytes32 mint) external;
     // transfer spl-tokens between ata owned by external pda.
     function transfer_spl(bytes32 to_ata, uint64 tokens, bytes32 mint) external;
+    // Delegate variant: src_ata is caller-supplied (the other transfer_spl
+    // overloads derive it from external_auth(caller)). Signs as
+    // external_auth(caller); SPL Token Program accepts this PDA as the
+    // transfer_checked authority when it is the source ATA's owner OR its
+    // delegate with delegated_amount >= tokens. Required by ERC20-style
+    // transferFrom flows (e.g. SPL_ERC20._transfer with from != msg.sender).
+    function transfer_spl(bytes32 src_ata, bytes32 to_ata, uint64 tokens, bytes32 mint) external;
     // external pda
     function pda(address user) external view returns (bytes32);
     // ata owned by external pda. Gas token mint is used.


### PR DESCRIPTION
## Summary

Adds a fifth `transfer_spl` overload to `IHelperProgram`:

```solidity
function transfer_spl(bytes32 src_ata, bytes32 to_ata, uint64 tokens, bytes32 mint) external;
```

Mirrors rome-protocol/rome-evm-private#353 (selector `0x766b362a`). The delegate variant takes an explicit `src_ata` (vs. derived from `external_auth(caller)` in the other overloads) and signs as `external_auth(caller)`. SPL Token Program accepts the caller's PDA as the `transfer_checked` authority when it is the source ATA's **owner** OR its **delegate with `delegated_amount >= tokens`** — the model that ERC20-style `transferFrom` flows rely on.

## Why

`SPL_ERC20._transfer` is shared by both `transfer(to,value)` and `transferFrom(from,to,value)`. For `transferFrom`, the source ATA belongs to `from`, but the signer (msg.sender's PDA) is the SPL delegate — none of the existing four `transfer_spl` overloads can express that, because they all derive `src_ata` from the caller's PDA.

The previous CPI shortcut `spl_transfer_checked_v1` (`0x351aa22f`) handled this; #141 removed it during the HelperProgram migration. Until rome-evm-private #353 ships, `_transfer` falls back to `SplTokenLib.transfer_checked + CpiProgram.invoke` (committed in #141), costing ~250k extra CU per call.

## What changed

One new function declaration inside `IHelperProgram`. Interface-only — no contract callers updated in this PR.

## Test plan

- [x] `npx hardhat compile` — green locally.
- [ ] Pair this with the rome-evm-private PR before the matching `SPL_ERC20._transfer` simplification PR.

## Sequencing

1. rome-evm-private #353 lands + ships to devnet.
2. This PR lands.
3. Follow-up PR switches `SPL_ERC20._transfer` from the `SplTokenLib + invoke` fallback to a single `HelperProgram.transfer_spl(bytes32,bytes32,uint64,bytes32)` delegatecall, recovering the ~250k CU.

🤖 _This response was generated by Claude Code._