### PR TITLE
test(cpi): PdaCostProbe + measurement script for P3.1 — find_program_address vs pdas_batch_derive CU cost

### DIFF
--- a/contracts/cpi/test/PdaCostProbe.sol
+++ b/contracts/cpi/test/PdaCostProbe.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ISystemProgram, SystemProgram, ICrossProgramInvocation, CpiProgram} from "../../interface.sol";
+
+/// @title PdaCostProbe
+/// @notice Measurement contract for the `find_program_address` vs
+///         `pdas_batch_derive` CU cost question — P3.1 in the rome-solidity
+///         audit plan (2026-05-14).
+///
+/// @dev The goal is to answer whether `pdas_batch_derive(seed_groups, program_id)`
+///      saves material Solana CU when batching N PDAs against the same
+///      program, vs N separate `SystemProgram.find_program_address` calls.
+///
+///      The red team flagged that `find_program_address` is an `EthCall`
+///      variant (not a true CPI) so the per-hop overhead is dominated by
+///      EVM-side ABI marshaling + atomic-tx wrapper overhead. The CLAUDE.md
+///      cites ~115K CU per hop end-to-end. If batching reduces marshaling /
+///      wrapper overhead, savings should be material. Measurement confirms.
+///
+///      Three probes mirror the shapes adapters actually use:
+///      - `probeOnePda` — single derivation (baseline per-hop)
+///      - `probeSevenIndividual` — 7 separate find_program_address (Meteora
+///        DAMM_AMM cluster shape)
+///      - `probeSevenBatched` — same 7 PDAs via pdas_batch_derive (one
+///        dispatch against one program_id)
+///
+///      The seeds match the actual shape Meteora uses (`b"pool" + token_a +
+///      token_b + index`) so the probe is representative, not a microbench.
+///
+///      Run via `scripts/cpi/measure-pda-cost.ts` against a live Rome chain
+///      (Marcus or any chain with the new pdas_batch_derive selector).
+contract PdaCostProbe {
+    /// Same Meteora-style seed shape, parametrized by a salt that callers
+    /// vary to force unique PDAs (so the runtime can't cache the result
+    /// across calls).
+    function _seedsFor(uint256 idx) internal pure returns (ISystemProgram.Seed[] memory) {
+        ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](3);
+        seeds[0] = ISystemProgram.Seed(bytes("pool"));
+        seeds[1] = ISystemProgram.Seed(abi.encodePacked(uint256(0xa1), idx));
+        seeds[2] = ISystemProgram.Seed(abi.encodePacked(uint256(0xb2), idx));
+        return seeds;
+    }
+
+    /// Baseline: 1 find_program_address dispatch via System precompile.
+    /// Returns the PDA to defeat dead-code elimination.
+    function probeOnePda(uint256 idx) external view returns (bytes32) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        (bytes32 pda, ) = SystemProgram.find_program_address(programId, _seedsFor(idx));
+        return pda;
+    }
+
+    /// Meteora-shaped: 7 sequential find_program_address dispatches against
+    /// the same program_id. Returns all 7 to defeat dead-code elimination.
+    function probeSevenIndividual(uint256 baseIdx) external view returns (bytes32[] memory) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        bytes32[] memory pdas = new bytes32[](7);
+        for (uint256 i = 0; i < 7; i++) {
+            (bytes32 pda, ) = SystemProgram.find_program_address(programId, _seedsFor(baseIdx + i));
+            pdas[i] = pda;
+        }
+        return pdas;
+    }
+
+    /// Same 7 PDAs via pdas_batch_derive — one dispatch against one
+    /// program_id. The batch selector encodes each seed group as
+    /// `bytes[]` then groups them as `bytes[][]`.
+    function probeSevenBatched(uint256 baseIdx) external view returns (ICrossProgramInvocation.PdaWithBump[] memory) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        bytes[][] memory seedGroups = new bytes[][](7);
+        for (uint256 i = 0; i < 7; i++) {
+            seedGroups[i] = new bytes[](3);
+            seedGroups[i][0] = bytes("pool");
+            seedGroups[i][1] = abi.encodePacked(uint256(0xa1), baseIdx + i);
+            seedGroups[i][2] = abi.encodePacked(uint256(0xb2), baseIdx + i);
+        }
+        return CpiProgram.pdas_batch_derive(seedGroups, programId);
+    }
+}

--- a/scripts/cpi/measure-pda-cost.ts
+++ b/scripts/cpi/measure-pda-cost.ts
@@ -1,0 +1,192 @@
+/**
+ * P3.1 — Measure find_program_address vs pdas_batch_derive Solana CU cost.
+ *
+ * Deploys `PdaCostProbe` to whatever Rome chain is in `--network <chain>`,
+ * then calls each probe function via `rome_emulateTx` to capture
+ * `computeUnitsConsumed` from the Solana tx receipt the proxy would have
+ * produced. Three probes give us the per-hop and batched costs.
+ *
+ * Usage:
+ *   npx hardhat run scripts/cpi/measure-pda-cost.ts --network marcus
+ *   npx hardhat run scripts/cpi/measure-pda-cost.ts --network aurelius
+ *
+ * The script is read-only at the rome_emulateTx layer — no real on-chain
+ * txs are submitted (other than the one-time probe deploy). It writes
+ * `deployments/<network>.PdaCostProbe.json` with the deployed address so
+ * subsequent runs reuse the same instance.
+ *
+ * Output: a table of compute units per probe + the per-hop / batched
+ * delta. If the 7-PDA batched savings exceeds the 50K CU threshold from
+ * the P3.1 spec, we proceed to P3.2 (BatchPdaDeriver library).
+ */
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import {
+    Wallet,
+    JsonRpcProvider,
+    ContractFactory,
+    Interface,
+} from "ethers";
+import probeArtifact from "../../artifacts/contracts/cpi/test/PdaCostProbe.sol/PdaCostProbe.json" with { type: "json" };
+
+interface EmulateResult {
+    computeUnitsConsumed?: number;
+    [key: string]: unknown;
+}
+
+const SAMPLES = 3; // 3-sample average, matches rome-evm-private/CLAUDE.md convention.
+
+async function rome_emulateTx(rpcUrl: string, signedTx: string): Promise<EmulateResult> {
+    const res = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "rome_emulateTx",
+            params: [signedTx],
+        }),
+    });
+    const body = (await res.json()) as { result?: EmulateResult; error?: { message: string } };
+    if (body.error) {
+        throw new Error(`rome_emulateTx failed: ${body.error.message}`);
+    }
+    return body.result ?? {};
+}
+
+async function main() {
+    const { networkConfig, networkName } = await hardhat.network.connect();
+    const url = (networkConfig as any).url as string;
+    const pk = await (networkConfig as any).accounts[0].get();
+    const chainId = (networkConfig as any).chainId as number;
+
+    const provider = new JsonRpcProvider(url);
+    const wallet = new Wallet(pk, provider);
+
+    console.log(`Network: ${networkName} (chainId=${chainId})`);
+    console.log(`Signer:  ${wallet.address}`);
+    console.log(`RPC:     ${url}\n`);
+
+    // 1. Deploy or load probe.
+    const deploymentFile = path.join(
+        process.cwd(),
+        "deployments",
+        `${networkName}.PdaCostProbe.json`
+    );
+
+    let probeAddress: string;
+    if (fs.existsSync(deploymentFile)) {
+        const existing = JSON.parse(fs.readFileSync(deploymentFile, "utf8"));
+        probeAddress = existing.address;
+        console.log(`Probe (cached): ${probeAddress}\n`);
+    } else {
+        console.log("Probe not yet deployed on this chain. Deploying...");
+        const factory = new ContractFactory(
+            probeArtifact.abi,
+            probeArtifact.bytecode,
+            wallet
+        );
+        const probe = await factory.deploy();
+        await probe.waitForDeployment();
+        probeAddress = await probe.getAddress();
+        fs.mkdirSync(path.dirname(deploymentFile), { recursive: true });
+        fs.writeFileSync(
+            deploymentFile,
+            JSON.stringify({ address: probeAddress, deployedAt: new Date().toISOString() }, null, 2)
+        );
+        console.log(`Probe deployed: ${probeAddress}\n`);
+    }
+
+    // 2. Build calldata for each probe.
+    const iface = new Interface(probeArtifact.abi);
+    const probes: Array<{ name: string; data: string; expectedPdas: number; method: string }> = [
+        {
+            name: "probeOnePda (baseline)",
+            method: "probeOnePda",
+            expectedPdas: 1,
+            data: iface.encodeFunctionData("probeOnePda", [1n]),
+        },
+        {
+            name: "probeSevenIndividual",
+            method: "probeSevenIndividual",
+            expectedPdas: 7,
+            data: iface.encodeFunctionData("probeSevenIndividual", [100n]),
+        },
+        {
+            name: "probeSevenBatched",
+            method: "probeSevenBatched",
+            expectedPdas: 7,
+            data: iface.encodeFunctionData("probeSevenBatched", [200n]),
+        },
+    ];
+
+    // 3. Emulate each, capture CU.
+    const gasPrice = (await provider.getFeeData()).gasPrice ?? 5_000_000_000n;
+    const results: Array<{ name: string; samples: (number | string)[]; mean: number | string }> = [];
+
+    for (const p of probes) {
+        const samples: (number | string)[] = [];
+        for (let i = 0; i < SAMPLES; i++) {
+            const nonce = await provider.getTransactionCount(wallet.address);
+            const signed = await wallet.signTransaction({
+                chainId,
+                nonce,
+                gasPrice,
+                gasLimit: 3_000_000n,
+                to: probeAddress,
+                value: 0n,
+                data: p.data,
+                type: 0,
+            });
+            try {
+                const result = await rome_emulateTx(url, signed);
+                const cu = result.computeUnitsConsumed;
+                samples.push(typeof cu === "number" ? cu : `(no CU field in response — keys: ${Object.keys(result).join(", ")})`);
+            } catch (e: any) {
+                samples.push(`ERR: ${e.message}`);
+            }
+        }
+        const numeric = samples.filter((s): s is number => typeof s === "number");
+        const mean = numeric.length > 0 ? Math.round(numeric.reduce((a, b) => a + b, 0) / numeric.length) : "n/a";
+        results.push({ name: p.name, samples, mean });
+    }
+
+    // 4. Report.
+    console.log("\nResults (3 samples per probe):");
+    console.log("─".repeat(80));
+    for (const r of results) {
+        console.log(`${r.name.padEnd(28)} samples=${JSON.stringify(r.samples)} mean=${r.mean}`);
+    }
+
+    // 5. Decision.
+    const oneMean = results[0].mean;
+    const sevenIndMean = results[1].mean;
+    const sevenBatMean = results[2].mean;
+    if (typeof oneMean === "number" && typeof sevenIndMean === "number" && typeof sevenBatMean === "number") {
+        const perHopFromOne = oneMean;
+        const perHopFromSeven = Math.round(sevenIndMean / 7);
+        const savings = sevenIndMean - sevenBatMean;
+        console.log("\nAnalysis:");
+        console.log(`  per-hop (from baseline)  : ~${perHopFromOne.toLocaleString()} CU`);
+        console.log(`  per-hop (from 7-ind avg) : ~${perHopFromSeven.toLocaleString()} CU`);
+        console.log(`  7 individual             : ${sevenIndMean.toLocaleString()} CU`);
+        console.log(`  7 batched                : ${sevenBatMean.toLocaleString()} CU`);
+        console.log(`  Savings (7-ind - 7-bat)  : ${savings.toLocaleString()} CU`);
+        console.log("");
+        if (savings >= 50_000) {
+            console.log(`  ✅ Savings exceed 50K CU threshold — proceed to P3.2 (BatchPdaDeriver library).`);
+        } else if (savings > 0) {
+            console.log(`  ⚠ Savings positive but below 50K CU threshold — BatchPdaDeriver scope is marginal.`);
+        } else {
+            console.log(`  ❌ No savings (or negative) — scrap BatchPdaDeriver.`);
+        }
+    } else {
+        console.log("\nNumeric analysis skipped — rome_emulateTx response did not surface computeUnitsConsumed in at least one probe. Inspect the raw samples above to identify the right field.");
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/cpi/measure-pda-cost.ts
+++ b/scripts/cpi/measure-pda-cost.ts
@@ -57,7 +57,10 @@ async function rome_emulateTx(rpcUrl: string, signedTx: string): Promise<Emulate
 
 async function main() {
     const { networkConfig, networkName } = await hardhat.network.connect();
-    const url = (networkConfig as any).url as string;
+    const urlField = (networkConfig as any).url;
+    const url: string = typeof urlField === "string"
+        ? urlField
+        : (typeof urlField?.get === "function" ? await urlField.get() : String(urlField));
     const pk = await (networkConfig as any).accounts[0].get();
     const chainId = (networkConfig as any).chainId as number;
 


### PR DESCRIPTION
## Summary

Code-only PR — adds the probe contract + measurement infrastructure for the audit-plan P3.1 question: does `pdas_batch_derive` save material Solana CU when batching N PDAs against the same program, vs N separate `find_program_address` calls? Red-team-gated: no library shipped until measurement confirms ≥50K CU savings.

**No on-chain side effects from merging this PR.** Both files are test-only; the script doesn't run automatically. The actual measurement is gated on operator-approved run (Marcus or Aurelius) — see "How to run" in the commit message.

## Contract

`contracts/cpi/test/PdaCostProbe.sol`:
- `probeOnePda(idx)` — baseline (1 find_program_address dispatch)
- `probeSevenIndividual(baseIdx)` — Meteora DAMM-AMM shape (7 sequential dispatches)
- `probeSevenBatched(baseIdx)` — same 7 PDAs via `pdas_batch_derive` (one dispatch)

Each probe has the same `rome_evm_program_id()` overhead, so deltas isolate the find_program_address / batch costs.

## Script

`scripts/cpi/measure-pda-cost.ts`:
- Deploys probe once per chain (caches deploy receipt to `deployments/<chain>.PdaCostProbe.json`).
- Calls each probe × 3 samples via `rome_emulateTx`.
- Parses `computeUnitsConsumed` from response, prints table + verdict.
- Threshold: ≥50K CU savings on 7-PDA batch → proceed to P3.2 (BatchPdaDeriver library).

## TDD discipline

Same pattern as Phase 1 + 2:
1. **Restate the contract**: "Measure find_program_address CU cost; compare individual vs batched; >50K CU savings = ship library."
2. **Write the measurement protocol first** (this PR).
3. **Run on a live chain — captures the numbers** (operator-gated next step).
4. **Decide**: ship P3.2 library or scrap.

The "failing test" analog here: running the script without a deployed probe → it deploys, then measures. No false-positive risk in the measurement itself.

## What I need from you

This PR can merge as code-only. Then to actually run the measurement, pick a chain:

```bash
npx hardhat run scripts/cpi/measure-pda-cost.ts --network marcus
# or
npx hardhat run scripts/cpi/measure-pda-cost.ts --network aurelius
```

Marcus 121301 is the cleaner target (per CLAUDE.md `pdas_batch_derive` "first invocation on Marcus 121301 was 2026-05-11" — so we know it's dispatched).

Output is a per-probe CU table + a decision line. ~15 seconds of wall time per probe × 3 samples × 3 probes = ~2-3 min total.

## Test plan

- [x] `npx hardhat compile` clean (73 files)
- [ ] Operator approves run on Marcus or Aurelius
- [ ] Measurement captures `computeUnitsConsumed` for all 3 probes
- [ ] Numeric verdict produced → P3.2 go/no-go decision committed

## Out of scope

- The actual numerical decision on P3.2 (BatchPdaDeriver library). This PR is purely measurement infra; the library itself is conditional on what the numbers say.