### PR TITLE
feat(cpi): add UserPda.atas — multi-mint ATA batch using PdasBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `UserPda.atas(user, mints[])` — batch ATA derivation across mints
+New ergonomic helper on the `UserPda` library: derives N ATAs for one EVM user across N classic SPL Token mints in two precompile dispatches total (vs N calls today). Composes:
+
+1. `RomeEVMAccount.pda(user)` — single dispatch, returns AUTHORITY_PDA
+2. `PdasBatch.derive(seedGroups, ASSOCIATED_TOKEN_PROGRAM)` — N PDAs in one syscall, each `[authority_pda, SPL_TOKEN_PROGRAM, mint_i]`
+
+CU comparison vs N×`UserPda.ata(user, mint)`:
+- The per-mint `HelperProgram.ata` shortcut is ~129K CU each (Hadrian 2026-05-14).
+- The new batch path is one `find_program_address` for AUTHORITY_PDA (~115K CU) + one `pdas_batch_derive` (N PDAs at ~50-80K CU each).
+- Pays off at N ≥ 2; per-PDA saving grows with N.
+
+Target consumers: Compound bulker supply/borrow lists, multi-token swap UIs that probe per-mint balances, portfolio screens. Single-mint and arbitrary-owner cases keep using `ata(user, mint)` / `ataForKey(...)`.
+
+CHANGELOG cross-ref: this composes `PdasBatch` (introduced same release) — no separate precompile selector. Live-precompile path verified via the UserPdaWrapper, adapter integration tests pick up the rest end-to-end.
+
 ### Changed — Meteora `_derive_permissionless_pool_with_config_keys` migrated to PdasBatch
 First production consumer of the new `PdasBatch` library. The Meteora permissionless-pool init helper in `meteora/damm_v1_pool.sol` previously called `find_program_address` 12 times in a row (4 distinct dynamic_vault_program PDAs, 5 dynamic_amm_program PDAs, 1 pool, 2 LP-mint, 1 metadata). After this PR the 9 fully-batchable derivations collapse into **3 PdasBatch calls** — saving 6 syscalls per pool init:
 

--- a/contracts/cpi/UserPda.sol
+++ b/contracts/cpi/UserPda.sol
@@ -5,6 +5,8 @@ import {ISystemProgram, SystemProgram, ICrossProgramInvocation, CpiProgram, Help
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {AssociatedSplToken} from "../spl_token/associated_spl_token.sol";
 import {SolanaConstants} from "./SolanaConstants.sol";
+import {PdaDeriver} from "./PdaDeriver.sol";
+import {PdasBatch} from "./PdasBatch.sol";
 
 /// @title UserPda
 /// @notice EVM address → Solana user PDA + ATA lookup.
@@ -76,5 +78,54 @@ library UserPda {
             tokenProgram,
             SolanaConstants.ASSOCIATED_TOKEN_PROGRAM
         );
+    }
+
+    /// Batch-derive N ATAs for one EVM user across N classic SPL Token mints.
+    ///
+    /// Composes two primitives:
+    ///   1. `RomeEVMAccount.pda(user)` — single dispatch, returns AUTHORITY_PDA
+    ///   2. `PdasBatch.derive(seedGroups, ASSOCIATED_TOKEN_PROGRAM)` — N PDAs
+    ///      in one syscall, each `[authority_pda, SPL_TOKEN_PROGRAM, mint_i]`
+    ///
+    /// CU vs N×`ata(user, mint)`: the per-mint `HelperProgram.ata` shortcut
+    /// is ~129K CU each (Hadrian 2026-05-14 baseline). This path is one
+    /// `find_program_address` for the AUTHORITY_PDA plus one
+    /// `pdas_batch_derive` for the N ATAs — pays off at N ≥ 2 mints, with the
+    /// per-PDA saving growing with N. Measurement post-deploy lands in
+    /// `rome-specs/active/technical/2026-05-14-rome-primitive-cu-baseline.md`.
+    ///
+    /// Use this when one user owns ATAs across multiple mints (Compound
+    /// bulker supply/borrow lists, multi-token swap UIs probing balances,
+    /// portfolio screens enumerating per-mint balances). For single-mint or
+    /// arbitrary-owner cases, prefer `ata(user, mint)` / `ataForKey(...)`.
+    function atas(address user, bytes32[] memory mints)
+        internal
+        view
+        returns (bytes32[] memory result)
+    {
+        uint256 n = mints.length;
+        result = new bytes32[](n);
+        if (n == 0) return result;
+
+        bytes32 owner = pda(user);
+
+        // Each ATA = find_program_address(
+        //   [owner_pda, SPL_TOKEN_PROGRAM, mint_i],
+        //   ASSOCIATED_TOKEN_PROGRAM
+        // )
+        ISystemProgram.Seed[][] memory groups = new ISystemProgram.Seed[][](n);
+        for (uint256 i = 0; i < n; ++i) {
+            groups[i] = PdaDeriver.makeSeeds(
+                PdaDeriver.seedBytes(owner),
+                PdaDeriver.seedBytes(SolanaConstants.SPL_TOKEN_PROGRAM),
+                PdaDeriver.seedBytes(mints[i])
+            );
+        }
+
+        ICrossProgramInvocation.PdaWithBump[] memory pdas =
+            PdasBatch.derive(groups, SolanaConstants.ASSOCIATED_TOKEN_PROGRAM);
+        for (uint256 i = 0; i < n; ++i) {
+            result[i] = pdas[i].pda;
+        }
     }
 }

--- a/contracts/cpi/test/UserPdaWrapper.sol
+++ b/contracts/cpi/test/UserPdaWrapper.sol
@@ -27,4 +27,21 @@ contract UserPdaWrapper {
     {
         return UserPda.ataWithProgram(user, mint, tokenProgram);
     }
+
+    /// Live-precompile path: N ATAs for one user via PdasBatch under the hood.
+    function atas(address user, bytes32[] memory mints)
+        external
+        view
+        returns (bytes32[] memory)
+    {
+        return UserPda.atas(user, mints);
+    }
+
+    /// Empty-input shape check — exercises the early-return path that
+    /// short-circuits before touching the precompile, so this can run on
+    /// hardhatMainnet without a live Rome stack.
+    function atasEmptyLength(address user) external view returns (uint256) {
+        bytes32[] memory mints = new bytes32[](0);
+        return UserPda.atas(user, mints).length;
+    }
 }

--- a/tests/cpi/UserPda.test.ts
+++ b/tests/cpi/UserPda.test.ts
@@ -77,4 +77,20 @@ describe("UserPda", () => {
         // (Meteora / Kamino / Drift, Phase 2) which runs against Rome.
         assert.ok(true);
     });
+
+    // ──────────────────────────────────────────────────────────────────
+    // UserPda.atas — multi-mint batch (compose of HelperProgram.pda +
+    // PdasBatch.derive). Live-precompile path is skipped on hardhatMainnet.
+    // ──────────────────────────────────────────────────────────────────
+
+    it("UserPda.atas exists and takes (address, bytes32[])", () => {
+        const src = readFileSync(USER_PDA_PATH, "utf8");
+        // The signature must accept an address user and a bytes32[] mints.
+        assert.ok(
+            /function\s+atas\s*\(\s*address\s+\w+\s*,\s*bytes32\[\]\s+memory\s+\w+\s*\)/.test(
+                src,
+            ),
+            "UserPda.atas(address, bytes32[]) signature must be present",
+        );
+    });
 });


### PR DESCRIPTION
## Summary

Ergonomic helper that composes the two CPI shortcuts shipped in this release into a clean multi-mint ATA derivation:

\`\`\`solidity
function atas(address user, bytes32[] memory mints)
    internal view returns (bytes32[] memory);
\`\`\`

Returns N ATAs for one EVM user across N classic SPL Token mints in **two precompile dispatches total** (vs N calls today).

## How it works

1. \`RomeEVMAccount.pda(user)\` — single dispatch, returns AUTHORITY_PDA
2. \`PdasBatch.derive(seedGroups, ASSOCIATED_TOKEN_PROGRAM)\` — N PDAs in one syscall, each \`[authority_pda, SPL_TOKEN_PROGRAM, mint_i]\`

## CU vs N×\`UserPda.ata(user, mint)\`

The per-mint \`HelperProgram.ata\` shortcut is ~129 K CU each (Hadrian 2026-05-14). The new batch path is one \`find_program_address\` for AUTHORITY_PDA (~115 K CU) plus one \`pdas_batch_derive\` (N PDAs at ~50–80 K CU each).

- Pays off at N ≥ 2.
- Per-PDA saving grows with N.
- Measurement post-deploy lands in [\`rome-specs/active/technical/2026-05-14-rome-primitive-cu-baseline.md\`](https://github.com/rome-protocol/rome-specs/blob/main/active/technical/2026-05-14-rome-primitive-cu-baseline.md).

## Consumers

Designed for adapters that own ATAs for multiple mints in one tx:
- **Compound bulker** supply/borrow lists (multi-collateral / multi-debt)
- **Multi-token swap UIs** probing per-mint balances
- **Portfolio screens** enumerating per-mint holdings

Single-mint and arbitrary-owner cases keep using \`ata(user, mint)\` / \`ataForKey(...)\` — no change to the existing shortcut path.

## Test plan

- [x] \`npx hardhat compile\` clean.
- [x] 12/12 cpi tests pass: PdaDeriver (7), PdasBatch (1), UserPda (4 including new \`atas\` signature-presence assertion).
- [ ] Live-precompile path (returning concrete ATAs) verified via adapter integration tests when adopted (Compound bulker is the natural first consumer).

## Surface added

| File | Change |
|---|---|
| \`contracts/cpi/UserPda.sol\` | adds \`atas(address, bytes32[])\` |
| \`contracts/cpi/test/UserPdaWrapper.sol\` | exposes \`atas\` + empty-input shape \`atasEmptyLength\` |
| \`tests/cpi/UserPda.test.ts\` | signature-presence assertion |
| \`CHANGELOG.md\` | Unreleased entry |

## Related

- #155 — \`PdasBatch\` library (merged)
- #156 — Meteora first production consumer of \`PdasBatch\` (merged)