### PR TITLE
perf(meteora, erc20spl_factory): DAMMv1 swap-quote typed reads + lamports-only mint-missing probe

### DIFF
--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -8,6 +8,7 @@ import {SystemProgramLib} from "../system_program/system_program.sol";
 import {ICrossProgramInvocation, ISystemProgram, SystemProgram, HelperProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
 import {Convert} from "../convert.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 
 contract ERC20SPLFactory {
     uint8 public constant DEFAULT_DECIMALS = 9;
@@ -114,8 +115,10 @@ contract ERC20SPLFactory {
 
     function _assert_mint_account_missing(bytes32 mint) internal view {
         require(token_by_mint[mint] == address(0), "Token exists");
-        (uint64 lamports,,,,,) = ICrossProgramInvocation(cpi_program).account_info(mint);
-        if (lamports != 0) {
+        // Typed lamports-only probe via account_lamports (selector 0xde79ed54)
+        // — skips the full account_info 6-tuple decode + 82-byte data buffer.
+        // Saves ~15-30K CU per create_token_mint call (Agent 2/4 audit, 2026-05-16).
+        if (AccountReader.lamportsOf(mint) != 0) {
             revert MintAccountAlreadyExists(mint);
         }
     }

--- a/contracts/meteora/damm_v1_pool.sol
+++ b/contracts/meteora/damm_v1_pool.sol
@@ -13,6 +13,7 @@ import {MplTokenMetadataLib} from "../mpl_token_metadata/lib.sol";
 import {ICrossProgramInvocation} from "../interface.sol";
 import {PdaDeriver} from "../cpi/PdaDeriver.sol";
 import {PdasBatch} from "../cpi/PdasBatch.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
 
 library DAMMv1Lib {
     bytes32 public constant PROG_DYNAMIC_AMM =
@@ -358,20 +359,28 @@ library DAMMv1Lib {
     // Reads DAMMv1 pool account from Solana and parses it
     // @param pool_pubkey address of DAMMv1 Pool account in Solana
     // @return instance PoolState structure
-    function load_pool(bytes32 pool_pubkey, address cpi_program)
+    function load_pool(bytes32 pool_pubkey, address /* cpi_program (unused — typed slice via AccountReader) */)
     internal
     view
     returns (PoolState memory) {
-        (,,,,, bytes memory data) = ICrossProgramInvocation(cpi_program).account_info(pool_pubkey);
+        // Slice-only read via account_data_at (selector 0x593762e8) — skips
+        // the lamports/owner/flags fields of the prior account_info 6-tuple
+        // since parse_pool only consumes data[0..POOL_PREFIX_MIN_LEN].
+        // Saves ~10-15K CU per load_pool call (Agent 3 audit, 2026-05-16).
+        bytes memory data = AccountReader.readBytesAt(pool_pubkey, 0, uint16(POOL_PREFIX_MIN_LEN));
         return parse_pool(data);
     }
 
-    function load_vault(bytes32 vault_pubkey, address cpi_program)
+    function load_vault(bytes32 vault_pubkey, address /* cpi_program (unused — typed slice via AccountReader) */)
     internal
     view
     returns (VaultState memory)
     {
-        (,,,,, bytes memory data) = ICrossProgramInvocation(cpi_program).account_info(vault_pubkey);
+        // Slice-only read via account_data_at. parse_vault consumes the full
+        // VAULT_MIN_LEN-byte prefix (including the 960-byte strategies skip);
+        // saving ~15-25K CU per load_vault call vs the prior account_info
+        // 6-tuple decode (Agent 3 audit, 2026-05-16).
+        bytes memory data = AccountReader.readBytesAt(vault_pubkey, 0, uint16(VAULT_MIN_LEN));
         return parse_vault(data);
     }
 
@@ -1257,20 +1266,26 @@ contract DAMMv1Pool {
         DAMMv1Lib.VaultState memory vault_a_state = DAMMv1Lib.load_vault(a_vault, cpi_program);
         DAMMv1Lib.VaultState memory vault_b_state = DAMMv1Lib.load_vault(b_vault, cpi_program);
 
-        SplTokenLib.SplMint memory a_lp_mint = SplTokenLib.load_mint(vault_a_state.lp_mint, cpi_program);
-        SplTokenLib.SplMint memory b_lp_mint = SplTokenLib.load_mint(vault_b_state.lp_mint, cpi_program);
-
-        uint64 pool_lp_a = SplTokenLib.load_token_amount(a_vault_lp, cpi_program);
-        uint64 pool_lp_b = SplTokenLib.load_token_amount(b_vault_lp, cpi_program);
+        // Read only the fields we actually use — `supply` from each LP mint
+        // (offset 36 in SPL Mint layout) and `amount` from each vault LP token
+        // account (offset 64 in SPL TokenAccount layout). Typed `account_u64_at`
+        // (selector 0xb317d4c1) skips the full account_info 6-tuple decode +
+        // 82/165-byte data buffer fetch that SplTokenLib.load_mint/load_token_amount
+        // were doing. Saves ~22K CU per typed read; 4 reads per call → ~88K CU
+        // per get_price_e18 (Agent 3 audit measurement, 2026-05-16).
+        uint64 a_lp_supply = AccountReader.readU64At(vault_a_state.lp_mint, 36);
+        uint64 b_lp_supply = AccountReader.readU64At(vault_b_state.lp_mint, 36);
+        uint64 pool_lp_a = AccountReader.readU64At(a_vault_lp, 64);
+        uint64 pool_lp_b = AccountReader.readU64At(b_vault_lp, 64);
         uint64 current_time = uint64(block.timestamp);
 
-        token_a_amount = a_lp_mint.supply == 0
+        token_a_amount = a_lp_supply == 0
             ? 0
-            : get_amount_by_share(vault_a_state, current_time, pool_lp_a, a_lp_mint.supply);
+            : get_amount_by_share(vault_a_state, current_time, pool_lp_a, a_lp_supply);
 
-        token_b_amount = b_lp_mint.supply == 0
+        token_b_amount = b_lp_supply == 0
             ? 0
-            : get_amount_by_share(vault_b_state, current_time, pool_lp_b, b_lp_mint.supply);
+            : get_amount_by_share(vault_b_state, current_time, pool_lp_b, b_lp_supply);
     }
 
     function get_reserves()
@@ -1291,25 +1306,28 @@ contract DAMMv1Pool {
     returns (uint256)
     {
         Reserves memory r = get_reserves();
-        SplTokenLib.SplMint memory mint_a = SplTokenLib.load_mint(token_a_mint, cpi_program);
-        SplTokenLib.SplMint memory mint_b = SplTokenLib.load_mint(token_b_mint, cpi_program);
+        // Read only mint.decimals (offset 44 in SPL Mint layout — 1 byte).
+        // Typed account_data_at slice (1 byte) vs prior full account_info
+        // 6-tuple decode. Saves ~20-30K CU per get_price_e18 call.
+        uint8 dec_a = uint8(AccountReader.readBytesAt(token_a_mint, 44, 1)[0]);
+        uint8 dec_b = uint8(AccountReader.readBytesAt(token_b_mint, 44, 1)[0]);
 
         if (token == PoolToken.TokenA) {
             if (r.a_reserve == 0) revert ZeroReserve();
 
             return uint256(r.b_reserve)
-                * (10 ** uint256(mint_a.decimals))
+                * (10 ** uint256(dec_a))
                 * 1e18
                 / uint256(r.a_reserve)
-                / (10 ** uint256(mint_b.decimals));
+                / (10 ** uint256(dec_b));
         } else {
             if (r.b_reserve == 0) revert ZeroReserve();
 
             return uint256(r.a_reserve)
-                * (10 ** uint256(mint_b.decimals))
+                * (10 ** uint256(dec_b))
                 * 1e18
                 / uint256(r.b_reserve)
-                / (10 ** uint256(mint_a.decimals));
+                / (10 ** uint256(dec_a));
         }
     }
 


### PR DESCRIPTION
## Summary

Solidity-only refactor (no new precompile selector needed; existing `account_u64_at` / `account_data_at` / `account_lamports` cover everything). Four migrations on the hot swap-quote + factory paths.

**Solidity-only — independent of Hadrian deploy.** Safe to merge whenever CI is green.

## Migrations

| Site | Before | After | CU |
|---|---|---|---|
| `DAMMv1Pool.get_pool_token_amounts` (lines 1252-1274) | 4× `SplTokenLib.load_mint`/`load_token_amount` (full `account_info` 6-tuple + 82/165-byte Borsh decode) | 4× `AccountReader.readU64At` (typed u64-LE at known offsets: Mint.supply=36, TokenAccount.amount=64) | **−88K CU per `get_price_e18`** (Agent 3 audit, 2026-05-16) |
| `DAMMv1Pool.get_price_e18` (lines 1294-1295) | 2× `SplTokenLib.load_mint` for `mint.decimals` | 2× `AccountReader.readBytesAt(mint, 44, 1)` (1-byte slice) | -20-30K CU per call |
| `DAMMv1Lib.load_pool` / `load_vault` (lines 362-377) | `account_info` 6-tuple (discarding 5 fields, only using `data`) | `AccountReader.readBytesAt(pubkey, 0, MIN_LEN)` slice-only | -10-25K CU per call |
| `ERC20SPLFactory._assert_mint_account_missing` (lines 115-121) | `account_info` 6-tuple, only `lamports` used | `AccountReader.lamportsOf(mint)` (typed u64-LE-only probe) | -15-30K CU per `create_token_mint` |

## Hot-path consumers of the savings

- Every **romeswap quote** (uses `get_price_e18`)
- Every **oracle price read** (downstream of `get_reserves`)
- Every **Cardo price probe** for the DAMMv1 pool
- Every **factory mint creation** (uses `_assert_mint_account_missing`)

## Diff

2 files changed, +42 / −21:
- `contracts/meteora/damm_v1_pool.sol` — all 4 DAMMv1 migrations + AccountReader import
- `contracts/erc20spl/erc20spl_factory.sol` — `_assert_mint_account_missing` migration + AccountReader import

## Verification

- [x] `npx hardhat compile` — clean (79 files, solc 0.8.28)
- [ ] CI green
- [ ] No runtime dependency — Hadrian-deploy-independent. Can merge before or after the PR-1 deploy.

## Cross-references

- Comprehensive audit driving these: `/tmp/rome-solidity-comprehensive-audit-2026-05-16.md` (Agent 3 + Agent 4 source-level findings)
- Locked target spec: `/tmp/rome-solidity-locked-target-2026-05-16.md` §B "Solidity-only refactors"
- Memory principle: `feedback_solidity_evm_addresses_only_principle.md`

## Related PRs in this series

- [PR-1 (rome-evm-private #364)](https://github.com/rome-protocol/rome-evm-private/pull/364) — Rust selectors (merged)
- [PR-1.5 (#164)](https://github.com/rome-protocol/rome-solidity/pull/164) — broken Token-2022 decl cleanup (merged)
- [PR-2 (#165)](https://github.com/rome-protocol/rome-solidity/pull/165) — A1/A2/A3 consumers (open, gated on Hadrian deploy)
- [PR-3 (#166)](https://github.com/rome-protocol/rome-solidity/pull/166) — A4/A5 factory consumers (open, gated on Hadrian deploy)
- **PR-4 (this) — DAMMv1 typed reads** (open, NO deploy gating)
- PR-5 — orphan library cleanup (pending)