### PR TITLE
docs(precompile-surface): refresh stale selector citation + retired-precompile doc comments + modernize bridge example

### DIFF
--- a/contracts/bridge/RomeBridgeEvents.sol
+++ b/contracts/bridge/RomeBridgeEvents.sol
@@ -29,10 +29,12 @@ interface RomeBridgeEvents {
     );
 
     /// @notice Emitted when a user settles an inbound-bridge gas-split by
-    ///         converting rUSDC (or any chain-gas-mint wrapper) into native
-    ///         Rome gas via the `unwrap_spl_to_gas` precompile. Mirror of
-    ///         `Withdrawn`; indexers watch both events to reconcile CCTP /
-    ///         Wormhole attestation records against on-Rome settlement.
+    ///         converting wUSDC (or any chain-gas-mint wrapper) into native
+    ///         Rome gas via the unwrap-leg precompile (historically
+    ///         `unwrap_spl_to_gas`; now `HelperProgram.deposit_from_ata`).
+    ///         Mirror of `Withdrawn`; indexers watch both events to
+    ///         reconcile CCTP / Wormhole attestation records against
+    ///         on-Rome settlement.
     /// @param user            EVM address that received the gas.
     /// @param mint            SPL mint (bytes32 pubkey) whose wrapper was unwrapped.
     /// @param wrapperAmount   Mint-unit tokens pulled from user's wrapper balance.

--- a/contracts/bridge/RomeBridgeInbound.sol
+++ b/contracts/bridge/RomeBridgeInbound.sol
@@ -13,19 +13,27 @@ import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
 ///         existing `do_tx` instruction (operator-signed, fee_addr=operator
 ///         so the user pays zero Rome gas).
 ///
-/// @dev    ## Flow
-///         1. CCTP receiveMessage / Wormhole redeem mints `total` rUSDC to
+/// @dev    LEGACY: this contract is no longer in the active inbound-bridge
+///         path (replaced by `settle_inbound_bridge` on rome-evm-private).
+///         Kept for back-compat config parsing only. The unwrap-leg
+///         precompile referenced below has also been retired and replaced
+///         by `HelperProgram.deposit_from_ata` at `0xff…09` — these doc
+///         comments describe the historical flow shape, not current behavior.
+///
+///         ## Flow (historical)
+///         1. CCTP receiveMessage / Wormhole redeem mints `total` wUSDC to
 ///            user's PDA-owned ATA (unchanged — happens on Solana side).
 ///         2. User signs one EVM tx calling `settleInbound(wrapperAmount)`.
 ///         3. Worker submits the tx via `do_tx(fee_addr=operator, rlp)` —
 ///            operator pays Rome gas; user pays nothing.
 ///         4. `settleInbound`:
-///              - Pulls `wrapperAmount` rUSDC from user's ATA into this
+///              - Pulls `wrapperAmount` wUSDC from user's ATA into this
 ///                contract's ATA via `SPL_ERC20.transferFrom`.
-///              - Calls `unwrap_spl_to_gas(gasAmountWei)` — wrapper balance
-///                in this contract's ATA becomes gas in this contract's
-///                Balance PDA. The precompile reads `msg.sender`, which
-///                from its point of view is this contract.
+///              - Calls the historical `unwrap_spl_to_gas(gasAmountWei)`
+///                precompile — wrapper balance in this contract's ATA
+///                becomes gas in this contract's Balance PDA. The
+///                precompile read `msg.sender`, which from its point of
+///                view was this contract.
 ///              - Forwards the just-minted gas to the user via a native
 ///                `user.call{value: gasAmountWei}("")`. This debits this
 ///                contract's Balance PDA and credits the user's.
@@ -45,13 +53,16 @@ import {RomeBridgeEvents} from "./RomeBridgeEvents.sol";
 ///         contract call via `do_tx` keeps the UX as standard
 ///         `writeContractAsync` on whatever wallet the user has.
 ///
-///         ## Why not just `user.call(unwrap_spl_to_gas)` directly
-///         `unwrap_spl_to_gas` reads `msg.sender` and unwraps the CALLER's
-///         wrapper balance into the CALLER's gas balance. If we want to
-///         atomically record events / enforce invariants / emit structured
-///         audit data, we need a contract wrapper. This is it.
+///         ## Why not just `user.call(<unwrap-precompile>)` directly
+///         The historical `unwrap_spl_to_gas` precompile read `msg.sender`
+///         and unwrapped the CALLER's wrapper balance into the CALLER's
+///         gas balance. If we want to atomically record events / enforce
+///         invariants / emit structured audit data, we need a contract
+///         wrapper. This is it. (Current canonical unwrap leg is
+///         `HelperProgram.deposit_from_ata` with the same caller-as-signer
+///         semantics.)
 contract RomeBridgeInbound is ERC2771Context, ReentrancyGuard, RomeBridgeEvents {
-    /// @notice ERC20-SPL wrapper for the chain's gas mint (e.g. rUSDC on Rome).
+    /// @notice ERC20-SPL wrapper for the chain's gas mint (e.g. wUSDC on Rome).
     SPL_ERC20 public immutable wrapper;
 
     /// @notice Chain's gas mint (bytes32 pubkey) — recorded in SettledInbound
@@ -100,7 +111,7 @@ contract RomeBridgeInbound is ERC2771Context, ReentrancyGuard, RomeBridgeEvents 
         }
     }
 
-    /// @notice Convert `wrapperAmount` of the user's rUSDC into native Rome
+    /// @notice Convert `wrapperAmount` of the user's wUSDC into native Rome
     ///         gas, crediting the user's Balance PDA.
     /// @param  wrapperAmount Mint-unit tokens to convert (e.g. for USDC with
     ///                       6 decimals, `1_000_000` = 1 USDC).

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -202,7 +202,7 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     // CCTP path — path=0
     // -------------------------------------------------------------------------
 
-    /// @notice Burns rUSDC on the Rome EVM and initiates a CCTP deposit_for_burn
+    /// @notice Burns wUSDC on the Rome EVM and initiates a CCTP deposit_for_burn
     ///         CPI on Solana, bridging funds to `ethereumRecipient` on Ethereum.
     /// @param amount           Token amount in SPL decimals (must fit uint64).
     /// @param ethereumRecipient Destination address on Ethereum.

--- a/contracts/cpi/UserPda.sol
+++ b/contracts/cpi/UserPda.sol
@@ -29,13 +29,15 @@ library UserPda {
     /// different derivation; adapters that support Token-2022 call
     /// `ataWithProgram` directly.
     ///
-    /// Delegates to the `derive_user_ata` CPI shortcut selector
-    /// (rome-evm-private #319, dispatched at `0xc654e119`) which combines
-    /// the Rome unified-user PDA + SPL ATA derivation into a single
-    /// syscall. Behavior is byte-identical to the prior two-hop path
-    /// through `0xFF…07` — verified on-chain against Marcus 121301 on
-    /// 2026-05-11 with EVM address `0xC777…2DAc` and USDC mint
-    /// `4zMMC9sr…ncDU` (resulting ATA `FkFYez2a…n8vw`).
+    /// Delegates to `HelperProgram.ata(address, bytes32)` — selector
+    /// `0xfeb1c647` on `0xff…09` (HelperProgram precompile; rome-evm-
+    /// private #348/#349, post-2026-05-12 consolidation). The earlier
+    /// `derive_user_ata` shortcut at `0xc654e119` on `0xff…08` (#319)
+    /// was migrated to HelperProgram and no longer dispatches there.
+    /// Behavior is byte-identical to the prior two-hop path through
+    /// `0xFF…07` — verified on-chain against Marcus 121301 on 2026-05-
+    /// 11 with EVM address `0xC777…2DAc` and USDC mint `4zMMC9sr…ncDU`
+    /// (resulting ATA `FkFYez2a…n8vw`).
     ///
     /// Saves ~152K Solana CU per call vs the two-hop path (3-sample
     /// average on Marcus 121301: 281K → 129K, 54 % reduction).

--- a/contracts/examples/bridge.sol
+++ b/contracts/examples/bridge.sol
@@ -1,21 +1,46 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
-import {CpiProgram, SystemProgram,  ISystemProgram, HelperProgram, ICrossProgramInvocation} from "../interface.sol";
+import {CpiProgram, SystemProgram, ISystemProgram, HelperProgram, ICrossProgramInvocation} from "../interface.sol";
 import {Convert} from "../convert.sol";
 import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {AssociatedSplToken} from "../spl_token/associated_spl_token.sol";
-import {SystemProgramLib} from "../system_program/system_program.sol";
 
-contract UnwrapSplToGasContract  {
-    function unwrap_spl_to_gas(uint256 value)  external {
+/// @title BridgeExample
+/// @notice Reference patterns for bridge-adjacent operations (unwrap, ATA
+///         derivation, balance probe). NOT a production contract — this is
+///         a sandbox for adapter authors.
+///
+/// @dev    Demonstrates canonical post-2026-05 surface:
+///         - Unwrap leg uses `HelperProgram.deposit_from_ata` (the historical
+///           `unwrap_spl_to_gas` precompile was retired in the #348-#354
+///           consolidation).
+///         - User-keyed ATA derivation uses `HelperProgram.ata(address, bytes32)`
+///           single-dispatch path — saves ~152K Solana CU vs the two-hop
+///           pattern.
+///         - For raw Solana-pubkey-keyed ATAs (chain gas-pool, fee accumulator,
+///           pool authority), `AssociatedSplToken.get_associated_token_address_with_program_id`
+///           is the right path — HelperProgram.ata takes an EVM `address`, not
+///           a `bytes32` Solana pubkey.
+///
+///         For the full HelperProgram method inventory by example, see
+///         `contracts/examples/helper.sol` (helper_example).
+contract BridgeExample {
+    /// Unwrap leg of the gas-token bridge: wrapper SPL balance in caller's
+    /// ATA becomes native Rome gas credit in caller's Balance PDA. Caller
+    /// must have a non-zero balance in their wrapper ATA.
+    function unwrap_spl_to_gas(uint256 value) external {
         (bool success, bytes memory result) = address(HelperProgram).delegatecall(
             abi.encodeWithSignature("deposit_from_ata(uint256)", value)
         );
-        require (success, string(Convert.revert_msg(result)));
+        require(success, string(Convert.revert_msg(result)));
     }
 
-    function rome_wallet_ata() public view returns(string memory) {
+    /// Chain gas-pool ATA — keyed by the per-chain `CONTRACT_SOL_WALLET`
+    /// PDA which is a raw Solana pubkey, not an EVM address. Uses
+    /// `AssociatedSplToken.get_associated_token_address_with_program_id`
+    /// because HelperProgram.ata only accepts EVM `address`.
+    function rome_wallet_ata() public view returns (string memory) {
         bytes32 rome_program = SystemProgram.rome_evm_program_id();
 
         ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](2);
@@ -24,16 +49,22 @@ contract UnwrapSplToGasContract  {
 
         (bytes32 wallet,) = SystemProgram.find_program_address(rome_program, seeds);
 
-        bytes32 ata_b32 = ata(wallet);
-        bytes memory ata_b58 = SystemProgram.bytes32_to_base58(bytes32(ata_b32));
+        bytes32 ata_b32 = _ata_for_key(wallet);
+        bytes memory ata_b58 = SystemProgram.bytes32_to_base58(ata_b32);
 
         return string(ata_b58);
     }
 
+    /// User's gas-mint ATA — canonical single-dispatch via HelperProgram.ata.
+    /// Replaces the prior two-hop `RomeEVMAccount.pda(msg.sender)` +
+    /// `AssociatedSplToken.get_associated_token_address_with_program_id`
+    /// pattern. Saves ~152K Solana CU per call.
     function user_ata() public view returns (string memory) {
-        bytes32 user_pda = RomeEVMAccount.pda(msg.sender);
-        bytes32 ata_b32 = ata(user_pda);
-        bytes memory ata_b58 = SystemProgram.bytes32_to_base58(bytes32(ata_b32));
+        bytes32 mint_id = SystemProgram.mint_id();
+        require(mint_id != bytes32(0), "Rollup doesn't use SPL as gas token");
+
+        bytes32 ata_b32 = HelperProgram.ata(msg.sender, mint_id);
+        bytes memory ata_b58 = SystemProgram.bytes32_to_base58(ata_b32);
 
         return string(ata_b58);
     }
@@ -43,65 +74,43 @@ contract UnwrapSplToGasContract  {
         return SplTokenLib.load_token_amount(ata_b32, address(CpiProgram));
     }
 
-    function ata(bytes32 pda) internal view returns(bytes32) {
+    /// Bootstrap caller's unified Rome user PDA. Funds it to rent-exempt
+    /// threshold so subsequent CPIs the user signs can succeed. Idempotent
+    /// (no-op if already funded).
+    function create_payer() public {
+        RomeEVMAccount.create_payer(msg.sender, 10000000);
+    }
+
+    /// Idempotent ATA-create for the caller against the chain's gas mint —
+    /// canonical single-dispatch via `HelperProgram.create_ata(address, bytes32)`.
+    /// Replaces the prior pattern of constructing
+    /// `AssociatedSplToken.create_associated_token_account_idempotent` calldata
+    /// and dispatching through `CpiProgram.invoke_signed` with PAYER salt
+    /// (PAYER_PDA collapsed into the unified user PDA in rome-solidity 0acabea).
+    function create_user_ata() external {
         bytes32 mint_id = SystemProgram.mint_id();
         require(mint_id != bytes32(0), "Rollup doesn't use SPL as gas token");
 
-        (,bytes32 spl_program,,,,) = CpiProgram.account_info(mint_id);
+        (bool success, bytes memory result) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature("create_ata(address,bytes32)", msg.sender, mint_id)
+        );
+        require(success, string(Convert.revert_msg(result)));
+    }
 
-        bytes32 key = AssociatedSplToken.get_associated_token_address_with_program_id(
-            pda,
+    /// Internal — ATA derivation against a raw Solana pubkey (used for
+    /// chain-side keys, e.g. gas pool wallet). HelperProgram.ata is the
+    /// EVM-address equivalent.
+    function _ata_for_key(bytes32 owner_pubkey) internal view returns (bytes32) {
+        bytes32 mint_id = SystemProgram.mint_id();
+        require(mint_id != bytes32(0), "Rollup doesn't use SPL as gas token");
+
+        (, bytes32 spl_program, , , , ) = CpiProgram.account_info(mint_id);
+
+        return AssociatedSplToken.get_associated_token_address_with_program_id(
+            owner_pubkey,
             mint_id,
             spl_program,
             AssociatedSplToken.ASSOCIATED_TOKEN_PROGRAM_ID
         );
-
-        return key;
-    }
-
-    function create_payer()  public {
-        RomeEVMAccount.create_payer(msg.sender, 10000000);
-    }
-
-    function payer() internal view returns (bytes32) {
-        bytes32 rome_program = SystemProgram.rome_evm_program_id();
-        bytes32 salt = Convert.bytes_to_bytes32(bytes("PAYER"));
-        ISystemProgram.Seed[] memory seeds = RomeEVMAccount.authority_seeds_with_salt(msg.sender, salt);
-        (bytes32 key,) = SystemProgram.find_program_address(rome_program, seeds);
-        return key;
-    }
-
-    function create_user_ata() external {
-        bytes32 funding = payer();
-        bytes32 wallet = RomeEVMAccount.pda(msg.sender);
-        bytes32 token_mint = SystemProgram.mint_id();
-
-        (
-            bytes32 program_id,
-            ICrossProgramInvocation.AccountMeta[] memory accounts,
-            bytes memory data,
-        ) = AssociatedSplToken.create_associated_token_account_idempotent(
-            funding,
-            wallet,
-            token_mint,
-            SystemProgramLib.PROGRAM_ID,
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            AssociatedSplToken.ASSOCIATED_TOKEN_PROGRAM_ID
-        );
-
-        bytes32[] memory seeds = new bytes32[](1);
-        seeds[0] = Convert.bytes_to_bytes32(bytes("PAYER"));
-
-        (bool success, bytes memory result) = address(CpiProgram).delegatecall(
-            abi.encodeWithSelector(
-                ICrossProgramInvocation.invoke_signed.selector,
-                program_id,
-                accounts,
-                data,
-                seeds
-            )
-        );
-
-        require(success, string(result));
     }
 }

--- a/contracts/rome_evm_account.sol
+++ b/contracts/rome_evm_account.sol
@@ -60,7 +60,7 @@ library RomeEVMAccount {
     function create_payer(address user, uint64 lamports) internal {
         bytes32 key = get_payer(user);
 
-        (uint64 current_lamports,,,,,) = CpiProgram.account_info(key);
+        uint64 current_lamports = CpiProgram.account_lamports(key);
         if (current_lamports == 0) {
             require(lamports >= minimum_balance(0), "insufficient lamports, rent-exemption value is 890880");
         }


### PR DESCRIPTION
## Summary
Phase 1 of a small audit-driven cleanup of rome-solidity following the rome-evm-private #348/#349/#351/#353 HelperProgram consolidation (2026-05-12) and rome-evm-private CLAUDE.md polish (#355). All four fixes are small, surgical, and verified by `npx hardhat compile`.

- **`contracts/cpi/UserPda.sol` (HIGH severity)** — fix stale selector citation. The doc-comment claimed `UserPda.ata` delegates to `derive_user_ata` at `0xc654e119` on `0xff…08` (#319). That selector migrated to `HelperProgram.ata(address, bytes32)` at `0xfeb1c647` on `0xff…09`. Future adapter authors reading this widely-cited shared library now get the right pointer.
- **`contracts/rome_evm_account.sol:63`** — replace `CpiProgram.account_info(key)` six-tuple unpack with the typed `CpiProgram.account_lamports(key)` shortcut. One-line CU + consistency win; matches `SimpleActivator.isActivated:166`.
- **`contracts/bridge/RomeBridgeEvents.sol` + `RomeBridgeInbound.sol` + `RomeBridgeWithdraw.sol`** — sweep deprecated `rUSDC` → `wUSDC` in NatSpec and reframe `unwrap_spl_to_gas` mentions as historical with current canonical name (`HelperProgram.deposit_from_ata`). `RomeBridgeInbound` is already marked legacy in CLAUDE.md.
- **`contracts/examples/bridge.sol`** — modernize: rename contract, replace two-hop ATA derivation with `HelperProgram.ata(address, bytes32)`, replace hand-built `create_associated_token_account_idempotent` + manual `CpiProgram.invoke_signed` with `HelperProgram.create_ata(address, bytes32)`, drop deprecated PAYER-salt helper. Examples set the norm for new adapter authors.

## Test plan
- [x] `npx hardhat compile` passes (70 files, no new warnings)
- [ ] No behavioral changes — all edits are doc / equivalent-precompile / dead-pattern removal. No new tests needed.
- [ ] Diff review: 6 files, +113/-89 lines (most of which is `examples/bridge.sol` cleanup).

## Out of scope
- Meteora `damm_v1_pool.sol` 7-site ATA refactor (red-teamed: those sites pass raw `bytes32` Solana keys, not EVM addresses — `HelperProgram.ata` inapplicable; only readability swap with `UserPda.ataForKey` available, zero CU delta).
- SplTokenLib internals migration (red-teamed: already done at consumer layer in #138/#143; SplTokenLib is a pure calldata-builder, doesn't issue CPIs).
- `pdas_batch_derive` library (gated on a CU measurement of Meteora's 12-PDA derive function — pending).