### PR TITLE
feat(erc20spl): direct-precompile rewrite — 5 hot paths via new HelperProgram selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed — `SPL_ERC20` hot paths direct-precompile rewrite (5 new HelperProgram selectors)
+
+Five `IHelperProgram` selectors (8 ABI sigs) added in [`rome-evm-private#363`](https://github.com/rome-protocol/rome-evm-private/pull/363) — `approve_spl` / `mint_spl` / `transfer_spl(addr,addr,...)` / `user_balance` / `allowance_of`. This PR migrates `SPL_ERC20`'s `approve` / `transferFrom` / `mint_to` / `balanceOf` / `allowance` off the Solidity-side SPL ix marshaling (`SplTokenLib.approve` / `SplTokenLib.mint_to_checked` + raw `CpiProgram.invoke_signed` via `delegatecall`) into the new dedicated HelperProgram selectors.
+
+CU per call:
+- Writes (approve / transferFrom delegate path / mint_to): ~140-180K Solana CU saved per call (Solidity-side AccountMeta[] + ix-data marshaling removed). Mirrors the measured −372 to −394K CU `transfer_spl` migration on Hadrian (2026-05-14 baseline).
+- Reads (balanceOf / allowance): ~37K CU saved per call (3-5 dispatch composition → 1 CrossStateEthCall).
+
+Other changes:
+- Deleted `SPL_ERC20.getAta(address) → bytes32` (no callers in this repo; cross-repo dependency sweep clean). New callers compose via `HelperProgram.ata(user, mint_id)` directly.
+- Internal helpers `ensure_token_account` / `get_token_account` / `create_token_account` kept (still used by `_transfer`, `mint_to`, and off-chain test/deploy scripts in `scripts/bridge/`, `tests/damm_v1_*.integration.ts`).
+- `ERC20Users.get_user` kept (8 callers in `damm_v1_factory.sol` + `damm_v1_pool.sol` rely on its "revert if unregistered" gate; migration deferred).
+- `ERC20SPLFactory.create_token_mint` + `init_token_mint` migrated off `users.get_user` to direct `HelperProgram.pda(msg.sender)` derivation (no behavior change — same address; runtime still catches under-funded PDA at `create_account`).
+- `mint_id` kept public (legit identity, analogous to `bridgeOutToSolana(bytes32 recipient, ...)` which spec explicitly keeps as "legit bytes32").
+- `ensureRecipientAta` kept (per `contracts/bridge/README.md:82` — "public utility"; consumed by rome-ui's `useOutboundSplBridge` legacy path).
+- `interface.sol` declares all 8 new selector signatures under `IHelperProgram`.
+- `CLAUDE.md` HelperProgram surface table extended with the 8 new rows.
+
+Status: hardhat compile passes (79 files). 39 erc20spl regression tests pass (view-defensive + approve-saturation + bridge-out-collapse helpers). On-chain integration testing pending Hadrian rome-evm program upgrade to [`rome-evm-private#363`](https://github.com/rome-protocol/rome-evm-private/pull/363).
+
+Spec: [`rome-specs/active/technical/2026-05-16-spl-erc20-direct-precompile-rewrite.md`](https://github.com/rome-protocol/rome-specs/blob/main/active/technical/2026-05-16-spl-erc20-direct-precompile-rewrite.md).
+
 ### Added — `UserPda.atas(user, mints[])` — batch ATA derivation across mints
 New ergonomic helper on the `UserPda` library: derives N ATAs for one EVM user across N classic SPL Token mints in two precompile dispatches total (vs N calls today). Composes:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,14 @@ The post-consolidation home for Rome-specific Solana plumbing that EVM contracts
 | `0x8854a299` | `pda(address user) view → bytes32` | Returns `external_auth(user)` — replaces the prior `RomeEVMAccount.pda` helper for new code. |
 | `0x31db4f82` | `ata(address user) view → bytes32` | User's gas-mint ATA. Gas-mint chains only. |
 | `0xfeb1c647` | `ata(address user, bytes32 mint) view → bytes32` | User's ATA for an arbitrary mint. Replaces the old `CpiProgram.derive_user_ata(0xc654e119)` shortcut; `UserPda.ata(user, mint)` now delegates here. |
+| `0xabf6f675` | `approve_spl(address spender, uint64 amount, bytes32 mint)` | Caller-PDA-as-owner sets `delegate_pda(spender)` on owner-ATA via SPL `approve_checked`. Replaces v1 `SPL_ERC20.approve`'s Solidity-side `SplTokenLib.approve` + raw `invoke_signed` marshaling. Saves ~150-200K CU per call. |
+| `0xc9884b1e` | `approve_spl(address spender, uint64 amount, bytes32 mint, bytes32 token_program)` | Same with explicit `token_program` (Token-2022-ready). |
+| `0xd795522b` | `mint_spl(address to, uint64 amount, bytes32 mint)` | Caller-PDA-as-mint-authority mints to dest user's ATA via SPL `mint_to_checked`. SPL Token runtime enforces caller-PDA == on-chain mint authority. Replaces v1 `SPL_ERC20.mint_to`'s Solidity-side `SplTokenLib.mint_to_checked` + `invoke` marshaling. |
+| `0x406ee21b` | `mint_spl(address to, uint64 amount, bytes32 mint, bytes32 token_program)` | Same with explicit `token_program`. |
+| `0xe479df56` | `transfer_spl(address from, address to, uint64 amount, bytes32 mint)` | **Addr-keyed delegate variant.** Derives both ATAs from EVM addresses internally; signs as `external_auth(caller)`. SPL Token accepts PDA as owner OR delegate. Replaces `SPL_ERC20.transferFrom`'s prior bytes32-ATA delegate variant (`0x766b362a`). |
+| `0x7b11c48f` | `transfer_spl(address from, address to, uint64 amount, bytes32 mint, bytes32 token_program)` | Same with explicit `token_program`. |
+| `0xdd0119c8` | `user_balance(address account, bytes32 mint) view → uint64` | Read SPL TokenAccount.amount (u64 LE at offset 64) on user's PDA-owned ATA. Returns 0 if ATA doesn't exist (fresh-chain probe). Collapses 3 v1 dispatches (`ata` + `lamports` + `readU64At`) into one CrossStateEthCall. Backs `SPL_ERC20.balanceOf`. |
+| `0xed72dbc8` | `allowance_of(address owner, address spender, bytes32 mint) view → uint64` | Read owner-ATA's `delegated_amount` IFF on-chain delegate matches `external_auth(spender)` (HARD REQ in Rust to enforce ERC-20 semantics; otherwise routers probe non-zero allowance when actual delegate is someone else). Collapses 5 v1 dispatches into one. Backs `SPL_ERC20.allowance`. |
 | `0x4479b709` | `deposit_from_ata(uint256 wei_)` | Move wrapper SPL balance from caller's ATA into gas-token credit. Unwrap leg of the gas-wrapper bridge. |
 
 #### `Withdraw` surface (`0x42..16`)

--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -52,6 +52,12 @@ contract ERC20Users {
         }
     }
 
+    /// @notice Returns the previously-registered unified PDA for `user`,
+    ///         reverting if `user` has not yet been registered via
+    ///         `ensure_user`. Used by meteora pool + factory to gate
+    ///         operations on caller registration. Kept for cross-contract
+    ///         back-compat; new code should prefer `HelperProgram.pda`
+    ///         (direct derivation, no revert).
     function get_user(address user) public view returns (bytes32) {
         bytes32 existing_user = users[user];
         require(existing_user != bytes32(0), "User does not exist");
@@ -73,17 +79,6 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     string private _symbol;
     ERC20Users private _users;
     mapping(address => bytes32) private _accounts;
-
-    /// @notice Public reader for the SPL token account owned by this EVM user.
-    /// @dev Returns the canonical user-PDA ATA derived from the unified PDA
-    ///      (post-0acabea). Equivalent to `UserPda.ata(user, mint_id)`. The
-    ///      legacy `_accounts` cache is retained for write-through (callers
-    ///      that previously relied on a non-zero cache value still see one
-    ///      after any wrapper-mediated mutation). New callers should treat
-    ///      this as the canonical lookup.
-    function getAta(address user) external view returns (bytes32) {
-        return HelperProgram.ata(user, mint_id);
-    }
 
     error ERC20InvalidApprover(address approver);
     error ERC20InvalidSpender(address spender);
@@ -223,28 +218,14 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function balanceOf(address account) public view virtual returns (uint256) {
-        // Always read AUTHORITY_PDA's ATA — that's the canonical
-        // cross-chain location where bridged-in SPL tokens live
-        // (Wormhole's complete_transfer_wrapped, useNativeDepositSend,
-        // any inbound flow). Same source bridgeOutToSolana spends from.
-        // Falling back to the legacy _accounts mapping (which was
-        // populated only after a wrapper-mediated `ensure_token_account`
-        // call) would mismatch and report 0 for any user whose tokens
-        // arrived via a non-wrapper path.
-        bytes32 ata = HelperProgram.ata(account, mint_id);
-        // ERC20-standard total: an address that has never received the
-        // token has balance 0, not a revert. When the user's ATA hasn't
-        // been initialized on Solana yet, account_u64_at(ata, 64) would
-        // revert with `account_u64_at: offset 64 + 8 out of 0 bytes`,
-        // forcing every consumer (DEX routers, allowance checks, wallet
-        // UIs that simulate balance reads on first-time wallets) to wrap
-        // balanceOf in try/catch. account_lamports is cheap (no data
-        // buffer pull) and returns 0 when the account doesn't exist.
-        if (AccountReader.lamportsOf(ata) == 0) {
-            return 0;
-        }
-        // SPL TokenAccount.amount is a u64 LE at offset 64.
-        return uint256(AccountReader.readU64At(ata, 64));
+        // Single CrossStateEthCall via HelperProgram.user_balance. Reads
+        // SPL TokenAccount.amount (u64 LE at offset 64) on the user's
+        // PDA-owned ATA. Returns 0 if the ATA doesn't exist (fresh-chain
+        // probe — same canonical AUTHORITY_PDA-ATA semantic as the legacy
+        // 3-dispatch composition: HelperProgram.ata + AccountReader.lamportsOf
+        // + AccountReader.readU64At). Projected saving: ~37K Solana CU
+        // per call (3 dispatches → 1).
+        return uint256(HelperProgram.user_balance(account, mint_id));
     }
 
     function transfer(address to, uint256 value) public virtual returns (bool) {
@@ -311,19 +292,24 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
             );
         } else {
             // DELEGATE PATH (`transferFrom(from, to, v)`): caller is
-            // the SPL delegate set by a prior `approve()` (which calls
-            // `SplTokenLib.approve` to write `spender_pda` as delegate
-            // of `from`'s ATA). Use the 4-arg overload with explicit
-            // source/dest ATAs since `from != msg.sender` — the 3-arg
-            // overload would derive the spender's ATA as source,
-            // which is wrong. Signs as `external_auth(msg.sender)` =
-            // the delegate PDA. SPL Token accepts delegate-as-authority
-            // when `delegated_amount ≥ value`. Measured saving:
-            // −372K CU (−67%) vs legacy.
+            // the SPL delegate set by a prior `approve()` (which now
+            // writes external_auth(spender) as delegate via the new
+            // approve_spl selector). Use the addr-keyed 4-arg overload
+            // — Rust internally derives src_ata = ata(external_auth(from),
+            // mint) and dst_ata = ata(external_auth(to), mint). Signs as
+            // external_auth(msg.sender) = the delegate PDA. SPL Token
+            // accepts delegate-as-authority when delegated_amount ≥ value.
+            // Replaces the prior bytes32-ATA variant (0x766b362a) —
+            // selectors are distinct; this is 0xe479df56. Eliminates
+            // Solidity-side ATA derivation via get_token_account.
+            // Reference `to_account` so the compiler doesn't warn —
+            // ensure_token_account(to) above still creates the ATA when
+            // missing; the precompile re-derives but won't create.
+            to_account;
             (success, result) = address(HelperProgram).delegatecall(
                 abi.encodeWithSignature(
-                    "transfer_spl(bytes32,bytes32,uint64,bytes32)",
-                    get_token_account(from), to_account, uint64(value), mint_id
+                    "transfer_spl(address,address,uint64,bytes32)",
+                    from, to, uint64(value), mint_id
                 )
             );
         }
@@ -334,67 +320,28 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     }
 
     function allowance(address owner, address spender) public view virtual returns (uint256) {
-        // FB-2a: derive the spender's unified PDA directly via the
-        // global precompile instead of `_users.get_user(spender)`,
-        // which reverted "User does not exist" when the spender had
-        // never been registered in this wrapper's ERC20Users mapping.
-        // Both paths compute `find_program_address([EXTERNAL_AUTHORITY,
-        // spender], rome_evm)` — byte-identical result. The mapping is
-        // still needed by `approve()` (which calls `ensure_user` to
-        // record the EVM addr) but a read-only `allowance()` consumer
-        // (DEX router probe, wallet UI) must not require any prior
-        // wrapper-side registration of the spender. ERC-20 spec: the
-        // allowance of any unapproved pair is 0, NEVER a revert.
-        bytes32 spenderUser = HelperProgram.pda(spender);
-        bytes32 ata = get_token_account(owner);
-
-        // FB-2b: gate the data read behind a lamports existence probe.
-        // When the owner's ATA is uninitialized — fresh user, never
-        // received this token — the underlying buffer is 0 bytes and
-        // `account_data_at(ata, 72, 36)` reverts
-        //   "account_data_at: range 72..108 out of 0 bytes"
-        // forcing every wallet / router / multicall probe to wrap
-        // `allowance()` in try/catch. Same symmetric pattern as
-        // `balanceOf`: no ATA → no balance → no delegate possible → 0.
-        if (AccountReader.lamportsOf(ata) == 0) {
-            return 0;
-        }
-
-        // SPL TokenAccount delegate is `COption<Pubkey>` at offset 72:
-        //   72..75 tag (u32 LE; 0 = None, 1 = Some)
-        //   76..107 pubkey (only valid when tag=1)
-        // delegated_amount is `u64 LE` at offset 121.
-        //
-        // `account_data_at(ata, 72, 36)` reads exactly the 36-byte COption
-        // slice (skipping the unrelated mint/owner/amount/state/is_native
-        // fields that `account_info` would also marshal). Decode via the
-        // existing Convert.read_coption_bytes32 helper.
-        bytes memory delegateOption = AccountReader.readBytesAt(ata, 72, 36);
-        Convert.COptionBytes32 memory parsed;
-        (parsed,) = Convert.read_coption_bytes32(delegateOption, 0);
-        bytes32 delegate = parsed.is_some ? parsed.value : bytes32(0);
-
-        if (delegate != spenderUser) {
-            return uint256(0);
-        }
-
-        // Read the u64 delegated_amount at offset 121 directly.
-        // Sentinel: if storage saturated at u64::MAX, surface as type(uint256).max
-        // so wallets that use MaxUint256 as the "infinite approval" sentinel keep
-        // working — see approve() below.
-        uint64 delegated = AccountReader.readU64At(ata, 121);
+        // Single CrossStateEthCall via HelperProgram.allowance_of. Reads
+        // owner-ATA's delegated_amount IFF on-chain delegate ==
+        // external_auth(spender) (HARD REQ enforced inside Rust — see
+        // 2026-05-16 spec). Returns 0 otherwise — covers fresh user (no
+        // ATA), unapproved spender (no delegate or wrong delegate), and
+        // expired allowance. Collapses 5 v1 dispatches into 1. Projected
+        // saving: ~37K Solana CU per call.
+        uint64 delegated = HelperProgram.allowance_of(owner, spender, mint_id);
+        // Saturation sentinel: u64::MAX storage → uint256::MAX readback.
+        // Pairs with the saturation cap inside approve() so wallets that
+        // probe `if allowance == MaxUint256` (infinite-approval sentinel)
+        // keep working.
         return delegated == type(uint64).max ? type(uint256).max : uint256(delegated);
     }
 
     function approve(address spender, uint256 value) public virtual returns (bool) {
-        // ensure_user on both sides — both owner AND spender need
-        // ERC20Users entries (the SPL approve sets the spender's unified
-        // PDA as delegate, and transferFrom signs as that PDA). Without
-        // auto-register, contract spenders (DEX routers, paymasters)
-        // can never be approved-to since they don't go through any
-        // user-initiated activation flow themselves.
-        bytes32 ownerUser = _users.ensure_user(msg.sender);
-        bytes32 spenderUser = _users.ensure_user(spender);
+        // Register owner in ERC20Users mapping (mapping-side-effect for
+        // any consumers still reading _users). Spender registration is no
+        // longer required — allowance_of uses external_auth(spender)
+        // directly and the new approve_spl selector signs as the caller's
+        // PDA without needing the spender's mapping entry.
+        _users.ensure_user(msg.sender);
 
         // SPL Token stores delegated_amount as u64 on-chain; we cannot
         // expand the storage layer. Saturate when the caller's value
@@ -406,25 +353,18 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
             ? type(uint64).max
             : uint64(value);
 
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data) =
-        SplTokenLib.approve(
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            get_token_account(msg.sender),
-            spenderUser,
-            ownerUser,
-            new bytes32[](0),
-            storedAmount
-        );
-
-        // Only the owner's unified user PDA signs — auto-detected from metas.
-        // No salt-derived signer → use `invoke`.
-        (bool success, bytes memory result) = address(cpi_program).delegatecall(
+        // Migration to HelperProgram.approve_spl — moves SPL Approve ix
+        // marshaling from Solidity (SplTokenLib.approve + raw invoke,
+        // ~150-200K CU of EVM bytecode) into Rust (~5-10K CU). Signs
+        // as external_auth(msg.sender) which IS the owner of the source
+        // ATA. SPL Token runtime stores external_auth(spender) as the
+        // delegate; allowance_of compares against the same derivation.
+        (bool success, bytes memory result) = address(HelperProgram).delegatecall(
             abi.encodeWithSignature(
-                "invoke(bytes32,(bytes32,bool,bool)[],bytes)",
-                program_id, accounts, data
+                "approve_spl(address,uint64,bytes32)",
+                spender, storedAmount, mint_id
             )
         );
-
         require(success, string(Convert.revert_msg(result)));
 
         // Emit the effective approval — when storage saturates at u64::MAX
@@ -654,33 +594,32 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
     function mint_to(address to, uint256 value) public virtual returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
 
-        bytes32 user = _users.ensure_user(msg.sender);
-        // Mint to a fresh address: ensure the recipient's PDA-owned
-        // ATA exists before the SPL mint_to_checked CPI. Same
-        // idempotent pattern as `_transfer` above — no-op when the
-        // ATA already exists.
-        bytes32 to_account = ensure_token_account(to);
-        (bytes32 program_id, ICrossProgramInvocation.AccountMeta[] memory accounts, bytes memory data)
-            = SplTokenLib.mint_to_checked(
-            SplTokenLib.SPL_TOKEN_PROGRAM,
-            mint_id,
-            to_account,
-            user,
-            new bytes32[](0),
-            uint64(value),
-            decimals
-        );
+        // Register caller (mint authority) in ERC20Users mapping for any
+        // consumers still reading _users. The new selector signs as
+        // external_auth(msg.sender) — SPL Token runtime enforces that
+        // this PDA is the on-chain mint authority.
+        _users.ensure_user(msg.sender);
 
-        // mint_to_checked signs as the mint authority's unified user PDA —
-        // auto-detected from metas. No salt-derived signer → use `invoke`.
-        (bool success, bytes memory result) = address(cpi_program).delegatecall(
+        // Mint to a fresh address: ensure the recipient's PDA-owned
+        // ATA exists before the SPL mint_to_checked CPI. New mint_spl
+        // selector assumes the ATA exists — same as legacy. Idempotent
+        // on repeat (lamports != 0 fast-path).
+        ensure_token_account(to);
+
+        // Migration to HelperProgram.mint_spl — moves SPL MintTo ix
+        // marshaling from Solidity (SplTokenLib.mint_to_checked + raw
+        // invoke) into Rust. Signs as external_auth(msg.sender); SPL
+        // runtime enforces caller-PDA == on-chain mint authority.
+        // Projected saving: ~150-200K CU per call (matches transfer_spl
+        // migration which measured -372K CU on Hadrian).
+        (bool success, bytes memory result) = address(HelperProgram).delegatecall(
             abi.encodeWithSignature(
-                "invoke(bytes32,(bytes32,bool,bool)[],bytes)",
-                program_id, accounts, data
+                "mint_spl(address,uint64,bytes32)",
+                to, uint64(value), mint_id
             )
         );
+        require(success, string(Convert.revert_msg(result)));
 
-        require (success, string(Convert.revert_msg(result)));
         emit Transfer(address(0), to, value);
         return true;
     }

--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -5,7 +5,7 @@ import "./erc20spl.sol";
 import {MplTokenMetadataLib} from "../mpl_token_metadata/lib.sol";
 import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {SystemProgramLib} from "../system_program/system_program.sol";
-import {ICrossProgramInvocation, ISystemProgram, SystemProgram} from "../interface.sol";
+import {ICrossProgramInvocation, ISystemProgram, SystemProgram, HelperProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {Convert} from "../convert.sol";
 
@@ -130,7 +130,14 @@ contract ERC20SPLFactory {
      * @return (bytes32 mint) Address of the created SPL Token mint.
      */
     function create_token_mint() external returns (bytes32) {
-        bytes32 user = users.get_user(msg.sender);
+        // Direct PDA derivation — was `users.get_user(msg.sender)` which
+        // reverted "User does not exist" pre-registration. The new path
+        // derives external_auth(msg.sender) without the mapping lookup
+        // (HelperProgram.pda has been the canonical derivation since
+        // 2026-05-12). Behavior equivalence: same returned address;
+        // runtime still catches a fund-less PDA when create_account CPI
+        // executes (Solana System Program rejects insufficient lamports).
+        bytes32 user = HelperProgram.pda(msg.sender);
         (bytes32 mint, bytes32 mintSeed) = get_current_mint(msg.sender);
         _assert_mint_account_missing(mint);
 
@@ -165,7 +172,9 @@ contract ERC20SPLFactory {
      * Initializes previously created mint account.
      */
     function init_token_mint(bytes32 mint) external {
-        bytes32 user = users.get_user(msg.sender);
+        // Direct PDA derivation — see create_token_mint above for the
+        // get_user migration rationale.
+        bytes32 user = HelperProgram.pda(msg.sender);
 
         (
             bytes32 tokenProgramId,

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -85,6 +85,29 @@ interface IHelperProgram {
     // delegate with delegated_amount >= tokens. Required by ERC20-style
     // transferFrom flows (e.g. SPL_ERC20._transfer with from != msg.sender).
     function transfer_spl(bytes32 src_ata, bytes32 to_ata, uint64 tokens, bytes32 mint) external;
+    // Addr-keyed delegate variant — both endpoints by EVM address.
+    // Derives src_ata = ata(external_auth(from), mint) and
+    // dst_ata = ata(external_auth(to), mint) internally. Signs as
+    // external_auth(caller); SPL Token accepts PDA as owner OR delegate.
+    // Distinct from the bytes32-ATA variant above (0x766b362a).
+    // Replaces SPL_ERC20.transferFrom's delegate path.
+    function transfer_spl(address from, address to, uint64 tokens, bytes32 mint) external;
+    // Same with explicit token_program (Token-2022-ready).
+    function transfer_spl(address from, address to, uint64 tokens, bytes32 mint, bytes32 token_program) external;
+    // approve_spl — caller-PDA-as-owner sets delegate_pda(spender) on the
+    // owner-ATA via SPL approve_checked. Replaces v1 SPL_ERC20.approve's
+    // SplTokenLib.approve + raw invoke_signed marshaling path. Signs as
+    // external_auth(caller).
+    function approve_spl(address spender, uint64 amount, bytes32 mint) external;
+    // Same with explicit token_program.
+    function approve_spl(address spender, uint64 amount, bytes32 mint, bytes32 token_program) external;
+    // mint_spl — caller-PDA-as-mint-authority mints to dest user's ATA
+    // via SPL mint_to_checked. SPL Token runtime enforces caller-PDA ==
+    // on-chain mint authority. Replaces v1 SPL_ERC20.mint_to's
+    // SplTokenLib.mint_to_checked + raw invoke marshaling path.
+    function mint_spl(address to, uint64 amount, bytes32 mint) external;
+    // Same with explicit token_program.
+    function mint_spl(address to, uint64 amount, bytes32 mint, bytes32 token_program) external;
     // external pda
     function pda(address user) external view returns (bytes32);
     // ata owned by external pda. Gas token mint is used.
@@ -92,8 +115,21 @@ interface IHelperProgram {
     function ata(address user) external view returns (bytes32);
     // ata owned by external pda.
     function ata(address user, bytes32 mint) external view returns (bytes32);
+    // user_balance — read SPL TokenAccount.amount on user's PDA-owned
+    // ATA. Returns 0 if ATA doesn't exist (fresh-chain probe; matches
+    // v1 SPL_ERC20.balanceOf semantic). Collapses 3 v1 dispatches
+    // (HelperProgram.ata + AccountReader.lamportsOf + AccountReader.readU64At)
+    // into one CrossStateEthCall.
+    function user_balance(address account, bytes32 mint) external view returns (uint64);
+    // allowance_of — read owner-ATA's delegated_amount IFF on-chain
+    // delegate matches external_auth(spender). Returns 0 otherwise.
+    // HARD REQ for ERC-20 semantics: without the delegate-equality
+    // check, routers see non-zero allowance for one spender while the
+    // actual delegate is another, then transferFrom reverts. Collapses
+    // 5 v1 dispatches into one.
+    function allowance_of(address owner, address spender, bytes32 mint) external view returns (uint64);
     // deposit gas-token from ata
-    function deposit_from_ata(uint256 wei_) external; 
+    function deposit_from_ata(uint256 wei_) external;
 }
 
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,6 +22,14 @@ export default defineConfig({
     },
   },
   networks: {
+    hadrian: {
+      type: "http",
+      chainType: "l1",
+      chainId: 200010,
+      url: "https://hadrian.testnet.romeprotocol.xyz/",
+      accounts: [configVariable("HADRIAN_PRIVATE_KEY")],
+    },
+
     aurelius: {
       type: "http",
       chainType: "l1",

--- a/scripts/bench-spl-erc20-rewrite.ts
+++ b/scripts/bench-spl-erc20-rewrite.ts
@@ -1,0 +1,164 @@
+// Side-by-side CU bench: v1 SPL_ERC20 wUSDC wrapper vs freshly-deployed
+// v2 (this PR). For each method, submit one real EVM tx against each
+// wrapper and read Solana `computeUnitsConsumed` from the tx receipt.
+//
+// Spec: rome-specs/active/technical/2026-05-16-spl-erc20-direct-precompile-rewrite.md
+// Hadrian addresses from rome-solidity/deployments/hadrian.json.
+
+import hardhat from "hardhat";
+
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const SOLANA_RPC = "https://api.devnet.solana.com";
+
+// v1 contracts already on Hadrian:
+const V1_WUSDC = "0x94AC3E5e998d72088045853C1CfB910F6CE90E56" as const;
+const ERC20_USERS = "0xad2518145a7a95f2ca8a468499e4c33e10fb5dcc" as const;
+const WUSDC_MINT_B32 =
+    "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7" as const;
+const CPI_PROGRAM = "0xFF00000000000000000000000000000000000008" as const;
+
+// Targets — any addresses; we don't need real on-chain accounts behind them.
+// approve(spender, value): spender doesn't need to exist on Solana.
+// transfer(to, value): "to" needs an EVM mapping but the recipient ATA gets
+// auto-created (ensure_token_account fast-path). Use the deployer's own
+// address as recipient for simplicity (self-transfer is a valid SPL op).
+const SPENDER = "0x000000000000000000000000000000000000ddee" as const;
+
+type RpcResponse<T> = { result?: T; error?: { code: number; message: string } };
+
+async function rpc<T>(url: string, method: string, params: unknown[]): Promise<T> {
+    const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const data = (await resp.json()) as RpcResponse<T>;
+    if (data.error) throw new Error(`${method}: ${data.error.message}`);
+    return data.result as T;
+}
+
+async function getSolanaCU(evmTxHash: `0x${string}`): Promise<number | null> {
+    // rome_solanaTxForEvmTx returns the Solana signature(s) for an EVM tx.
+    // Response shape: a single base58 sig string, OR an array, OR null if
+    // the indexer hasn't seen it yet. Handle all three.
+    const sig = await rpc<string | string[] | null>(
+        HADRIAN_RPC,
+        "rome_solanaTxForEvmTx",
+        [evmTxHash],
+    );
+    if (!sig) return null;
+    const solanaSig = Array.isArray(sig) ? sig[sig.length - 1] : sig;
+    if (!solanaSig) return null;
+
+    const tx = await rpc<{ meta?: { computeUnitsConsumed?: number } } | null>(
+        SOLANA_RPC,
+        "getTransaction",
+        [solanaSig, { commitment: "confirmed", maxSupportedTransactionVersion: 0 }],
+    );
+    return tx?.meta?.computeUnitsConsumed ?? null;
+}
+
+async function pollForCU(evmTxHash: `0x${string}`): Promise<number | null> {
+    // Solana indexer + RPC may lag — poll up to 30s.
+    for (let i = 0; i < 30; i++) {
+        const cu = await getSolanaCU(evmTxHash);
+        if (cu !== null) return cu;
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    return null;
+}
+
+async function main() {
+    const { viem, networkName } = await hardhat.network.connect();
+    if (networkName !== "hadrian") {
+        throw new Error(`Expected --network hadrian, got ${networkName}`);
+    }
+
+    const [deployer] = await viem.getWalletClients();
+    if (!deployer?.account) throw new Error("No deployer wallet — set HADRIAN_PRIVATE_KEY");
+    const me = deployer.account.address;
+    const publicClient = await viem.getPublicClient();
+
+    console.log("Network:        ", networkName);
+    console.log("Deployer:       ", me);
+    console.log(
+        "Gas balance:    ",
+        (await publicClient.getBalance({ address: me })).toString(),
+    );
+
+    // Deploy a throwaway wrapper just to measure CU side-by-side against
+    // the v1 wrapper at V1_WUSDC. NOT the canonical replacement — the
+    // production cutover (post-#163 merge) deploys with plain
+    // name="Rome USDC" / symbol="wUSDC", no version suffix.
+    console.log("\n=== Deploying SPL_ERC20 (bench artifact) ===");
+    const v2 = await viem.deployContract("SPL_ERC20", [
+        WUSDC_MINT_B32,
+        CPI_PROGRAM,
+        "Rome USDC (rewrite bench)",
+        "wUSDCbench",
+        ERC20_USERS,
+    ]);
+    console.log("bench wrapper:  ", v2.address);
+
+    const erc20Abi = [
+        { type: "function", name: "approve", inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }], stateMutability: "nonpayable" },
+        { type: "function", name: "transfer", inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }], stateMutability: "nonpayable" },
+        { type: "function", name: "balanceOf", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }], stateMutability: "view" },
+        { type: "function", name: "allowance", inputs: [{ type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }], stateMutability: "view" },
+    ] as const;
+
+    type Run = { label: string; address: `0x${string}`; method: "approve" | "transfer"; args: readonly [string, bigint] };
+    const runs: Run[] = [
+        { label: "v1 approve  ", address: V1_WUSDC, method: "approve",  args: [SPENDER, 1000n] },
+        { label: "v2 approve  ", address: v2.address, method: "approve",  args: [SPENDER, 1000n] },
+        { label: "v1 transfer ", address: V1_WUSDC, method: "transfer", args: [me, 1n] },
+        { label: "v2 transfer ", address: v2.address, method: "transfer", args: [me, 1n] },
+    ];
+
+    const results: Array<{ label: string; tx: `0x${string}`; cu: number | null }> = [];
+
+    for (const run of runs) {
+        console.log(`\n=== ${run.label} ===`);
+        const hash = await deployer.writeContract({
+            address: run.address,
+            abi: erc20Abi,
+            functionName: run.method,
+            args: run.args as readonly [`0x${string}`, bigint],
+        });
+        console.log("  tx hash: ", hash);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        console.log("  status:  ", receipt.status);
+        const cu = await pollForCU(hash);
+        console.log("  Solana CU:", cu ?? "(not found within 30s)");
+        results.push({ label: run.label, tx: hash, cu });
+    }
+
+    console.log("\n=== Summary ===");
+    console.log("label         | tx hash                                                            | Solana CU");
+    console.log("--------------+--------------------------------------------------------------------+----------");
+    for (const r of results) {
+        console.log(`${r.label} | ${r.tx} | ${r.cu ?? "?"}`);
+    }
+
+    const v1Approve = results[0]?.cu;
+    const v2Approve = results[1]?.cu;
+    const v1Transfer = results[2]?.cu;
+    const v2Transfer = results[3]?.cu;
+
+    console.log("\n=== Deltas ===");
+    if (v1Approve && v2Approve) {
+        const delta = v1Approve - v2Approve;
+        const pct = ((delta / v1Approve) * 100).toFixed(1);
+        console.log(`approve  : v1=${v1Approve}  v2=${v2Approve}  Δ=${delta > 0 ? "−" : "+"}${Math.abs(delta)} (${pct}%)`);
+    }
+    if (v1Transfer && v2Transfer) {
+        const delta = v1Transfer - v2Transfer;
+        const pct = ((delta / v1Transfer) * 100).toFixed(1);
+        console.log(`transfer : v1=${v1Transfer}  v2=${v2Transfer}  Δ=${delta > 0 ? "−" : "+"}${Math.abs(delta)} (${pct}%)  [control — both paths same selector]`);
+    }
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Migrates `SPL_ERC20`'s `approve` / `transferFrom` / `mint_to` / `balanceOf` / `allowance` off Solidity-side SPL ix marshaling (`SplTokenLib.{approve, mint_to_checked}` + raw `CpiProgram.invoke_signed`) into the 5 new dedicated HelperProgram selectors landed in [rome-evm-private#363](https://github.com/rome-protocol/rome-evm-private/pull/363).
- Projected CU savings: ~140-180K Solana CU per write call (matches measured −372/−394K from the prior `transfer_spl` migration on Hadrian); ~37K per read call (3-5 dispatch composition → 1).
- **Draft** until [rome-evm-private#363](https://github.com/rome-protocol/rome-evm-private/pull/363) is deployed to Hadrian (`/upgrade-program` against `RPTWwELX…` testnet primary + lockstep proxy/hercules redeploy) — at which point side-by-side CU bench against v1 wrappers can verify the projections.

## Migration map

| v1 path | v2 path | Saving |
|---|---|---|
| `approve` via `SplTokenLib.approve` + raw `delegatecall(invoke_signed)` | `HelperProgram.approve_spl(spender, value, mint)` (0xabf6f675) | ~150-200K CU |
| `mint_to` via `SplTokenLib.mint_to_checked` + raw `delegatecall(invoke)` | `HelperProgram.mint_spl(to, value, mint)` (0xd795522b) | ~150-200K CU |
| `transferFrom` delegate path via `transfer_spl(bytes32,bytes32,...)` (0x766b362a) | `HelperProgram.transfer_spl(from, to, value, mint)` (0xe479df56) — addr-keyed | Same dispatch class; eliminates Solidity-side ATA derivation via `get_token_account` |
| `transfer` sender path via `transfer_spl(address, uint64, bytes32)` (0x53b505e0) | **unchanged** | — |
| `balanceOf` via `HelperProgram.ata` + `AccountReader.lamportsOf` + `AccountReader.readU64At` | `HelperProgram.user_balance(account, mint)` (0xdd0119c8) | ~37K CU (3 dispatches → 1) |
| `allowance` via `HelperProgram.pda` + `get_token_account` + `AccountReader.lamportsOf` + `AccountReader.readBytesAt` + Solidity COption decode + delegate-eq + `AccountReader.readU64At` | `HelperProgram.allowance_of(owner, spender, mint)` (0xed72dbc8) — HARD REQ delegate-equality in Rust | ~37K CU (5 dispatches → 1) |

## Non-mechanical findings during the rewrite

The original spec assumed PR-1 (drop legacy getters) was purely mechanical. Cross-repo audit revealed:
- **`getAta`**: no callers in this repo (`RomeBridgeWithdraw.sol:222` reference is a comment, not a call). Safely deleted.
- **`ensureRecipientAta`**: per `contracts/bridge/README.md:82` it's "kept as a public utility"; consumed by rome-ui's `useOutboundSplBridge`. **Kept.**
- **`mint_id`**: legit identity (analogous to spec-explicit `bridgeOutToSolana(bytes32 recipient, ...)`). **Kept public.**
- **`ERC20Users.get_user`**: 8 callers across `damm_v1_factory.sol` + `damm_v1_pool.sol` rely on its "revert if unregistered" gate. **Kept** — meteora migration deferred to follow-up.
- **`ERC20SPLFactory.{create_token_mint, init_token_mint}`** internally used `users.get_user` to derive payer PDA. Migrated to `HelperProgram.pda(msg.sender)` (same address; runtime still catches under-funded PDA at `create_account`).
- **Internal helpers `ensure_token_account` / `get_token_account` / `create_token_account`**: still used by `_transfer`, `mint_to`, and off-chain test/deploy scripts in `scripts/bridge/`, `tests/damm_v1_*.integration.ts`. **Kept.**

## Test plan
- [x] `npx hardhat compile` — 79 files compile (only pre-existing warnings)
- [x] `npx hardhat test tests/erc20spl/view-defensive.test.ts` — 12 passed (validates `allowance` / `totalSupply` fresh-chain probe semantics)
- [x] `npx hardhat test tests/erc20spl/approve-saturation.test.ts` — 18 passed (validates u64 saturation + MaxUint256 sentinel)
- [x] `npx hardhat test tests/erc20spl/bridge-out-collapse.test.ts` — 9 passed (validates bridge input validation)
- [ ] Hadrian deploy + side-by-side CU bench against v1 `SPL_ERC20` (`approve` / `transferFrom` / `mint_to` / `balanceOf` / `allowance`) — gated on [rome-evm-private#363](https://github.com/rome-protocol/rome-evm-private/pull/363) being live on `RPTWwELX…`
- [ ] rome-ui smoke: `useOutboundSplBridge` (uses `ensureRecipientAta` + `bridgeOutToSolana` — unchanged) and Portfolio balance reads (now go through new `balanceOf` → `user_balance`)

## Files changed
- `contracts/erc20spl/erc20spl.sol` (+/−)
- `contracts/erc20spl/erc20spl_factory.sol` (migration off `users.get_user`)
- `contracts/interface.sol` (8 new IHelperProgram declarations)
- `CLAUDE.md` (HelperProgram surface table extended)
- `CHANGELOG.md` (Unreleased entry)

## Sequencing
- PR-3 (factory updates) per the original spec — now subsumed: this PR keeps the existing factory deploy surface. New canonical wrapper deploys happen against this PR's `SPL_ERC20` bytecode once merged + deployed.
- After merge: deploy new `SPL_ERC20` bytecode on Hadrian (registry-tracked address change for the canonical wUSDC/wETH/wSOL wrappers). Old wrappers remain at their CREATE2 addresses (no breakage; just higher CU until decommissioned with the chain).

Spec: [`rome-specs/active/technical/2026-05-16-spl-erc20-direct-precompile-rewrite.md`](https://github.com/rome-protocol/rome-specs/blob/main/active/technical/2026-05-16-spl-erc20-direct-precompile-rewrite.md)