### PR TITLE
fix(erc20spl): make view methods ERC-20 spec compliant (FB-2)

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -206,6 +206,18 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // 46..81 freeze_authority COption. `account_u64_at` reads exactly
         // the 8-byte supply field directly — no full mint Borsh decode,
         // no 5-tuple ABI roundtrip.
+        //
+        // ERC-20 spec invariant (FB-2c): never revert on a view method.
+        // When the mint account is uninitialized — wrapper deployed against
+        // a stale or never-funded mint address — `account_u64_at(mint, 36)`
+        // would revert "account_u64_at: offset 36 + 8 out of 0 bytes",
+        // breaking every consumer that probes totalSupply on chain
+        // bring-up. `account_lamports` is the cheap existence probe (no
+        // data buffer pull) used symmetrically by `balanceOf` and
+        // `allowance` below.
+        if (AccountReader.lamportsOf(mint_id) == 0) {
+            return 0;
+        }
         return uint256(AccountReader.readU64At(mint_id, 36));
     }
 
@@ -321,8 +333,31 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function allowance(address owner, address spender) public view virtual returns (uint256) {
-        bytes32 spenderUser = _users.get_user(spender);
+        // FB-2a: derive the spender's unified PDA directly via the
+        // global precompile instead of `_users.get_user(spender)`,
+        // which reverted "User does not exist" when the spender had
+        // never been registered in this wrapper's ERC20Users mapping.
+        // Both paths compute `find_program_address([EXTERNAL_AUTHORITY,
+        // spender], rome_evm)` — byte-identical result. The mapping is
+        // still needed by `approve()` (which calls `ensure_user` to
+        // record the EVM addr) but a read-only `allowance()` consumer
+        // (DEX router probe, wallet UI) must not require any prior
+        // wrapper-side registration of the spender. ERC-20 spec: the
+        // allowance of any unapproved pair is 0, NEVER a revert.
+        bytes32 spenderUser = HelperProgram.pda(spender);
         bytes32 ata = get_token_account(owner);
+
+        // FB-2b: gate the data read behind a lamports existence probe.
+        // When the owner's ATA is uninitialized — fresh user, never
+        // received this token — the underlying buffer is 0 bytes and
+        // `account_data_at(ata, 72, 36)` reverts
+        //   "account_data_at: range 72..108 out of 0 bytes"
+        // forcing every wallet / router / multicall probe to wrap
+        // `allowance()` in try/catch. Same symmetric pattern as
+        // `balanceOf`: no ATA → no balance → no delegate possible → 0.
+        if (AccountReader.lamportsOf(ata) == 0) {
+            return 0;
+        }
 
         // SPL TokenAccount delegate is `COption<Pubkey>` at offset 72:
         //   72..75 tag (u32 LE; 0 = None, 1 = Some)

--- a/contracts/erc20spl/test/ViewDefensiveHelper.sol
+++ b/contracts/erc20spl/test/ViewDefensiveHelper.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/// Mirror of the defensive-guard arithmetic used in `SPL_ERC20.allowance`
+/// and `SPL_ERC20.totalSupply` post-FB-2. Pure functions so the predicate
+/// + early-exit + sentinel-readback logic is testable on hardhat-network
+/// without the SPL CPI roundtrip.
+///
+/// The three pre-FB-2 bugs (verified Hadrian 2026-05-15):
+///   FB-2a: `allowance` reverted "User does not exist" when the spender
+///          had never been registered in the wrapper's ERC20Users mapping
+///          (because allowance called `_users.get_user(spender)`).
+///   FB-2b: `allowance` reverted with "account_data_at: range 72..108
+///          out of 0 bytes" when the owner had no ATA for this mint
+///          (because it read 36 bytes from offset 72 of an empty buffer).
+///   FB-2c: `totalSupply` reverted similarly when the SPL mint account
+///          was uninitialized.
+///
+/// The fix substitutes `HelperProgram.pda(spender)` for the get_user
+/// lookup (FB-2a — same derivation, never reverts) AND gates the
+/// readBytesAt / readU64At calls behind `account_lamports(account) > 0`
+/// existence probes (FB-2b + FB-2c — matches the balanceOf pattern shipped
+/// post-0acabea). All three view methods then return 0 instead of
+/// reverting, which is what ERC-20 consumers (DEX routers, wagmi
+/// multicall, wallet UIs) expect.
+contract ViewDefensiveHelper {
+    /// @notice Pure mirror of SPL_ERC20.allowance's post-FB-2 control flow.
+    ///
+    /// FB-2 scope is the missing-state guards only — does NOT include
+    /// FB-1's u64::MAX → MaxUint256 sentinel (that lives in PR #160 and
+    /// will merge into allowance() separately; either order is fine).
+    ///
+    /// Inputs are the OBSERVED state the real wrapper would see from
+    /// the SPL CPI roundtrips:
+    /// @param ataLamports     `AccountReader.lamportsOf(ownerAta)` — 0 ⇔ ATA missing.
+    /// @param delegateIsSome  `COption<Pubkey>` tag at offset 72..76 of the ATA.
+    /// @param storedDelegate  `Pubkey` at offset 76..108 of the ATA (only meaningful when `delegateIsSome`).
+    /// @param spenderPda      `HelperProgram.pda(spender)` — never reverts, matches `external_auth(spender)`.
+    /// @param delegatedAmount `u64 LE` at offset 121 of the ATA (only meaningful when `delegateIsSome`).
+    ///
+    /// Branches:
+    ///  - FB-2b: `ataLamports == 0` → return 0 (owner has no ATA, no allowance possible).
+    ///  - mismatched delegate → return 0.
+    ///  - otherwise → return `uint256(delegatedAmount)`.
+    function tryReadAllowance(
+        uint64 ataLamports,
+        bool delegateIsSome,
+        bytes32 storedDelegate,
+        bytes32 spenderPda,
+        uint64 delegatedAmount
+    ) external pure returns (uint256) {
+        // FB-2b: missing-ATA early exit. Must fire BEFORE any readBytesAt
+        // (real contract) since the SPL precompile reverts on a zero-byte
+        // buffer.
+        if (ataLamports == 0) {
+            return 0;
+        }
+
+        // FB-2a: `HelperProgram.pda(spender)` is precomputed by the
+        // caller; the real wrapper substitutes that for the
+        // `_users.get_user(spender)` lookup that used to revert when
+        // the spender had no ERC20Users mapping entry.
+        bytes32 delegate = delegateIsSome ? storedDelegate : bytes32(0);
+        if (delegate != spenderPda) {
+            return 0;
+        }
+
+        return uint256(delegatedAmount);
+    }
+
+    /// @notice Pure mirror of SPL_ERC20.totalSupply's post-FB-2 control flow.
+    ///
+    /// @param mintLamports    `AccountReader.lamportsOf(mintId)` — 0 ⇔ mint missing.
+    /// @param onChainSupply   `u64 LE` at offset 36 of the mint account (only meaningful when `mintLamports > 0`).
+    function tryReadTotalSupply(uint64 mintLamports, uint64 onChainSupply)
+        external
+        pure
+        returns (uint256)
+    {
+        if (mintLamports == 0) {
+            return 0;
+        }
+        return uint256(onChainSupply);
+    }
+}

--- a/tests/erc20spl/view-defensive.test.ts
+++ b/tests/erc20spl/view-defensive.test.ts
@@ -1,0 +1,210 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/// FB-2 regression suite for the defensive-guard arithmetic used by the
+/// SPL_ERC20 view methods `allowance` and `totalSupply`. The on-chain SPL
+/// CPI roundtrips that read the SPL Mint + TokenAccount account buffers
+/// cannot run on hardhat-network — this verifies the predicate + early-exit
+/// arithmetic via a mirror helper contract, identical in shape to FB-1's
+/// `ApproveSaturationHelper`.
+///
+/// The contract-level arithmetic is the new behavior we're locking in:
+///   FB-2a: when the spender has never been registered in the wrapper's
+///          ERC20Users mapping, allowance must derive the spender's
+///          unified PDA via HelperProgram.pda(spender) instead of
+///          reverting via _users.get_user. Comparison against the on-chain
+///          delegate field then resolves to "no match" → returns 0.
+///   FB-2b: when the owner has no ATA yet for this wrapper's mint, the
+///          ATA-read path is skipped and allowance returns 0 (matches
+///          ERC-20 spec: never revert on a missing/empty pair).
+///   FB-2c: when the SPL mint account itself is uninitialized, totalSupply
+///          returns 0 instead of reverting via the underlying u64 read.
+///
+/// The harness uses `account_lamports(account) > 0` as the existence
+/// probe — the same pattern balanceOf shipped (post-0acabea) for symmetric
+/// behavior across the three view methods.
+describe("SPL_ERC20 view-method defensive guards (FB-2)", function () {
+    let helper: any;
+
+    const U64_MAX = (1n << 64n) - 1n;
+
+    // Stand-in values for tests; the helper doesn't actually read on-chain.
+    const FAKE_SPENDER_PDA = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    const FAKE_OTHER_PDA = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    const ZERO_BYTES32 = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    before(async function () {
+        const { viem } = await hardhat.network.connect();
+        helper = await viem.deployContract("ViewDefensiveHelper", []);
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // FB-2a — allowance with unregistered spender
+    //
+    // Pre-fix: `_users.get_user(spender)` reverts "User does not exist"
+    // when the spender has never been registered via `ensure_user`.
+    // Post-fix: we use `HelperProgram.pda(spender)` instead — never
+    // reverts; same PDA derivation. When the on-chain delegate field
+    // does not match the spender's PDA, allowance returns 0.
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("FB-2a — tryReadAllowance with unregistered spender", function () {
+        it("returns 0 when owner ATA exists but on-chain delegate does not match", async function () {
+            // Owner has tokens (ATA exists, lamports > 0). On-chain
+            // delegate is unset (is_some = false). Spender PDA from
+            // HelperProgram.pda is FAKE_SPENDER_PDA. No match → 0.
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 12345n,
+                /* delegateIsSome */ false,
+                /* storedDelegate */ ZERO_BYTES32,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ 0n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("returns 0 when delegate is some-but-different from spender PDA", async function () {
+            // Owner approved someone else; allowance(owner, our spender)
+            // must return 0 since our spender's PDA differs from the
+            // recorded delegate.
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 12345n,
+                /* delegateIsSome */ true,
+                /* storedDelegate */ FAKE_OTHER_PDA,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ 999n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("returns the delegated amount when on-chain delegate matches spender PDA", async function () {
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 12345n,
+                /* delegateIsSome */ true,
+                /* storedDelegate */ FAKE_SPENDER_PDA,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ 1000n,
+            ]);
+            assert.equal(result, 1000n);
+        });
+
+        it("returns the raw u64 value at the upper bound (FB-2 scope; FB-1 PR #160 adds the MaxUint256 sentinel separately)", async function () {
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 12345n,
+                /* delegateIsSome */ true,
+                /* storedDelegate */ FAKE_SPENDER_PDA,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ U64_MAX,
+            ]);
+            assert.equal(result, U64_MAX);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // FB-2b — allowance with owner's ATA missing
+    //
+    // Pre-fix: `AccountReader.readBytesAt(ata, 72, 36)` reverts
+    // "account_data_at: range 72..108 out of 0 bytes" when the owner's
+    // ATA is uninitialized.
+    // Post-fix: gate the readBytesAt behind a lamports>0 probe; return
+    // 0 when the ATA has no balance / no allocation.
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("FB-2b — tryReadAllowance with owner's ATA missing", function () {
+        it("returns 0 when ataLamports == 0 regardless of remaining inputs", async function () {
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 0n,
+                /* delegateIsSome */ true,
+                /* storedDelegate */ FAKE_SPENDER_PDA,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ 1000n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("returns 0 when ataLamports == 0 even if all other inputs match", async function () {
+            // The early-exit MUST fire BEFORE the delegate comparison.
+            // If it didn't, on a missing ATA the bytes32 read would
+            // revert on the real contract.
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 0n,
+                /* delegateIsSome */ false,
+                /* storedDelegate */ ZERO_BYTES32,
+                /* spenderPda */ ZERO_BYTES32,
+                /* delegatedAmount */ 0n,
+            ]);
+            assert.equal(result, 0n);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // FB-2c — totalSupply with uninitialized mint
+    //
+    // Pre-fix: `AccountReader.readU64At(mint_id, 36)` reverts when the
+    // SPL Mint account has 0 bytes of data.
+    // Post-fix: gate the u64 read behind a lamports>0 probe.
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("FB-2c — tryReadTotalSupply with uninitialized mint", function () {
+        it("returns 0 when mint account does not exist (lamports == 0)", async function () {
+            const result = await helper.read.tryReadTotalSupply([
+                /* mintLamports */ 0n,
+                /* onChainSupply */ 1_000_000n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("returns the on-chain supply when mint exists", async function () {
+            const result = await helper.read.tryReadTotalSupply([
+                /* mintLamports */ 5000000n,
+                /* onChainSupply */ 1_000_000n,
+            ]);
+            assert.equal(result, 1_000_000n);
+        });
+
+        it("returns 0 when mint exists but supply is 0 (uncirculated)", async function () {
+            const result = await helper.read.tryReadTotalSupply([
+                /* mintLamports */ 5000000n,
+                /* onChainSupply */ 0n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("returns u64.max supply faithfully (no sentinel — totalSupply is not allowance)", async function () {
+            const result = await helper.read.tryReadTotalSupply([
+                /* mintLamports */ 5000000n,
+                /* onChainSupply */ U64_MAX,
+            ]);
+            assert.equal(result, U64_MAX);
+        });
+    });
+
+    // ──────────────────────────────────────────────────────────────────
+    // ERC-20 spec invariant: view methods never revert on missing pairs
+    // ──────────────────────────────────────────────────────────────────
+
+    describe("ERC-20 spec invariant — never revert on missing state", function () {
+        it("allowance returns 0 for all-zero / unregistered inputs (fresh wallet probe)", async function () {
+            // Fresh wallet on a fresh wrapper: owner has no ATA, no
+            // delegate has ever been written, spender PDA is some
+            // derived value. The whole path resolves to 0.
+            const result = await helper.read.tryReadAllowance([
+                /* ataLamports */ 0n,
+                /* delegateIsSome */ false,
+                /* storedDelegate */ ZERO_BYTES32,
+                /* spenderPda */ FAKE_SPENDER_PDA,
+                /* delegatedAmount */ 0n,
+            ]);
+            assert.equal(result, 0n);
+        });
+
+        it("totalSupply returns 0 on a wrapper pointing at an uninitialized mint", async function () {
+            const result = await helper.read.tryReadTotalSupply([
+                /* mintLamports */ 0n,
+                /* onChainSupply */ 0n,
+            ]);
+            assert.equal(result, 0n);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Three sibling defects in SPL_ERC20 view methods reverted instead of returning defaults — violating the ERC-20 spec and breaking every fresh-user / fresh-recipient probe used by wallets and DEX routers. Forward-only; deployed wrappers stay broken.

- **FB-2a** `allowance(owner, spender)` reverted `"User does not exist"` when spender hadn't been approved on this wrapper (read path called `_users.get_user(spender)`). Fix: derive spender's `external_auth` PDA globally via `HelperProgram.pda(spender)` — byte-identical to `RomeEVMAccount.get_payer` but never reverts. `approve` continues to call `_users.ensure_user(spender)` for the write path; only the read path is changed.
- **FB-2b** `allowance(owner, spender)` reverted `"account_data_at: range 72..108 out of 0 bytes"` when the owner's wrapper-ATA didn't exist. Fix: `AccountReader.lamportsOf(ata) == 0 → return 0`, mirroring `balanceOf`'s existing defensive gate at `:230-232`.
- **FB-2c** `totalSupply()` would revert similarly when reading from an uninitialized SPL mint. Fix: same `lamportsOf` pre-gate at the read site.

## Evidence

Surfaced by the 2026-05-15 Wave 0 fresh-wallet Hadrian probe:
- `wUSDC.allowance(activated, freshAddr)` → reverts `"User does not exist"`
- `wUSDC.allowance(freshAddr, anything)` → reverts `"account_data_at: range 72..108 out of 0 bytes"`

Both branches now return 0 in the post-fix arithmetic.

## Test plan

- [x] `tests/erc20spl/view-defensive.test.ts` — 12 cases via `ViewDefensiveHelper.sol`, all sub-fixes + ERC-20 spec invariants
- [x] 51 network-independent unit tests pass (no regression in AccountReader / UserPda / PdaDeriver / oracle parsers)
- [x] `npx hardhat compile` exit 0
- [x] Auto-merge with FB-1 (https://github.com/rome-protocol/rome-solidity/pull/160) verified clean — no textual conflict despite both touching `allowance()`
- [ ] Integration verification on next Rome chain bring-up (Hadrian wrappers stay broken per project policy)

## Relationship to FB-1

FB-1 (#160) modifies `allowance()`'s final return (sentinel readback). FB-2 modifies the spender-PDA derivation + adds pre-gates. They commute; either order of merge works.