### PR TITLE
docs(cpi/README): add PdasBatch to the library inventory

### DIFF
--- a/contracts/cpi/README.md
+++ b/contracts/cpi/README.md
@@ -259,7 +259,8 @@ See cardo-foundation.md §12 for the full list. Highlights:
 | `CostEstimator.sol` | Rent formula + USD helpers + oracleReads audit trail |
 | `CpiError.sol` | AmountTooLarge + 3 other shared errors |
 | `ICostView.sol` | `quoteCost(address, bytes) view → CostEstimate` |
-| `PdaDeriver.sol` | `find_program_address` + typed seed helpers + N-arg makeSeeds |
+| `PdaDeriver.sol` | `find_program_address` + typed seed helpers + N-arg makeSeeds (single PDA via `0xFF…07`) |
+| `PdasBatch.sol` | `pdas_batch_derive` wrapper — N PDAs against one program in one syscall (`0xFF…08` / `0x944336f8`). Use over N×`PdaDeriver.derive` whenever you derive ≥2 PDAs back-to-back. Convenience: `pair` / `triplet` / `quad` for common shapes. Worked example: `contracts/examples/pdas_batch.sol`. |
 | `SolanaConstants.sol` | Sysvars + System/Token programs |
 | `UserPda.sol` | EVM user → Solana PDA + ATA (no tx.origin) |
 | `templates/CpiAdapterBase.sol` | Ownable + Pausable + ReentrancyGuard + backend |


### PR DESCRIPTION
## Summary

Adds \`PdasBatch\` to the Cardo CPI Foundation library inventory at \`contracts/cpi/README.md\`. That table is the entry point adapter authors read first; having both single-PDA (\`PdaDeriver\`) and multi-PDA (\`PdasBatch\`) paths listed side-by-side lets them pick by shape without re-reading the precompile docs.

## Why

The PdasBatch library shipped in #155 with full NatSpec + a worked example, and #156 + #157 added the first two production consumers (Meteora pool init + UserPda.atas). The README — which is the canonical adapter-authoring guide for Cardo + downstream consumers — hadn't been updated.

## Diff

\`\`\`
- | \`PdaDeriver.sol\` | \`find_program_address\` + typed seed helpers + N-arg makeSeeds |
+ | \`PdaDeriver.sol\` | \`find_program_address\` + typed seed helpers + N-arg makeSeeds (single PDA via \`0xFF…07\`) |
+ | \`PdasBatch.sol\`  | \`pdas_batch_derive\` wrapper — N PDAs against one program in one syscall (\`0xFF…08\` / \`0x944336f8\`). Use over N×\`PdaDeriver.derive\` whenever you derive ≥2 PDAs back-to-back. Convenience: \`pair\` / \`triplet\` / \`quad\` for common shapes. Worked example: \`contracts/examples/pdas_batch.sol\`. |
\`\`\`

## Related

- #155 — PdasBatch library
- #156 — Meteora migration (first production consumer)
- #157 — UserPda.atas batch ATA derivation