### PR TITLE
fix(erc20spl): saturate approve at u64::MAX + sentinel allowance readback (FB-1)

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -343,7 +343,11 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         }
 
         // Read the u64 delegated_amount at offset 121 directly.
-        return uint256(AccountReader.readU64At(ata, 121));
+        // Sentinel: if storage saturated at u64::MAX, surface as type(uint256).max
+        // so wallets that use MaxUint256 as the "infinite approval" sentinel keep
+        // working — see approve() below.
+        uint64 delegated = AccountReader.readU64At(ata, 121);
+        return delegated == type(uint64).max ? type(uint256).max : uint256(delegated);
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {
@@ -356,14 +360,24 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         bytes32 ownerUser = _users.ensure_user(msg.sender);
         bytes32 spenderUser = _users.ensure_user(spender);
 
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) = 
+        // SPL Token stores delegated_amount as u64 on-chain; we cannot
+        // expand the storage layer. Saturate when the caller's value
+        // exceeds type(uint64).max. The companion allowance() reader
+        // surfaces uint64.max storage as type(uint256).max so the
+        // standard wallet pattern `if allowance == MaxUint256` keeps
+        // working as an "infinite approval" sentinel.
+        uint64 storedAmount = value > type(uint64).max
+            ? type(uint64).max
+            : uint64(value);
+
+        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) =
         SplTokenLib.approve(
             SplTokenLib.SPL_TOKEN_PROGRAM,
             get_token_account(msg.sender),
             spenderUser,
             ownerUser,
             new bytes32[](0),
-            uint64(value)
+            storedAmount
         );
 
         // Only the owner's unified user PDA signs — auto-detected from metas.
@@ -375,8 +389,15 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
             )
         );
 
-        require (success, string(Convert.revert_msg(result)));
-        emit Approval(msg.sender, spender, value);
+        require(success, string(Convert.revert_msg(result)));
+
+        // Emit the effective approval — when storage saturates at u64::MAX
+        // surface as MaxUint256 so the on-chain event matches the readback
+        // from allowance().
+        uint256 emittedValue = storedAmount == type(uint64).max
+            ? type(uint256).max
+            : uint256(storedAmount);
+        emit Approval(msg.sender, spender, emittedValue);
         return true;
     }
 

--- a/contracts/erc20spl/test/ApproveSaturationHelper.sol
+++ b/contracts/erc20spl/test/ApproveSaturationHelper.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// Mirror of the saturation + sentinel arithmetic used in SPL_ERC20.approve
+/// and SPL_ERC20.allowance. Pure functions so this is testable on
+/// hardhat-network without the SPL CPI roundtrip.
+///
+/// SPL Token stores `delegated_amount` as a u64 on-chain. The wrapper's
+/// public ERC20 surface speaks `uint256`. When the caller passes a value
+/// that exceeds u64::MAX we MUST saturate at u64::MAX (truncating would
+/// silently corrupt the on-chain delegation). At read time we surface a
+/// saturated storage cell as `type(uint256).max` so the common wallet
+/// pattern `if allowance == MaxUint256` keeps recognizing infinite
+/// approvals.
+contract ApproveSaturationHelper {
+    /// @notice The arithmetic SPL_ERC20.approve uses to derive (stored_u64, emitted_uint256).
+    function saturateApproval(uint256 value) external pure returns (uint64 stored, uint256 emitted) {
+        stored = value > type(uint64).max ? type(uint64).max : uint64(value);
+        emitted = stored == type(uint64).max ? type(uint256).max : uint256(stored);
+    }
+
+    /// @notice The arithmetic SPL_ERC20.allowance uses to surface the u64 delegated_amount as uint256.
+    function readAllowance(uint64 delegated) external pure returns (uint256) {
+        return delegated == type(uint64).max ? type(uint256).max : uint256(delegated);
+    }
+}

--- a/tests/erc20spl/approve-saturation.test.ts
+++ b/tests/erc20spl/approve-saturation.test.ts
@@ -1,0 +1,122 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// FB-1 regression suite for the saturation + sentinel arithmetic used by
+/// `SPL_ERC20.approve` and `SPL_ERC20.allowance`. The on-chain SPL CPI
+/// roundtrip is out of scope for hardhat-network — this verifies the pure
+/// Solidity arithmetic via a mirror helper. The table is the FB-1 spec.
+describe("SPL_ERC20 approve saturation + sentinel arithmetic (FB-1)", function () {
+    let helper: any;
+
+    const U64_MAX = (1n << 64n) - 1n;
+    const U256_MAX = (1n << 256n) - 1n;
+    const U128_MAX = (1n << 128n) - 1n;
+
+    before(async function () {
+        const { viem } = await hardhat.network.connect();
+        helper = await viem.deployContract("ApproveSaturationHelper", []);
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // saturateApproval — what approve() will store + emit
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("saturateApproval", function () {
+        it("value=0 — stores 0, emits 0", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([0n]);
+            assert.equal(stored, 0n);
+            assert.equal(emitted, 0n);
+        });
+
+        it("value=1000 — stores 1000, emits 1000", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([1000n]);
+            assert.equal(stored, 1000n);
+            assert.equal(emitted, 1000n);
+        });
+
+        it("value=u64.max - 1 — stores u64.max - 1, emits u64.max - 1 (not saturated)", async function () {
+            const v = U64_MAX - 1n;
+            const [stored, emitted] = await helper.read.saturateApproval([v]);
+            assert.equal(stored, v);
+            assert.equal(emitted, v);
+        });
+
+        it("value=u64.max — stores u64.max, emits type(uint256).max (sentinel kicks in at the boundary)", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([U64_MAX]);
+            assert.equal(stored, U64_MAX);
+            assert.equal(emitted, U256_MAX);
+        });
+
+        it("value=u64.max + 1 — stores u64.max (saturated), emits type(uint256).max", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([U64_MAX + 1n]);
+            assert.equal(stored, U64_MAX);
+            assert.equal(emitted, U256_MAX);
+        });
+
+        it("value=u128.max — stores u64.max (saturated), emits type(uint256).max", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([U128_MAX]);
+            assert.equal(stored, U64_MAX);
+            assert.equal(emitted, U256_MAX);
+        });
+
+        it("value=type(uint256).max — stores u64.max (saturated), emits type(uint256).max", async function () {
+            const [stored, emitted] = await helper.read.saturateApproval([U256_MAX]);
+            assert.equal(stored, U64_MAX);
+            assert.equal(emitted, U256_MAX);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // readAllowance — what allowance() reads back from u64 storage
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("readAllowance", function () {
+        it("delegated=0 — reads 0", async function () {
+            const result = await helper.read.readAllowance([0n]);
+            assert.equal(result, 0n);
+        });
+
+        it("delegated=1000 — reads 1000", async function () {
+            const result = await helper.read.readAllowance([1000n]);
+            assert.equal(result, 1000n);
+        });
+
+        it("delegated=u64.max - 1 — reads u64.max - 1 (no sentinel)", async function () {
+            const v = U64_MAX - 1n;
+            const result = await helper.read.readAllowance([v]);
+            assert.equal(result, v);
+        });
+
+        it("delegated=u64.max — reads type(uint256).max (infinite-approval sentinel)", async function () {
+            const result = await helper.read.readAllowance([U64_MAX]);
+            assert.equal(result, U256_MAX);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // Round-trip: approve(value) → readAllowance(stored) must match the
+    // event payload that approve() emits. This is the key invariant —
+    // event/state divergence is the FB-1 bug we're fixing.
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("emitted == readAllowance(stored) round-trip invariant", function () {
+        const inputs: Array<{ label: string; value: bigint }> = [
+            { label: "0", value: 0n },
+            { label: "1000", value: 1000n },
+            { label: "u64.max - 1", value: U64_MAX - 1n },
+            { label: "u64.max", value: U64_MAX },
+            { label: "u64.max + 1", value: U64_MAX + 1n },
+            { label: "u128.max", value: U128_MAX },
+            { label: "type(uint256).max", value: U256_MAX },
+        ];
+
+        for (const { label, value } of inputs) {
+            it(`value=${label} — emitted matches allowance readback`, async function () {
+                const [stored, emitted] = await helper.read.saturateApproval([value]);
+                const readback = await helper.read.readAllowance([stored]);
+                assert.equal(readback, emitted);
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- `SPL_ERC20.approve(uint256 value)` silently truncated to `uint64(value)` and emitted the **original** value in `Approval`, producing event/state divergence.
- `SPL_ERC20.allowance(...)` read back the truncated `u64` directly as `uint256`, so a caller approving `MaxUint256` saw `Approval(... MaxUint256)` but `allowance()` returned `u64::MAX` (18446744073709551615) — wallets using the canonical `if allowance == MaxUint256` infinite-approval check saw every approval as "non-infinite" and re-approved on every tx.
- Forward-only fix per project policy; no Hadrian-side patching. Sentinel design preserves Ethereum wallet UX:
  - `approve` saturates to `u64::MAX` when `value > type(uint64).max`; emits `Approval` with `MaxUint256` when storage hits the ceiling, original value otherwise.
  - `allowance` returns `MaxUint256` when on-chain `delegated_amount == u64::MAX`.

## Evidence

- Surfaced by the 2026-05-15 Wave 0 fresh-wallet Hadrian probe: `approve(router, MaxUint256)` → `allowance(fresh, router)` returned `18446744073709551615`, not `MaxUint256`.

## Test plan

- [x] `tests/erc20spl/approve-saturation.test.ts` — 18 passing, full saturation table (0, 1000, u64.max-1, u64.max, u64.max+1, u128.max, uint256.max), event/state round-trip invariant
- [x] `npx hardhat compile` clean
- [ ] Integration verification on next Rome chain bring-up (Hadrian wrappers stay broken per project policy)