### PR TITLE
ci: add concurrency group + per-job timeouts to prevent stuck-queue failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,26 @@ on:
 permissions:
   contents: read
 
+# Cancel earlier runs of this workflow on the same ref. Closes the
+# stuck-queued failure mode we hit on 2026-05-15: a build-and-test job
+# sat in `queued` state for 50+ minutes (GitHub Actions runner-pickup
+# glitch); the parent workflow eventually got marked `failure` even
+# though no test had run. Subsequent pushes used to leave the stuck
+# run alongside the new one. With this group, the next push cancels
+# the prior queue + lets the new run start clean.
+#
+# Group key uses `github.ref` so PRs (branch-scoped) and master
+# (master-scoped) each cancel their own predecessors independently.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # Fail-fast instead of hanging when a runner doesn't pick the job up.
+    # Average successful run is <2 min; 15 min is generous headroom.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -52,6 +69,7 @@ jobs:
     # when tx.origin was present. `tx.origin` is unambiguous enough in
     # Solidity that anchors aren't needed.
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Ban tx.origin in contracts/ (strict)
@@ -94,6 +112,7 @@ jobs:
     # any future CU constants in rome-solidity (e.g. an ERC20SPL deposit
     # CU budget) are caught without a config change.
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Check CU_* recon comment freshness
@@ -171,6 +190,7 @@ jobs:
     #     to mocha tests; never deployed.
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Two small workflow hardening fixes that close the stuck-queue failure mode we hit on 2026-05-15.

**Problem (observed today):**
- Master CI run on \`9bf7e24\` (commit from #156) marked the parent workflow as \`failure\` despite no real test failure. The \`build-and-test\` job sat in \`queued\` state for **50+ minutes** before the parent timed out. No runner ever picked it up — GitHub Actions runner-pickup glitch.
- Same class of stall blocked #157 for 30+ minutes; only resolved by pushing an empty-commit retrigger.

**Fix:**
1. **Top-level \`concurrency:\` group** keyed on \`github.ref\`. New pushes auto-cancel prior queued runs on the same branch/PR. Eliminates the "stuck old run + fresh new run" twin-run problem.
2. **\`timeout-minutes:\` on every job.** Without these, a stuck job defaults to the GHA per-job 360-minute ceiling, chokes the workflow, and the parent eventually marks failure with no diagnostics. Targets (generous headroom over observed averages):
   - \`build-and-test\` — 15 min (typical <2 min)
   - \`tx-origin-ban\` — 5 min (shell grep only)
   - \`cu-recon-staleness\` — 5 min (python scan only)
   - \`slither\` — 20 min (compile + crytic-compile shim + slither)

## Verification

This is a workflow YAML config change — no unit test framework applies. Verification is empirical via the next push on the branch + the next stuck-job incident:

- **Smoke:** when this PR opens, CI fires once. Push a no-op commit, observe only ONE in-flight run (the new) and the prior is auto-cancelled by the concurrency group.
- **Stuck-job behavior:** the next time GHA's runner pool glitches, the job will error in ≤15 min instead of sitting for hours.

## Net effect

- Operator pushing a fix to a PR with a queued earlier run no longer needs to manually cancel.
- The merge train doesn't get blocked by a single bad GHA scheduling moment.
- "Master CI failure" alerts will mean real failures, not infrastructure stalls.

## Diff

20 lines added in \`.github/workflows/ci.yml\`. No code paths affected.