### PR TITLE
feat(cpi): AccountReader library — typed wrappers over CpiProgram account-read selectors

### DIFF
--- a/contracts/activation/SimpleActivator.sol
+++ b/contracts/activation/SimpleActivator.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {ICrossProgramInvocation, CpiProgram} from "../interface.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {SPL_ERC20, ERC20Users} from "../erc20spl/erc20spl.sol";
 
@@ -106,7 +107,7 @@ contract SimpleActivator {
         address user = msg.sender;
         bytes32 userPda = RomeEVMAccount.pda(user);
 
-        uint64 currentLamports = CpiProgram.account_lamports(userPda);
+        uint64 currentLamports = AccountReader.lamportsOf(userPda);
         if (currentLamports > 0) {
             (bool refundOk, ) = payable(user).call{value: msg.value}("");
             if (!refundOk) revert RefundFailed();
@@ -163,6 +164,6 @@ contract SimpleActivator {
     ///         whether step 2 / step 3 are still needed.
     function isActivated(address user) external view returns (bool) {
         bytes32 userPda = RomeEVMAccount.pda(user);
-        return CpiProgram.account_lamports(userPda) > 0;
+        return AccountReader.lamportsOf(userPda) > 0;
     }
 }

--- a/contracts/cpi/AccountReader.sol
+++ b/contracts/cpi/AccountReader.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {CpiProgram} from "../interface.sol";
+
+/// @title AccountReader
+/// @notice Typed wrappers over the `CpiProgram` precompile's account-read
+///         selectors (`account_lamports`, `account_u64_at`, `account_data_at`).
+/// @dev
+///   Solana account data lives in raw byte buffers parsed at known offsets.
+///   Adapter authors who read Mint / TokenAccount / Anchor account layouts
+///   reach for the same three precompile shortcuts repeatedly:
+///
+///   - `account_lamports(pubkey) → uint64`              — `0xde79ed54`
+///   - `account_u64_at(pubkey, offset) → uint64`        — `0xb317d4c1`
+///   - `account_data_at(pubkey, offset, length) → bytes`— `0x593762e8`
+///
+///   `AccountReader` exposes these under names that read as intent rather
+///   than mechanism, plus a `readBytes32At` convenience that parses a
+///   32-byte slice without the caller having to slice + decode by hand.
+///
+///   Selector hex was verified via `cast keccak` against rome-evm-private
+///   const definitions on 2026-05-13 and tracked in `rome-evm-private/
+///   CLAUDE.md` §"Non-EVM Bridge".
+///
+/// ## Scope (deliberately thin)
+///
+///   This library only contains typed-read primitives. Per the audit
+///   red-team (2026-05-14): invariant helpers like `expectDiscriminator`,
+///   `expectOwner`, `expectDataLen` are NOT included — no current consumer
+///   needs them. Add them when a consumer does, not before.
+///
+/// ## Live behavior
+///
+///   Every function dispatches through the `CpiProgram` pre-bound constant
+///   (precompile at `0xff00…0008`). The precompile signs the read as the
+///   EVM caller via Rome's `external_auth` derivation; for read-only
+///   account inspection this is irrelevant but worth knowing when reading
+///   the source.
+library AccountReader {
+    /// Lamports balance of `account`. Cheapest read — no data buffer
+    /// fetch. Common pattern: gate-check whether an account exists at all
+    /// (lamports == 0 ↔ account uninitialized) before issuing a heavier
+    /// `readU64At` or `readBytesAt`.
+    function lamportsOf(bytes32 account) internal view returns (uint64) {
+        return CpiProgram.account_lamports(account);
+    }
+
+    /// Read a little-endian `uint64` at `offset` bytes into `account`'s
+    /// data buffer. The most common SPL Token offset (e.g. Mint.supply
+    /// at offset 36, TokenAccount.amount at offset 64, TokenAccount.
+    /// delegated_amount at offset 121).
+    function readU64At(bytes32 account, uint16 offset) internal view returns (uint64) {
+        return CpiProgram.account_u64_at(account, offset);
+    }
+
+    /// Read `length` bytes starting at `offset` from `account`'s data
+    /// buffer. Returns the raw slice. Caller parses (Borsh, COption,
+    /// custom layout).
+    function readBytesAt(bytes32 account, uint16 offset, uint16 length)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return CpiProgram.account_data_at(account, offset, length);
+    }
+
+    /// Convenience: read a 32-byte slice at `offset` and return it as
+    /// `bytes32`. Common SPL Token offsets: Mint.mint_authority option
+    /// (offset 0-4 = discriminator + 4-36 = pubkey), TokenAccount.mint
+    /// (offset 0), TokenAccount.owner (offset 32), TokenAccount.delegate
+    /// option (offset 72-108).
+    function readBytes32At(bytes32 account, uint16 offset) internal view returns (bytes32) {
+        bytes memory slice = CpiProgram.account_data_at(account, offset, 32);
+        bytes32 out;
+        assembly {
+            out := mload(add(slice, 32))
+        }
+        return out;
+    }
+}

--- a/contracts/cpi/test/AccountReaderWrapper.sol
+++ b/contracts/cpi/test/AccountReaderWrapper.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {AccountReader} from "../AccountReader.sol";
+
+/// @dev Test-only wrapper exposing AccountReader. Every method here
+///      delegates to the library so Hardhat/Foundry tests can call
+///      against a deployed wrapper contract. Note: these reads require a
+///      live Rome EVM stack (the CpiProgram precompile is not present on
+///      hardhatMainnet), so all functional tests against this wrapper
+///      run on `--network local` or per-chain devnet networks.
+contract AccountReaderWrapper {
+    function lamportsOf(bytes32 account) external view returns (uint64) {
+        return AccountReader.lamportsOf(account);
+    }
+
+    function readU64At(bytes32 account, uint16 offset) external view returns (uint64) {
+        return AccountReader.readU64At(account, offset);
+    }
+
+    function readBytesAt(bytes32 account, uint16 offset, uint16 length)
+        external
+        view
+        returns (bytes memory)
+    {
+        return AccountReader.readBytesAt(account, offset, length);
+    }
+
+    function readBytes32At(bytes32 account, uint16 offset) external view returns (bytes32) {
+        return AccountReader.readBytes32At(account, offset);
+    }
+}

--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -8,6 +8,7 @@ import {AssociatedSplToken} from "../spl_token/associated_spl_token.sol";
 import {ISystemProgram, ICrossProgramInvocation, CpiProgram, HelperProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {UserPda} from "../cpi/UserPda.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 import {Convert} from "../convert.sol";
 
 contract ERC20Users {
@@ -157,7 +158,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         //    no Borsh decoding. The fast-path here only needs lamports != 0
         //    to confirm the account is initialized.
         bytes32 ata = HelperProgram.ata(user, mint_id);
-        uint64 lamports = ICrossProgramInvocation(cpi_program).account_lamports(ata);
+        uint64 lamports = AccountReader.lamportsOf(ata);
         if (lamports != 0) {
             // Account already exists on Solana — no CPI needed.
             // Cache write-through is optional; legacy callers checking
@@ -205,7 +206,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // 46..81 freeze_authority COption. `account_u64_at` reads exactly
         // the 8-byte supply field directly — no full mint Borsh decode,
         // no 5-tuple ABI roundtrip.
-        return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(mint_id, 36));
+        return uint256(AccountReader.readU64At(mint_id, 36));
     }
 
     function balanceOf(address account) public view virtual returns (uint256) {
@@ -226,11 +227,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // UIs that simulate balance reads on first-time wallets) to wrap
         // balanceOf in try/catch. account_lamports is cheap (no data
         // buffer pull) and returns 0 when the account doesn't exist.
-        if (ICrossProgramInvocation(cpi_program).account_lamports(ata) == 0) {
+        if (AccountReader.lamportsOf(ata) == 0) {
             return 0;
         }
         // SPL TokenAccount.amount is a u64 LE at offset 64.
-        return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(ata, 64));
+        return uint256(AccountReader.readU64At(ata, 64));
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {
@@ -322,7 +323,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // slice (skipping the unrelated mint/owner/amount/state/is_native
         // fields that `account_info` would also marshal). Decode via the
         // existing Convert.read_coption_bytes32 helper.
-        bytes memory delegateOption = ICrossProgramInvocation(cpi_program).account_data_at(ata, 72, 36);
+        bytes memory delegateOption = AccountReader.readBytesAt(ata, 72, 36);
         Convert.COptionBytes32 memory parsed;
         (parsed,) = Convert.read_coption_bytes32(delegateOption, 0);
         bytes32 delegate = parsed.is_some ? parsed.value : bytes32(0);
@@ -332,7 +333,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         }
 
         // Read the u64 delegated_amount at offset 121 directly.
-        return uint256(ICrossProgramInvocation(cpi_program).account_u64_at(ata, 121));
+        return uint256(AccountReader.readU64At(ata, 121));
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -6,6 +6,7 @@ import "./IAdapterFactory.sol";
 import "./IAdapterMetadata.sol";
 import "./PythPullParser.sol";
 import "../interface.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title PythPullAdapter
 /// @notice Per-feed adapter that reads PriceUpdateV2 from Pyth Solana Receiver
@@ -212,7 +213,7 @@ contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     ///          Romeswap / cardo oracle read) outweigh that marginal
     ///          incremental security in Rome's threat model.
     function _fetchAccount() internal view virtual returns (bytes memory data) {
-        data = CpiProgram.account_data_at(pythAccount, 0, uint16(PythPullParser.MIN_DATA_LENGTH));
+        data = AccountReader.readBytesAt(pythAccount, 0, uint16(PythPullParser.MIN_DATA_LENGTH));
     }
 
     function _readAndParse() internal view returns (PythPullParser.PythPullPrice memory) {

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -6,6 +6,7 @@ import "./IAdapterFactory.sol";
 import "./IAdapterMetadata.sol";
 import "./SwitchboardParser.sol";
 import "../interface.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title SwitchboardV3Adapter
 /// @notice Per-feed adapter that reads AggregatorAccountData from Switchboard V2
@@ -181,7 +182,7 @@ contract SwitchboardV3Adapter is IExtendedOracleAdapter, IAdapterMetadata {
     ///      PythPullAdapter._fetchAccount; see that contract for the M-5
     ///      audit-finding deferral rationale.
     function _fetchAccount() internal view virtual returns (bytes memory data) {
-        data = CpiProgram.account_data_at(switchboardAccount, 0, uint16(SwitchboardParser.MIN_DATA_LENGTH));
+        data = AccountReader.readBytesAt(switchboardAccount, 0, uint16(SwitchboardParser.MIN_DATA_LENGTH));
     }
 
     function _readAndParse() internal view returns (SwitchboardParser.SwitchboardPrice memory) {

--- a/tests/cpi/AccountReader.test.ts
+++ b/tests/cpi/AccountReader.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = join(__dirname, "../../contracts/cpi/AccountReader.sol");
+const WRAPPER_PATH = join(__dirname, "../../contracts/cpi/test/AccountReaderWrapper.sol");
+
+/**
+ * AccountReader tests.
+ *
+ * AccountReader wraps the `CpiProgram` precompile's account-read selectors
+ * (`account_data_at` / `account_u64_at` / `account_lamports`) into typed
+ * named functions. The selectors are EVM-precompile calls that only
+ * dispatch on a live Rome chain — Hardhat-simulated EVM cannot reach them
+ * — so functional/integration verification lives in SPL_ERC20 and oracle
+ * adapter integration tests (`--network local`).
+ *
+ * These unit tests are source-level: file exists, surface matches contract,
+ * no state, no unsafe patterns. They're enough to catch regressions in the
+ * shape of the library.
+ */
+
+describe("AccountReader", () => {
+    it("library file exists at contracts/cpi/AccountReader.sol", () => {
+        assert.equal(existsSync(LIB_PATH), true, `expected ${LIB_PATH} to exist`);
+    });
+
+    it("test-only wrapper exists at contracts/cpi/test/AccountReaderWrapper.sol", () => {
+        assert.equal(existsSync(WRAPPER_PATH), true, `expected ${WRAPPER_PATH} to exist`);
+    });
+
+    it("declares the four expected internal view functions", () => {
+        const src = readFileSync(LIB_PATH, "utf8");
+
+        // Each function: typed name, internal view, expected signature.
+        const expected = [
+            /function\s+lamportsOf\s*\(\s*bytes32\s+\w+\s*\)\s+internal\s+view\s+returns\s*\(\s*uint64\s*\)/,
+            /function\s+readU64At\s*\(\s*bytes32\s+\w+\s*,\s*uint16\s+\w+\s*\)\s+internal\s+view\s+returns\s*\(\s*uint64\s*\)/,
+            /function\s+readBytesAt\s*\(\s*bytes32\s+\w+\s*,\s*uint16\s+\w+\s*,\s*uint16\s+\w+\s*\)\s+internal\s+view\s+returns\s*\(\s*bytes\s+memory\s*\)/,
+            /function\s+readBytes32At\s*\(\s*bytes32\s+\w+\s*,\s*uint16\s+\w+\s*\)\s+internal\s+view\s+returns\s*\(\s*bytes32\s*\)/,
+        ];
+
+        for (const re of expected) {
+            assert.match(src, re, `missing function signature matching ${re}`);
+        }
+    });
+
+    it("is a pure library (no state, no constructor, no fallback)", () => {
+        const src = readFileSync(LIB_PATH, "utf8");
+
+        assert.equal(src.includes("library AccountReader"), true,
+            "AccountReader must be declared as `library AccountReader`");
+
+        // No state variables, mappings, or storage declarations outside functions.
+        // Libraries can't have state but enforce zero-style to catch refactor mistakes.
+        assert.equal(/^\s*mapping\s*\(/m.test(src), false, "library must not declare mappings");
+        assert.equal(/constructor\s*\(/m.test(src), false, "library must not declare a constructor");
+        assert.equal(/fallback\s*\(/m.test(src), false, "library must not declare fallback");
+        assert.equal(/receive\s*\(/m.test(src), false, "library must not declare receive");
+    });
+
+    it("dispatches through CpiProgram, not raw address calls", () => {
+        const src = readFileSync(LIB_PATH, "utf8");
+
+        // Each typed read must route through the pre-bound `CpiProgram`
+        // constant. No raw `address(...).call(...)` or
+        // `address(...).delegatecall(...)` patterns — those would bypass
+        // the typed dispatch the library promises to provide.
+        assert.equal(/CpiProgram\.account_lamports\s*\(/.test(src), true,
+            "lamportsOf must dispatch through CpiProgram.account_lamports");
+        assert.equal(/CpiProgram\.account_u64_at\s*\(/.test(src), true,
+            "readU64At must dispatch through CpiProgram.account_u64_at");
+        assert.equal(/CpiProgram\.account_data_at\s*\(/.test(src), true,
+            "readBytesAt/readBytes32At must dispatch through CpiProgram.account_data_at");
+
+        assert.equal(/\.call\s*\(/.test(src), false,
+            "library must not use raw .call(...) — use typed CpiProgram dispatch");
+        assert.equal(/\.delegatecall\s*\(/.test(src), false,
+            "library must not use raw .delegatecall(...) — use typed CpiProgram dispatch");
+    });
+
+    it("wrapper exposes all four functions for tests", () => {
+        const src = readFileSync(WRAPPER_PATH, "utf8");
+
+        for (const name of ["lamportsOf", "readU64At", "readBytesAt", "readBytes32At"]) {
+            assert.match(src, new RegExp(`function\\s+${name}\\s*\\(`),
+                `wrapper must expose ${name}`);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the audit-driven cleanup. Adds `contracts/cpi/AccountReader.sol`, a thin generic library that wraps the three account-read selectors on the CpiProgram precompile (`account_lamports` / `account_u64_at` / `account_data_at`) into typed functions named after intent. Migrates 10 existing call sites across 5 contracts to consume the library directly so adapter authors writing new Solana account readers have one canonical entry-point.

**Surface (4 internal view functions)**:
- `lamportsOf(bytes32) → uint64`
- `readU64At(bytes32, uint16) → uint64`
- `readBytesAt(bytes32, uint16, uint16) → bytes memory`
- `readBytes32At(bytes32, uint16) → bytes32` (convenience, not currently consumed)

**Migrated call sites (10)**:
- `contracts/erc20spl/erc20spl.sol` (6): `getAta` + `balanceOf` × 2 + `totalSupply` + `allowance` × 2
- `contracts/activation/SimpleActivator.sol` (2): `activate` + `isActivated`
- `contracts/oracle/PythPullAdapter.sol` (1): `_fetchAccount`
- `contracts/oracle/SwitchboardV3Adapter.sol` (1): `_fetchAccount`

## Red-teamed scope reduction

The audit proposed a wider library including `expectDiscriminator` / `expectOwner` / `expectDataLen` invariant helpers. Red team caught that no current consumer needs them and they'd commit to error-shape decisions speculatively. **This PR ships only the typed-read primitives.** Invariant helpers can ship when a consumer actually needs one.

## TDD evidence

1. Wrote `tests/cpi/AccountReader.test.ts` first with 6 source-level assertions (file exists, function signatures match, pure library, dispatches through CpiProgram, wrapper exposes all four).
2. Ran the test — confirmed all 6 fail with `ENOENT` (right reason — no implementation yet).
3. Wrote `AccountReader.sol` + `AccountReaderWrapper.sol` minimum to pass.
4. Re-ran the test — all 6 pass.
5. Migrated 10 call sites + recompiled (no new warnings).
6. Ran all 10 sibling cpi tests + 3 touched oracle parser tests — **76 + 24 = 100 passing**, no regressions.

## Test plan

- [x] `npx hardhat compile` clean (only pre-existing Meteora factory size + orra mutability warnings)
- [x] All cpi unit tests pass (`tests/cpi/*.test.ts`): 76 passing
- [x] Touched oracle parser tests pass: 24 passing
- [ ] Integration tests against live Rome stack — covered by SPL_ERC20 / oracle adapter integration runs on `--network local` (require live stack; not in CI)
- [ ] No ABI / behavioral changes; AccountReader.X(...) is byte-identical to `CpiProgram.account_X(...)` it replaces

## Cross-references

- Library scope per red-team review (2026-05-14): typed reads only, no invariant helpers
- Selector hex verified against `rome-evm-private/program/src/non_evm/cpi.rs` const definitions per `rome-evm-private/CLAUDE.md` §"Non-EVM Bridge"
- Out of scope: `BatchPdaDeriver` (gated on Phase 3 CU measurement); `SplTransfer` façade (only if paired with adapter-authoring-guide update); `AtaLifecycle` / `SystemProgramHelper` (scrapped — overlap with existing surface)