### PR TITLE
test(cpi): BenchProbe + Hadrian CU baseline + Tier 3 universal-delegation measurement

### DIFF
--- a/contracts/cpi/test/BenchProbe.sol
+++ b/contracts/cpi/test/BenchProbe.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {
+    ISystemProgram,
+    SystemProgram,
+    ICrossProgramInvocation,
+    CpiProgram,
+    IHelperProgram,
+    HelperProgram,
+    IWithdraw,
+    Withdraw
+} from "../../interface.sol";
+import {SplTokenLib} from "../../spl_token/spl_token.sol";
+
+/// @title BenchProbe — comprehensive primitive CU measurement
+/// @notice Each external function exercises EXACTLY ONE primitive so a
+///         caller measuring `computeUnitsConsumed` via the Solana tx
+///         receipt attributes the cost to one operation. Paired old/new
+///         variants enable direct before/after comparison.
+contract BenchProbe {
+    /// State for Tier 2 (mutation) probes. Set via setup().
+    bool public setupDone;
+    address public dest;
+
+    // ─────────────────────────────────────────────────────────────────
+    // PDA / ATA derivation (Tier 1 — no state setup)
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Solana PDA seeds are 32 bytes max each — use bytes32-packed second seed.
+    function _seedsFor(uint256 idx) internal pure returns (ISystemProgram.Seed[] memory) {
+        ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](2);
+        seeds[0] = ISystemProgram.Seed(bytes("benchmark"));
+        seeds[1] = ISystemProgram.Seed(abi.encodePacked(idx));
+        return seeds;
+    }
+
+    function probe_findPda_single(uint256 idx) external view returns (bytes32) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        (bytes32 pda, ) = SystemProgram.find_program_address(programId, _seedsFor(idx));
+        return pda;
+    }
+
+    function probe_findPda_twoHop(uint256 idx) external view returns (bytes32) {
+        bytes32 romeProgram = SystemProgram.rome_evm_program_id();
+
+        ISystemProgram.Seed[] memory pdaSeeds = new ISystemProgram.Seed[](2);
+        pdaSeeds[0] = ISystemProgram.Seed(bytes("EXTERNAL_AUTHORITY"));
+        pdaSeeds[1] = ISystemProgram.Seed(abi.encodePacked(bytes32(idx)));
+        (bytes32 userPda, ) = SystemProgram.find_program_address(romeProgram, pdaSeeds);
+
+        bytes32 mintId = SystemProgram.mint_id();
+        bytes32 splTokenProgram = bytes32(uint256(uint160(0)) | uint256(0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9));
+        bytes32 ataProgram = bytes32(uint256(uint160(0)) | uint256(0x8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859));
+
+        ISystemProgram.Seed[] memory ataSeeds = new ISystemProgram.Seed[](3);
+        ataSeeds[0] = ISystemProgram.Seed(abi.encodePacked(userPda));
+        ataSeeds[1] = ISystemProgram.Seed(abi.encodePacked(splTokenProgram));
+        ataSeeds[2] = ISystemProgram.Seed(abi.encodePacked(mintId));
+        (bytes32 ataAddr, ) = SystemProgram.find_program_address(ataProgram, ataSeeds);
+        return ataAddr;
+    }
+
+    function probe_helperPda(address user) external view returns (bytes32) {
+        return HelperProgram.pda(user);
+    }
+
+    function probe_helperAta(address user, bytes32 mint) external view returns (bytes32) {
+        return HelperProgram.ata(user, mint);
+    }
+
+    // NOTE: `probe_createPdaWithBump` (calls SystemProgram.create_program_address)
+    // omitted — that interface declaration lives on the pda-cost-probe branch
+    // and was not merged to master. Re-add once the selector decl ships.
+
+    // ─────────────────────────────────────────────────────────────────
+    // Batch derive (Tier 1 — no state setup)
+    // ─────────────────────────────────────────────────────────────────
+
+    /// 7× sequential find_program_address. Baseline for the batch comparison.
+    function probe_findPda_7sequential(uint256 baseIdx) external view returns (bytes32[] memory) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        bytes32[] memory pdas = new bytes32[](7);
+        for (uint256 i = 0; i < 7; i++) {
+            ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](2);
+            seeds[0] = ISystemProgram.Seed(bytes("benchmark"));
+            seeds[1] = ISystemProgram.Seed(abi.encodePacked(baseIdx + i));
+            (bytes32 pda, ) = SystemProgram.find_program_address(programId, seeds);
+            pdas[i] = pda;
+        }
+        return pdas;
+    }
+
+    /// 7× via pdas_batch_derive — one dispatch.
+    function probe_pdasBatch_7(uint256 baseIdx) external view returns (ICrossProgramInvocation.PdaWithBump[] memory) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        bytes[][] memory seedGroups = new bytes[][](7);
+        for (uint256 i = 0; i < 7; i++) {
+            seedGroups[i] = new bytes[](2);
+            seedGroups[i][0] = bytes("benchmark");
+            seedGroups[i][1] = abi.encodePacked(baseIdx + i);
+        }
+        return CpiProgram.pdas_batch_derive(seedGroups, programId);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Account reads (Tier 1 — no state setup)
+    // ─────────────────────────────────────────────────────────────────
+
+    function probe_accountInfo(bytes32 pubkey) external view returns (uint64 lamports, bytes32 owner, bool isSigner, bool isWritable, bool executable, uint256 dataLen) {
+        bytes memory data;
+        (lamports, owner, isSigner, isWritable, executable, data) = CpiProgram.account_info(pubkey);
+        dataLen = data.length;
+    }
+
+    function probe_accountDataAt(bytes32 pubkey, uint16 offset, uint16 length) external view returns (bytes memory) {
+        return CpiProgram.account_data_at(pubkey, offset, length);
+    }
+
+    function probe_accountU64At(bytes32 pubkey, uint16 offset) external view returns (uint64) {
+        return CpiProgram.account_u64_at(pubkey, offset);
+    }
+
+    function probe_accountLamports(bytes32 pubkey) external view returns (uint64) {
+        return CpiProgram.account_lamports(pubkey);
+    }
+
+    function probe_mintId() external view returns (bytes32) {
+        return SystemProgram.mint_id();
+    }
+
+    function probe_operator() external view returns (bytes32) {
+        return SystemProgram.operator();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Tier 2 — Mutations (require setup)
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Accept native gas from EOA — needed before setup().
+    receive() external payable {}
+
+    /// One-time state init. Funded via msg.value on this call (deployer
+    /// sends enough gas for the initial wrap). Activates probe's PDA,
+    /// creates probe's gas-mint ATA, creates destination's ATA so transfer
+    /// probes don't pay create cost, and wraps a starter balance.
+    ///
+    /// CU spent here is NOT measured as a probe — this is one-time setup.
+    function setup(address _dest, uint256 initialWrapWei) external payable {
+        require(!setupDone, "already setup");
+        require(msg.value >= initialWrapWei, "send wei >= initialWrapWei");
+        dest = _dest;
+
+        // Activate probe's PDA + create probe's gas-mint ATA.
+        HelperProgram.create_pda(address(this));
+        HelperProgram.create_ata(address(this));
+
+        // Pre-create dest ATA so transfer probes measure transfer-only cost.
+        HelperProgram.create_ata(_dest);
+
+        // Wrap a starter amount into probe's wUSDC ATA so unwrap/transfer
+        // probes have balance to work against.
+        Withdraw.withdraw_to_ata(initialWrapWei);
+
+        setupDone = true;
+    }
+
+    /// Wrap (NEW): gas → wrapper ATA via Withdraw.withdraw_to_ata.
+    /// Single Solana CPI (composed): mint wrapper SPL + credit to ATA.
+    function probe_wrap_new(uint64 amount) external {
+        Withdraw.withdraw_to_ata(amount);
+    }
+
+    /// Unwrap (NEW): wrapper ATA → gas via HelperProgram.deposit_from_ata.
+    /// Single Solana CPI (composed): burn wrapper SPL + credit gas.
+    function probe_unwrap_new(uint256 wei_) external {
+        HelperProgram.deposit_from_ata(wei_);
+    }
+
+    /// SPL transfer NEW 3-arg: HelperProgram.transfer_spl(addr, N, mint).
+    /// Source = probe's PDA-owned ATA (derived implicitly). Dest = address-keyed.
+    function probe_transfer_spl_helper_3arg() external {
+        bytes32 mintId = SystemProgram.mint_id();
+        HelperProgram.transfer_spl(dest, uint64(1), mintId);
+    }
+
+    /// SPL transfer NEW 4-arg delegate: explicit src_ata + dest_ata.
+    /// This is the B1 migration candidate for SPL_ERC20._transfer.
+    function probe_transfer_spl_helper_4arg() external {
+        bytes32 mintId = SystemProgram.mint_id();
+        bytes32 srcAta = HelperProgram.ata(address(this), mintId);
+        bytes32 destAta = HelperProgram.ata(dest, mintId);
+        HelperProgram.transfer_spl(srcAta, destAta, uint64(1), mintId);
+    }
+
+    /// SPL transfer LEGACY fallback: SplTokenLib.transfer_checked +
+    /// CpiProgram.invoke_signed. This is what SPL_ERC20._transfer does
+    /// today (see erc20spl.sol:290).
+    function probe_transfer_spl_legacy() external {
+        bytes32 mintId = SystemProgram.mint_id();
+        bytes32 srcAta = HelperProgram.ata(address(this), mintId);
+        bytes32 destAta = HelperProgram.ata(dest, mintId);
+        bytes32 ownerPda = HelperProgram.pda(address(this));
+
+        SplTokenLib.SplMint memory mint = SplTokenLib.load_mint(mintId, address(CpiProgram));
+
+        ICrossProgramInvocation.AccountMeta[] memory accts = new ICrossProgramInvocation.AccountMeta[](4);
+        accts[0] = ICrossProgramInvocation.AccountMeta(srcAta, false, true);    // source (writable)
+        accts[1] = ICrossProgramInvocation.AccountMeta(mintId, false, false);   // mint
+        accts[2] = ICrossProgramInvocation.AccountMeta(destAta, false, true);   // destination (writable)
+        accts[3] = ICrossProgramInvocation.AccountMeta(ownerPda, true, false);  // authority (signer)
+        bytes memory data = abi.encodePacked(uint8(12), _u64le(uint64(1)), mint.decimals);
+
+        bytes32[] memory emptySeeds = new bytes32[](0);
+        CpiProgram.invoke_signed(SplTokenLib.SPL_TOKEN_PROGRAM, accts, data, emptySeeds);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Tier 3 — Universal-delegation (A1-A6 from rome-evm-private #364)
+    //           Paired old/new for benchmark side-by-side
+    // ─────────────────────────────────────────────────────────────────
+
+    /// A3 OLD: salted PDA derivation via 2 syscalls
+    ///   (1) SystemProgram.rome_evm_program_id() + (2) find_program_address.
+    /// This is the v1 path consumed by `RomeEVMAccount.pda_with_salt`
+    /// pre-#165 (now collapsed to A3).
+    function probe_a3_pdaWithSalt_OLD(address user, bytes32 salt) external view returns (bytes32) {
+        bytes32 programId = SystemProgram.rome_evm_program_id();
+        ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](3);
+        seeds[0] = ISystemProgram.Seed(bytes("EXTERNAL_AUTHORITY"));
+        seeds[1] = ISystemProgram.Seed(abi.encodePacked(user));
+        seeds[2] = ISystemProgram.Seed(abi.encodePacked(salt));
+        (bytes32 pda, ) = SystemProgram.find_program_address(programId, seeds);
+        return pda;
+    }
+
+    /// A3 NEW: HelperProgram.pda_with_salt — single dispatch (selector 0x5c6d04b3).
+    /// Shipped in rome-evm-private #364, consumed by RomeEVMAccount.pda_with_salt
+    /// in rome-solidity #165.
+    function probe_a3_pdaWithSalt_NEW(address user, bytes32 salt) external view returns (bytes32) {
+        return HelperProgram.pda_with_salt(user, salt);
+    }
+
+    /// A2 OLD: SPL approve via SplTokenLib.approve + CpiProgram.invoke_signed.
+    /// This is the v1 path consumed by RomeBridgeWithdraw.approveBurnETH
+    /// pre-#165. The OLD SPL instruction is the 3-account `approve` (tag 4)
+    /// — no on-chain decimals enforcement. Caller pays mint-read cost
+    /// separately if `approve_checked` semantics are wanted.
+    function probe_a2_approveSplRawDelegate_OLD(bytes32 delegate, uint64 amount) external {
+        bytes32 mintId = SystemProgram.mint_id();
+        bytes32 srcAta = HelperProgram.ata(address(this), mintId);
+        bytes32 ownerPda = HelperProgram.pda(address(this));
+
+        ICrossProgramInvocation.AccountMeta[] memory accts = new ICrossProgramInvocation.AccountMeta[](3);
+        accts[0] = ICrossProgramInvocation.AccountMeta(srcAta, false, true);    // source (writable)
+        accts[1] = ICrossProgramInvocation.AccountMeta(delegate, false, false); // delegate
+        accts[2] = ICrossProgramInvocation.AccountMeta(ownerPda, true, false);  // owner (signer)
+        bytes memory data = abi.encodePacked(uint8(4), _u64le(amount));
+
+        bytes32[] memory emptySeeds = new bytes32[](0);
+        CpiProgram.invoke_signed(SplTokenLib.SPL_TOKEN_PROGRAM, accts, data, emptySeeds);
+    }
+
+    /// A2 NEW: HelperProgram.approve_spl_raw_delegate — single dispatch
+    /// (selector 0x7881d453). Caller passes `decimals` to skip on-chain
+    /// mint read (~30-50K CU saving over a decimals-fetching variant).
+    /// Shipped in rome-evm-private #364, consumed by
+    /// RomeBridgeWithdraw.approveBurnETH in rome-solidity #165.
+    function probe_a2_approveSplRawDelegate_NEW(bytes32 delegate, uint64 amount, uint8 decimals) external {
+        bytes32 mintId = SystemProgram.mint_id();
+        bytes32 srcAta = HelperProgram.ata(address(this), mintId);
+        HelperProgram.approve_spl_raw_delegate(srcAta, delegate, amount, mintId, decimals);
+    }
+
+    /// Inline LE-u64 encoder — used by the OLD probes that encode raw SPL
+    /// instructions. Replaces the prior `SplTokenLib._le_u64` (pruned in #169).
+    function _u64le(uint64 v) private pure returns (bytes memory) {
+        return abi.encodePacked(
+            uint8(v),
+            uint8(v >> 8),
+            uint8(v >> 16),
+            uint8(v >> 24),
+            uint8(v >> 32),
+            uint8(v >> 40),
+            uint8(v >> 48),
+            uint8(v >> 56)
+        );
+    }
+}

--- a/deployments/hadrian.BenchProbe.bench.json
+++ b/deployments/hadrian.BenchProbe.bench.json
@@ -1,0 +1,877 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "probeAddress": "0x4ddB8e15D1405869a050395602e5BE53ac81316e",
+  "mintId": "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7",
+  "operator": "0x1ba57c905417b673784efcc630fbcc9302e2d3b04c8e9c939145a0105ccf5cdc",
+  "solanaRpc": "https://api.devnet.solana.com/",
+  "runAt": "2026-05-16T20:23:33.647Z",
+  "methodology": "submit probe tx → rome_solanaTxForEvmTx → Solana getTransaction → meta.computeUnitsConsumed",
+  "results": [
+    {
+      "label": "[baseline] probe_mintId",
+      "group": "baseline",
+      "tier": 1,
+      "samples": [
+        {
+          "evmHash": "0x68b677167ff16001ede20f0a4a680cc1a52ab2afeb621ece9cd65911f7a7fbfd",
+          "sigs": [
+            "5aAm7K8GdpxiQmgrSsGmgwLeBzYz5eWxS9JygSg5nfCgZgTq8YGvDg9AybKdtkjvKZarJrN54wRyLpxa6kAinRPv"
+          ],
+          "perTx": [
+            108620
+          ],
+          "totalCu": 108620
+        },
+        {
+          "evmHash": "0x61c3d59c64218c9c3a55a3199b5ef34c2d90ba333668e5b576dae3790b482886",
+          "sigs": [
+            "4BtJs9h2H68D3Tgx4CdzeAMHEzLfwzYUub2FwYLBZzh6LKFocJ9hJvhsUSGP8CrQzWqPBamQLxMqmqhGTfqrgWKq"
+          ],
+          "perTx": [
+            104120
+          ],
+          "totalCu": 104120
+        },
+        {
+          "evmHash": "0xc77c28d9830fc54211ce0f3703baae177bdff6b7ddfed67a160858cdba231ec4",
+          "sigs": [
+            "2oPCF51ov6nvoQz1BQsQQ1hUwRd5dXQT4KcqH82JQYCW9RNdoBXrK8oqUeuUWsP9EszZmnj1XUBCqUg7VvB5rvEt"
+          ],
+          "perTx": [
+            104120
+          ],
+          "totalCu": 104120
+        }
+      ],
+      "mean": 105620
+    },
+    {
+      "label": "[baseline] probe_operator",
+      "group": "baseline",
+      "tier": 1,
+      "samples": [
+        {
+          "evmHash": "0xaa66db9626bad8621942e56e285b2bf49e30b2aff73b062e7c3dcc6258351eee",
+          "sigs": [
+            "4mCiP8RGoZP4trqm7nYpdnBvWxUbM96ExQY5MYtT3h8aELhcBnKYb86pRPqmPsfLyDhWGiYjXXaEoPRMJCE7H51x"
+          ],
+          "perTx": [
+            108919
+          ],
+          "totalCu": 108919
+        },
+        {
+          "evmHash": "0x3d6060ecc7086d38536b361e7d076bd2c8889c166ec15bd836536cf8b3f4f68f",
+          "sigs": [
+            "59pje54sCu2x3Dd24n7s2HD82bAKsZu7VKSHQdsTaXoz1SupC9DdxjV6wWWvFxePP5t5voVLZWYrecHo7bmHXngi"
+          ],
+          "perTx": [
+            102949
+          ],
+          "totalCu": 102949
+        },
+        {
+          "evmHash": "0xe81fc31b86298befc2f43e6a3c868578b87bf7bdbd32030c578ed56be603a559",
+          "sigs": [
+            "rpg4dNRQpy2EsEsDaPx2vkm2MkPzTrie8RVCySFyt6Dr45eL12rFCs3iLJE7HaDuigPmJ545aUEwHBuqi54Z3Hr"
+          ],
+          "perTx": [
+            110411
+          ],
+          "totalCu": 110411
+        }
+      ],
+      "mean": 107426
+    },
+    {
+      "label": "OLD findPda × 1 (single derive)",
+      "group": "pda",
+      "tier": 1,
+      "samples": [
+        {
+          "evmHash": "0x91a753e56b75e0447b98935ba66aec574c5a423be509ca529b85ed2cae44583b",
+          "sigs": [
+            "29Zkg7XzNPSZ5kPNRgAFrSN2K2sJqAQx6NuFkxLsqKf3FTWJgsqP7EXuPfqhdx2B92VJ6YoXHggHvaE8Bxonj4Ha"
+          ],
+          "perTx": [
+            180011
+          ],
+          "totalCu": 180011
+        },
+        {
+          "evmHash": "0x1451a0eb1ba0fb9185fdd39951911107506fafffcd41a62ced1b8fd42515e963",
+          "sigs": [
+            "3sUCi3yRdJmHmp8f2Nf5AmRMjEQYGGHzsF3RV9Xy4KAUBmtjV463ATS1ZC8z2q8d8nx5U6RAkTBJ61uh7KzPd7cX"
+          ],
+          "perTx": [
+            181653
+          ],
+          "totalCu": 181653
+        },
+        {
+          "evmHash": "0x31d189f1e3df1b3c60fd6d67e313d7721382ed587f8d69d61cd555635447eb9b",
+          "sigs": [
+            "1XFaCudSUe9GQj6qWZsGXUs8j9FQyaBdQszCT3HH2oe5YczhKxYZabQRgUvZjVJGRbvvkSj7VZGWMN9tPSPiEX6"
+          ],
+          "perTx": [
+            178511
+          ],
+          "totalCu": 178511
+        }
+      ],
+      "mean": 180058
+    },
+    {
+      "label": "OLD findPda × 2 (two-hop ATA path)",
+      "group": "pda",
+      "tier": 1,
+      "pairWith": "OLD findPda × 1 (single derive)",
+      "samples": [
+        {
+          "evmHash": "0x968faae70d6561e969e7fc52f3d619b80feccd63930d4f04195fc647eeb415ea",
+          "sigs": [
+            "1tYxCSsaQMyvju4UBtBZDhf81fbENbdgvsGpvYqWoSeqjR28Ua7USRpcb7UzADArA7zXPDbYdNTJ9dXyGdL4haB"
+          ],
+          "perTx": [
+            291371
+          ],
+          "totalCu": 291371
+        },
+        {
+          "evmHash": "0xfd1a7e63d9286bd050aa46c455ab38fa97bcab11392b81e60b148448a54dd14d",
+          "sigs": [
+            "2s3Zbcfbhd6yTA8aFv7yHpAVq3NnMPK2RxQ9Xn6Ujno9dFgpzjHT44V5DLNWrreQqw2A3JwuicnD8E4SjGiKDShM"
+          ],
+          "perTx": [
+            288371
+          ],
+          "totalCu": 288371
+        },
+        {
+          "evmHash": "0x5a6197a38a865467545d133753a2360b036364a9b52f1ad98af3c29f3648dbc8",
+          "sigs": [
+            "5oJaJxTSFqjbGYLrpUoJardrcHyK31E1v3M6EftWEi6rB7vdPEyR72JhCyoCnnRSyo2UmPDuJcC7SdXLwMXTcQgV"
+          ],
+          "perTx": [
+            289871
+          ],
+          "totalCu": 289871
+        }
+      ],
+      "mean": 289871
+    },
+    {
+      "label": "NEW HelperProgram.pda(user)",
+      "group": "pda",
+      "tier": 1,
+      "pairWith": "OLD findPda × 1 (single derive)",
+      "samples": [
+        {
+          "evmHash": "0x910f20751127998b29797613e833cb08bcfd90df4569cebccda295b16efd3e0e",
+          "sigs": [
+            "4nWRX8DQS6BDvsFcKD96uZUaN7gFixx6KhqoP7pEmcjNAcTRUGPXdupH2GjoP3jpAVQWjajJW29WcqAMaTHdUsVp"
+          ],
+          "perTx": [
+            120249
+          ],
+          "totalCu": 120249
+        },
+        {
+          "evmHash": "0x30bd5e0a44646846324842a93a2d67ffbffbf492b842cdb6a0cc82a53f700142",
+          "sigs": [
+            "62edYD1C8RF7KPD3L4qu6F5LrUt5cUW4rupyA9ERy2cF79ZyDLNobHZdaLT3sQgokYNSCWnt5GWFutezGi2rfESk"
+          ],
+          "perTx": [
+            118757
+          ],
+          "totalCu": 118757
+        },
+        {
+          "evmHash": "0x5658e308a1f24a897627eb74f6746aa87dcb4980e58e5a21c4a9b1bd479c59d1",
+          "sigs": [
+            "4e4ze79eLzUUH6wZpLQKXdhZzjBZpLGU7U7RuPeGQwPJhfxQuvtRna56u4PYYYVnxTLHQjynQrVSoNdUExy2knWZ"
+          ],
+          "perTx": [
+            114257
+          ],
+          "totalCu": 114257
+        }
+      ],
+      "mean": 117754
+    },
+    {
+      "label": "NEW HelperProgram.ata(user, mint)",
+      "group": "ata",
+      "tier": 1,
+      "pairWith": "OLD findPda × 2 (two-hop ATA path)",
+      "samples": [
+        {
+          "evmHash": "0x08012379a7933d12a46c5018ac6fbe4d682800618f64d7d8e640c035670f8950",
+          "sigs": [
+            "45rBSNFPDu7rzmb7kNkLiGyqa5GzKrwnY12DezLQJ61dZZVkVX3ao9JSRfsbx8SDa4Jpa4AjvawcUTJCLQkTXm7E"
+          ],
+          "perTx": [
+            115430
+          ],
+          "totalCu": 115430
+        },
+        {
+          "evmHash": "0xa114fe7d15262aa90eaf46b4f2dd357f224839761270a0c831be47d8478daa8c",
+          "sigs": [
+            "5BiAGmecij9by7ekjkiqWkobhrqUX5yxt3d86dZujgLiHWVkTFYheZ1zgix6pZkv7NXgYBs3LHS5Kpdf8hRTiX2C"
+          ],
+          "perTx": [
+            112438
+          ],
+          "totalCu": 112438
+        },
+        {
+          "evmHash": "0x844598dbe2ebc96ee1f5d05428b2359cb6625fa15e5dbf3a6469758cfa8aa37b",
+          "sigs": [
+            "2jVFq8MCKSW9VpzQqxctS4coEkT2fu5WoWguWWxRCqCHh3yb9K9rHJvj6VEb6nn5PJ7CDdp6skhRCCTjRAYEtYnB"
+          ],
+          "perTx": [
+            112430
+          ],
+          "totalCu": 112430
+        }
+      ],
+      "mean": 113433
+    },
+    {
+      "label": "NEW create_program_address (find+create)",
+      "group": "pda",
+      "tier": 1,
+      "pairWith": "OLD findPda × 1 (single derive)",
+      "samples": [
+        {
+          "evmHash": "0x2d55ef6f074e22c0705467e5d38a43614b393450a2558091a34fd33327e8de44",
+          "sigs": [
+            "2bNRgLDkoccqaVQ9pmDqpkBsZUhYJokC2JsdJ6XELHgVGJiYPChpYpnjwga6xpUDgANNQEWeumws8n5hY9kCabPG"
+          ],
+          "perTx": [
+            206495
+          ],
+          "totalCu": 206495
+        },
+        {
+          "evmHash": "0x2cd589eb4c1cf6bd373b25d865d4361dc860aed4e939fd755b3dd7aad46da2d7",
+          "sigs": [
+            "cR4ApgxWpXhLoPfEJmgM2oYBd3Xg2P5eov1tCgdyE5Hp36uyz6kfFsi29uuYX5U3iFco5CkK4RyrxgzUZVvw7sR"
+          ],
+          "perTx": [
+            206519
+          ],
+          "totalCu": 206519
+        },
+        {
+          "evmHash": "0x68ac73a913c798f238375532b518864059571ecbcbc0abdf0513f74d822ddb5a",
+          "sigs": [
+            "2s6CH1PZupe4F69WoMXrPrZRAgEzZ2sTD4nwpKz1K12NBdCB6TvenG4XgirGRnbFoBpz4CmbAKJpmtU9kXPsJqju"
+          ],
+          "perTx": [
+            206495
+          ],
+          "totalCu": 206495
+        }
+      ],
+      "mean": 206503
+    },
+    {
+      "label": "OLD findPda × 7 (sequential)",
+      "group": "batch",
+      "tier": 1,
+      "samples": [
+        {
+          "evmHash": "0xd0fa402bdfd85c6650642ad2c7d914527b89b02e37058319b9b58c7fc5932ef9",
+          "sigs": [
+            "LULGnfiou5LCuEqgrxy8Cp5d9g2VHELwLJckYK21yC8pwJYGYVcHXPnoKp7NA7fLNcrBNks5NW1X8n4EYe6NpBq"
+          ],
+          "perTx": [
+            659535
+          ],
+          "totalCu": 659535
+        },
+        {
+          "evmHash": "0x7920d6bfb38297d75c170c02214f577e1e414eff12bb9783b5470cbc59ba30f9",
+          "sigs": [
+            "3bUxrNGuKTFCuRz66E7rqWMFfzC3YB2AWcbgqPQyuGR2yUKkB3wkCjvws9E1ahnUVJuSnePLZhYzfCbyvExhvE2P"
+          ],
+          "perTx": [
+            658027
+          ],
+          "totalCu": 658027
+        },
+        {
+          "evmHash": "0x0ca9e75e9c70806078eec7222bd4bdc56c3ce84f11580af43c2295790d63df8a",
+          "sigs": [
+            "3juDi4XBAgFkXJUwHsEDjUKAZzWwnBG2X5x7U2vewqp2LuK8zkMHsKqgansW12Y6zkv6njXvyY6Y4okF7WBdj3LX"
+          ],
+          "perTx": [
+            658027
+          ],
+          "totalCu": 658027
+        }
+      ],
+      "mean": 658530
+    },
+    {
+      "label": "NEW pdas_batch_derive × 7",
+      "group": "batch",
+      "tier": 1,
+      "pairWith": "OLD findPda × 7 (sequential)",
+      "samples": [
+        {
+          "evmHash": "0x8f3f5f3281875ac5f2db202bcea17d2fab91c78bfe8b48988fa656bf9cc9c9a8",
+          "sigs": [
+            "2Bdhy2Zdiku7xm4Sg1FjEGdCxhEVDz6mJNGnt7SS59XQnUJgr61T84bV5C43BQ62xV38aAdE3GfGEVTjDu9eAfJe"
+          ],
+          "perTx": [
+            627061
+          ],
+          "totalCu": 627061
+        },
+        {
+          "evmHash": "0x2c61c9a1fee977168f774f46d7e3cf671924964ead0cff56703c483b6752634a",
+          "sigs": [
+            "2t9M99LzYcTF6K22hgrAMcT5WALXBvmYXekWwjZgFFF8SYsCyDjBfFtf7sdXTiS7B2j3RvG1hHh7kQ1pvvLkyPpy"
+          ],
+          "perTx": [
+            622569
+          ],
+          "totalCu": 622569
+        },
+        {
+          "evmHash": "0x9eccfc9b0c0d3e2ed5d57a53c4b1af365ec436ba0109115c2dee87afb9851910",
+          "sigs": [
+            "2o3GJSAJrcN4UqYcMhpnM115N454dA4Ppb9CZK2NXgGjuAMhYg6wdEeaaz9WX7gYHW2EG7AtPQUrUDWe6xaziqib"
+          ],
+          "perTx": [
+            625561
+          ],
+          "totalCu": 625561
+        }
+      ],
+      "mean": 625064
+    },
+    {
+      "label": "OLD account_info (full marshal)",
+      "group": "account",
+      "tier": 1,
+      "samples": [
+        {
+          "evmHash": "0x052eea5451f69681a6a70cbd62107aaffe93596f38d5480541df73b410174355",
+          "sigs": [
+            "4THqyhJupdhgjJBBXi8uWfkxXLt4Ch7hThpBxHSjcAiASUCj5xbRBqeqoaH596PpLD983X7uzFNBpJzfwdfU8ZzH"
+          ],
+          "perTx": [
+            136226
+          ],
+          "totalCu": 136226
+        },
+        {
+          "evmHash": "0x7a308758dc8d361303ea12316d0519f97cfacece5cd638682f31652da884632b",
+          "sigs": [
+            "wrgWwMgdUES9YFvmPAmsEMsbwX9J5LPXLzBG3oMeQWgw6eVzoKtDwfp6sqEdJ4bxm4H1pUJEhEkSLqUfFGcW4EM"
+          ],
+          "perTx": [
+            136218
+          ],
+          "totalCu": 136218
+        },
+        {
+          "evmHash": "0xa4b2b4e83072c66743537ca1525ca4bc147fce9cd509481e9963353082580a17",
+          "sigs": [
+            "32wo8ADdFRynbNKDmfR7UEUdm83jH9CCftzUqGfWoPk1WDTykX81DoK3PVu3xoTmsZtNATYnUWKE2Ayc5Uv1DnJa"
+          ],
+          "perTx": [
+            136226
+          ],
+          "totalCu": 136226
+        }
+      ],
+      "mean": 136223
+    },
+    {
+      "label": "NEW account_data_at (slice 0..82)",
+      "group": "account",
+      "tier": 1,
+      "pairWith": "OLD account_info (full marshal)",
+      "samples": [
+        {
+          "evmHash": "0x14d7d243024594b57c99063b1d4b0e5f3de54dc5c5fca33ef1c263738f53606e",
+          "sigs": [
+            "2megfQ59natSUCCb8Gqre9HEwfPtdpBnBdry9eSmj2dRfMFqfTFuLq7LyMcUs6Ya97WH4MfEWTZmTm1cFUaryEv9"
+          ],
+          "perTx": [
+            130438
+          ],
+          "totalCu": 130438
+        },
+        {
+          "evmHash": "0xa115c9511d6880a7b2a9e7030999295f5fb99a190131774c395fe707ef5b90f1",
+          "sigs": [
+            "2Rx5cgBU2uDV68iNRgs8TtSZgTUj7pdZYZmDbQNhfqXMMUGTDg5iJWByrhNtAgvQkEYgFNGhxCkAhauDSoggyTDK"
+          ],
+          "perTx": [
+            127438
+          ],
+          "totalCu": 127438
+        },
+        {
+          "evmHash": "0x517e00f81e0a2efa86ceb8d870eb9b19084a559ae2f192f61ce4f0aa90d4843a",
+          "sigs": [
+            "ZjpviRHDdrRdQpUbRv6ksVz5cXpn4UftFmfRZKHU6WcHfnYgxhZuniwMzHY2BWo4uaXHtX7HBexp5wzpNR2Agrt"
+          ],
+          "perTx": [
+            127438
+          ],
+          "totalCu": 127438
+        }
+      ],
+      "mean": 128438
+    },
+    {
+      "label": "NEW account_u64_at (offset 36)",
+      "group": "account",
+      "tier": 1,
+      "pairWith": "OLD account_info (full marshal)",
+      "samples": [
+        {
+          "evmHash": "0x12d89161df9b21129e6ea4c5ee0e6c161b5583bd6ed62a4b912fad81fe811046",
+          "sigs": [
+            "2Db9sd97pM1jMbpsE76GKCUuf2ht8PxuoeEg9wNToaNRoA1aJkFeUFq6YkMYQ2PCD3dmVjYXzp3UUwQoEUngvSVJ"
+          ],
+          "perTx": [
+            116892
+          ],
+          "totalCu": 116892
+        },
+        {
+          "evmHash": "0x00580e4a647c9c07461f09779f8794819e46b0396e2e5f02fbab4a354acbed17",
+          "sigs": [
+            "5rXeKw2Na6iWMwCSpRnZMUPyvzbwyKe98mf6ZJE2UuqefHLEavkt6kjtT3VXtygouD5VtDAsCgGXvkRDv8pqZ9wG"
+          ],
+          "perTx": [
+            116892
+          ],
+          "totalCu": 116892
+        },
+        {
+          "evmHash": "0x62444b08ee89fa0bab7d61a0c509025a6b363d5d3206333ed6fcd813119acc9c",
+          "sigs": [
+            "a3d4UDef8bKJbw7ZGz3WgQaqV2h9yXdJ9vL2ZcxvMmXfijfLabkaWh6HJ4Uxsf2aRWYBJtPo9prQ3G754zUfkmA"
+          ],
+          "perTx": [
+            116884
+          ],
+          "totalCu": 116884
+        }
+      ],
+      "mean": 116889
+    },
+    {
+      "label": "NEW account_lamports",
+      "group": "account",
+      "tier": 1,
+      "pairWith": "OLD account_info (full marshal)",
+      "samples": [
+        {
+          "evmHash": "0xe346eba2aa1ffb513fd19dc1bad8d50c5306df9c39fcb143b1952edf5bebe7ea",
+          "sigs": [
+            "3SSTjQQF9JjAWZVY4JzPkvQZfFf9kZUij3SfhBjLHSLDxjtH1FDqsE5Uu23eKoiEWmW6xt62GnRBwuzPpAfob8iD"
+          ],
+          "perTx": [
+            115982
+          ],
+          "totalCu": 115982
+        },
+        {
+          "evmHash": "0xd8024b9ae55e6ebf5289bdb5ea21e93d786d2bc31d44939efbc76c56f031df9c",
+          "sigs": [
+            "2V2G5pucrf5Nrssa7Kz9jxLGcB2KnrDR3GkXtRmF4kSYCSbesvHSnd9o493gTSa168xoy2jRZLX6LSzn9szHx1FZ"
+          ],
+          "perTx": [
+            111444
+          ],
+          "totalCu": 111444
+        },
+        {
+          "evmHash": "0x4314c2e3adcda395062106e80a6443bbbf04e0b5f7d49590e0e539d98adbd11c",
+          "sigs": [
+            "5QMVAAzinzZHLSnXbeDm46VVkSjpowkQJyD8WXq6DdBFNzwaDZsnoK7SSpyBj7Sw2MeCH1mWhqKaMTWsJMhUcd2V"
+          ],
+          "perTx": [
+            109952
+          ],
+          "totalCu": 109952
+        }
+      ],
+      "mean": 112459
+    },
+    {
+      "label": "[T2] Wrap NEW (Withdraw.withdraw_to_ata)",
+      "group": "wrap",
+      "tier": 2,
+      "samples": [
+        {
+          "evmHash": "0x766e493b1e73eacdc6571146810b84a73e65ed8fad699d35aa31104aabd4494e",
+          "sigs": [
+            "5DV9tPfcPCvt562d1ZhhDJRBShswyKxLD27jpWvcZnQbpumdJmbWZbeweTNU3MsjANNAUAandZiWhUvut5yeMYD1",
+            "2CFRj7NyuhVYA3hAwJpZhZxPrGLWpEaKjmjc5nj5Bu62YSnba1MmXqcf5zbrdJLHgX8wosTrpf3XjT7uzydjUXTD"
+          ],
+          "perTx": [
+            11171,
+            165586
+          ],
+          "totalCu": 176757
+        },
+        {
+          "evmHash": "0x2a4232a6dacb7cb2fce19456e91a238b9c1fdd5d1bb6d99d017690ff0888b06f",
+          "sigs": [
+            "5DAce94RcfsFGrWVk7yNmEgLJ41r3NxWEv5xxjU6pcMmUkvZ16dfUo8y31Ebmgzf7DWYFjKUazQZCbtjCVXGn246",
+            "3mk9q9ytLpB9xbzi3KspfKzsYHJGsf1gK4CY9Xmjz9VrdtvNJdUM4x1828uFLecZUdHmG9maVXx1TZ7dZaUA565P"
+          ],
+          "perTx": [
+            10609,
+            161196
+          ],
+          "totalCu": 171805
+        },
+        {
+          "evmHash": "0x6bcb4edf7fe7bd47d1e806e69fd8a185bcc7cefc70fa0b0cc33ec34422a096ed",
+          "sigs": [
+            "5ZfqYWCQygA1Lbo1Lyv8FFw7iaUKmuUxfaQiJUNKGXqvg5s4rUkHhtRtVA9c5XfjXX9X17k4ttn4jABh2cFdj8hq",
+            "84gCZiVxSkidcGmxKq29vJc6xBMmYKfpcnLgm88nEeTzHvJfZ6BHDvurBx4ibPY7XRd8zYqCBGDJnY4QXV5kohE"
+          ],
+          "perTx": [
+            10609,
+            167078
+          ],
+          "totalCu": 177687
+        }
+      ],
+      "mean": 175416
+    },
+    {
+      "label": "[T2] Unwrap NEW (HelperProgram.deposit_from_ata)",
+      "group": "wrap",
+      "tier": 2,
+      "samples": [
+        {
+          "evmHash": "0x5d17dbee6c4b50bf618689d002fcaf4685eb2d42b6a5f17f5d4efdb5d9f181c9",
+          "sigs": [
+            "49hTMWFXTMguVZrRgKmJx1vpfoHAJBXbrnUAfw29Web9vNgCkY4kzG2xG4NWJd8JHdzERneVBwj8trL4NacxUXt2"
+          ],
+          "perTx": [
+            139722
+          ],
+          "totalCu": 139722
+        },
+        {
+          "evmHash": "0x2d584462df7a7d884ea36df2a2c870b4d89d027a581b3eea97b34286a0290059",
+          "sigs": [
+            "29W1uzNkxuPjePFofMJ41pQTD3wsnAf3AMLyp3SSmopNmRr6dBwLiq87EkEdVWbvpg8i3S81iyp5DxCtZY4TS4G8"
+          ],
+          "perTx": [
+            144222
+          ],
+          "totalCu": 144222
+        },
+        {
+          "evmHash": "0x19fb65a43aa03602972a28ce2adc4683210bb012436c083dd45afca5f4d8bc4f",
+          "sigs": [
+            "JPgXFSK7dzxN6wFZEKbv9SpUJtFQeMS2mQd2LiRfCHa6JBwrjpbrooKdKyEpJDKq54xdfgh4FUNFm69xt2BirdN"
+          ],
+          "perTx": [
+            136760
+          ],
+          "totalCu": 136760
+        }
+      ],
+      "mean": 140235
+    },
+    {
+      "label": "[T2] SPL transfer NEW 3-arg (addr)",
+      "group": "transfer",
+      "tier": 2,
+      "samples": [
+        {
+          "evmHash": "0x475b8fafb02918b7db80f9ce695a084c1080039d3fa467e2854bde2cc9cc6dd3",
+          "sigs": [
+            "5cq8XcwrZBYgjmfPJk64GbY3SM6L7amh4bJY4XLD94nGSqsCrEPScbV1K2nDgN7k7WDc9mGEdJoACjNkkthinkAW"
+          ],
+          "perTx": [
+            158716
+          ],
+          "totalCu": 158716
+        },
+        {
+          "evmHash": "0xd559fa0f1d986ce8e0bfc7808d1be6b362aeab3ceb7792ff72d22af99219d9d6",
+          "sigs": [
+            "3uQbBqgyhSrBUnh6qCDYFSdyAoX3Zrsu6JrBd1fLJNbEbMpAMMndyfyVTf59bXRevbHe8pHxaDz7pbV1PFka6QjQ"
+          ],
+          "perTx": [
+            158716
+          ],
+          "totalCu": 158716
+        },
+        {
+          "evmHash": "0xf4a7d36ef17929a40278e67f1d5d16e301bdd40e290d2784f25dd4f5545b07df",
+          "sigs": [
+            "2d3ozWotwEaAZKyyxZYnUK1oEUJhXGp4ff2hbxKyvA7hCfjy4a2vQg4ZBTXQHrmPoB76RLHSqYLAUZXMnCTHWDrp"
+          ],
+          "perTx": [
+            158708
+          ],
+          "totalCu": 158708
+        }
+      ],
+      "mean": 158713
+    },
+    {
+      "label": "[T2] SPL transfer NEW 4-arg delegate",
+      "group": "transfer",
+      "tier": 2,
+      "pairWith": "[T2] SPL transfer LEGACY (SplTokenLib + invoke)",
+      "samples": [
+        {
+          "evmHash": "0x6b3b5827386b700b6b037806609a6cacfad8c8435a61420823d92efd2000bdc7",
+          "sigs": [
+            "LKYKp4QGStt8mugWgSHTNgKy3WPNkWVfARH4QktQfZWGWAxjDiLSa6LHj4C1J7U6kJsxkFExiYwze9DhyR6wKHS"
+          ],
+          "perTx": [
+            180342
+          ],
+          "totalCu": 180342
+        },
+        {
+          "evmHash": "0x24072d0be76da26684e57146749facc12ed9294c7c342e8f6d18d5e8f5985eac",
+          "sigs": [
+            "4oBa36KoiHudxZGcxwsXYxFuUEQkJkHTGRfEd4NFSkZiBvMuEa2wBaWA4ZxV4WCGiaudMywX4BUS9JFB1REjtU3H"
+          ],
+          "perTx": [
+            181850
+          ],
+          "totalCu": 181850
+        },
+        {
+          "evmHash": "0x2df5019804b4f35af01efc9dc886eb34bc124c8da84fbca26cf14753a45007ba",
+          "sigs": [
+            "2tDcrqFfeoeyNzdyuducZCiP1EqtNvrELE5v6HQZNx4Fgtb8tHvTcEyfUFrcfChKxJnx3GXZjvfVNQTLnu8QgHZg"
+          ],
+          "perTx": [
+            183342
+          ],
+          "totalCu": 183342
+        }
+      ],
+      "mean": 181845
+    },
+    {
+      "label": "[T2] SPL transfer LEGACY (SplTokenLib + invoke)",
+      "group": "transfer",
+      "tier": 2,
+      "samples": [
+        {
+          "evmHash": "0x2fd638c6149e72bd25bac6a8d72fc422d8b28d0f2d6121feb4bb6cab78963c75",
+          "sigs": [
+            "61AweVRY5YFbqxtzBFzwH4k5vH3ecszHbuiSbg5BhSq29Gd29xjjCeTPZLsfSTP9G7vLspsns1nJidj7KkBZZWuh"
+          ],
+          "perTx": [
+            555752
+          ],
+          "totalCu": 555752
+        },
+        {
+          "evmHash": "0x739a14d9d1e06c40c3bf3516b036b2a2c03eef8c94e088e4dd7e0a648ddf50c7",
+          "sigs": [
+            "4kUooohkTi8ioKGFeLRZK25LD8Jac6aZCjTpWVigWjyeYQZdKPUodNAT85ZzeEANcowxTzZJ1U5pv3EZ2puMnA4G"
+          ],
+          "perTx": [
+            554236
+          ],
+          "totalCu": 554236
+        },
+        {
+          "evmHash": "0x1d928059c6f51eb98780e982c6b5f6fd86caecd26444c9b4fa386b28ac29732f",
+          "sigs": [
+            "2XKNMM7pJtxrASv4LBe8uWka6Nq9UA4Tgxf5WH5tyjRAUXK4JQLZVmAfA3PWYgwhyTk2bQt7ni6BayzZnP5HqQfv"
+          ],
+          "perTx": [
+            555752
+          ],
+          "totalCu": 555752
+        }
+      ],
+      "mean": 555247
+    },
+    {
+      "label": "[T3] A3 OLD pda_with_salt (rome_evm_program_id + find_program_address)",
+      "group": "salted-pda",
+      "tier": 3,
+      "samples": [
+        {
+          "evmHash": "0xb018e9a9521cec0c20ecbad87974b9565d16f07476f46c7c0552651e2f9a57b8",
+          "sigs": [
+            "63mcSmhhm31RSZTV22knTBBKn5Hs13EKTvKK92X4vjQe4c88MZutLKw68dmiYXATw6jCLsVpaAkxrVYARPYk7qyP"
+          ],
+          "perTx": [
+            210665
+          ],
+          "totalCu": 210665
+        },
+        {
+          "evmHash": "0x52a11213f82b0667c63cfbba23e6b20ece6cb091e5d0e2dc9185a813eeb451b7",
+          "sigs": [
+            "MQLSn8WqsRT4iLEwCtTnyRgSL3AHau2QRXA9Pq81UFSi9WQ67W2X2NpLaqLHc4bDDBgH9jyG5EiuE6UaYurjwqk"
+          ],
+          "perTx": [
+            207665
+          ],
+          "totalCu": 207665
+        },
+        {
+          "evmHash": "0x17c1019de87d4a19504128b1fe12a5d3bb7f29a6a56ab71271a75dfe1ecd19cd",
+          "sigs": [
+            "58Cv3UKpewknbgYk2AmxBCMDLNAUC7rr1yosd1FVznaei8LundWCXqSnTC4N7Q3ygBsZisScgtAW92Q4tVRMSe1i"
+          ],
+          "perTx": [
+            207673
+          ],
+          "totalCu": 207673
+        }
+      ],
+      "mean": 208668
+    },
+    {
+      "label": "[T3] A3 NEW HelperProgram.pda_with_salt",
+      "group": "salted-pda",
+      "tier": 3,
+      "pairWith": "[T3] A3 OLD pda_with_salt (rome_evm_program_id + find_program_address)",
+      "samples": [
+        {
+          "evmHash": "0x2aeb4017ab1fdf14f41d6977d1d9acbcc8c80dc02b9363a9ceb89a838d801bbf",
+          "sigs": [
+            "YqfXUrGTNdMoQoiFuy79Uc444NGkhirJ9VFU2YuxY1X7TDC224RwVzGisu8A6GXVFrLe6j6F3ns3heTEBwLe1da"
+          ],
+          "perTx": [
+            114691
+          ],
+          "totalCu": 114691
+        },
+        {
+          "evmHash": "0x1f3e267560a45408939ee5194526b9192cda443be476605955af42f5f635fd67",
+          "sigs": [
+            "28fBcZLHVzHzFHNY7EcxL9xSJED16QaEuDFePCjc8SCVdKFU28bomFXiMAmTsrNKZsc81axAjFAZbtstcEGwuVih"
+          ],
+          "perTx": [
+            116191
+          ],
+          "totalCu": 116191
+        },
+        {
+          "evmHash": "0x5b918ea30ee295ec631d56c94c5c40d742b32fc8f27bff1a1424f844febfd7f7",
+          "sigs": [
+            "3gkMzwJLxVihEjiwLks399VQjzYkYjJr4M2cYTbDA5sjjirbsitQwfW5jQGSjAbBQUf6X51poCLLEkjZJTkdbSmM"
+          ],
+          "perTx": [
+            114683
+          ],
+          "totalCu": 114683
+        }
+      ],
+      "mean": 115188
+    },
+    {
+      "label": "[T3] A2 OLD approve (SplTokenLib.approve + invoke_signed)",
+      "group": "approve",
+      "tier": 3,
+      "samples": [
+        {
+          "evmHash": "0xd8b1b306ad066a0ebd9ad08a49424bfc49191b538cda2560bf9dbfa9afbb729f",
+          "sigs": [
+            "5U3eKmopUPY19yon8cczsAo6V122f1ccxyqDLhDTcJrNXSbcW9vEGMvZ4MmhrfsohsMdvQYM9bnMWfnUdjLaNMLt",
+            "7qK3zkCo7BfFqAy2opgy9b15MJmvAh88rcyLnPEQzZzTkx3c8DZMsALPstuHNHaWM4fEo1Um2ccmghZR3QDrqJi"
+          ],
+          "perTx": [
+            11197,
+            316609
+          ],
+          "totalCu": 327806
+        },
+        {
+          "evmHash": "0x53e51fbcd30c7841d8d96b76ae50c5df97d155c8b76925f3a2122fca89c822ce",
+          "sigs": [
+            "2nBXSxeJ8VqxdUv5grA95DC2g4BBKWJXCmRckDJcypyAavgfF8K92iikdrCykZqHTExoCQ3CEtmH9V3N4PaVFT8z",
+            "WtpjEcy67DXEDwnsYmeZVXoXi5ZK1cSQm1P67M2ffy8w2upWix12E8q1oVWd7Au6XPBbYyHyuaC6tR6fJGJbE6G"
+          ],
+          "perTx": [
+            10609,
+            321117
+          ],
+          "totalCu": 331726
+        },
+        {
+          "evmHash": "0x7c8b71f8bb70f6d687220b11a8efba978a5a05c5cb878d7a21195fcdadabecb8",
+          "sigs": [
+            "3edK59Zgxq27KpxweGGS5jjj9imh4SUYZE78nL4eyAKZjewu8XYXnm72z9GovCg6TXf7EtVoHUKkZzesDQB834kY",
+            "45VEXetadkyZGDg33EHABcDrimC5NvoXKng2m78kPwUsJDgQbLznoANTqqiXfgpn9cPNkLnqGuvcSm2BQrhkcUZD"
+          ],
+          "perTx": [
+            10609,
+            319609
+          ],
+          "totalCu": 330218
+        }
+      ],
+      "mean": 329917
+    },
+    {
+      "label": "[T3] A2 NEW HelperProgram.approve_spl_raw_delegate",
+      "group": "approve",
+      "tier": 3,
+      "pairWith": "[T3] A2 OLD approve (SplTokenLib.approve + invoke_signed)",
+      "samples": [
+        {
+          "evmHash": "0x71f56809f7f7afb9946bcb5764969c490f200a9e7de728d5d9d02f2d5d5d278e",
+          "sigs": [
+            "2ATsaYr82Wipw38DrA2XQauD48sepaQfnjmSUDzKbUsskhUNjNYP23jTw8ANrQoVpK1TCrwbbvBDisNUT24trdTU",
+            "WcMDnKbh8uUtERJwQ8dsVGaGfUL3RoRk1mw85WoQyQuUbsURkuCcCURFTJY7FC2x7txaWyPvo2SMWSmXJLUFffJ"
+          ],
+          "perTx": [
+            11171,
+            167997
+          ],
+          "totalCu": 179168
+        },
+        {
+          "evmHash": "0x3e3b802a74f3d0f23a5f0da38af3f03a6ea7e30fa92a172317d82fac0bde70e9",
+          "sigs": [
+            "59c9MSnea4tvvmihFBduovut86meMWJL6qoNdSg1hxErLXootT8QsKbcEpe5H4Gm2bdtQ5jNddkeaaMgQ3Mp4Ggq",
+            "4czCubyo8y6ZEziEo7SpfMH9pEnrLUNALR8uAioXMHKvXJpXjgefdnmomAo1xSDTPj26AY3cbpUcPqsuoVU8nRiB"
+          ],
+          "perTx": [
+            11197,
+            161997
+          ],
+          "totalCu": 173194
+        },
+        {
+          "evmHash": "0x29167c1aaaef9699cfb9f0c486cd549b2a5f1ab3f35f39df9e0f33157943300f",
+          "sigs": [
+            "3q6Eje8jZQrZ1AxqJMPxdrhW27mh6LPDc4em6cmjLJZNgYzcMn6DdR44wk6LBbgSiQVnsdQQxRHNHzP8TAT8ACvb",
+            "zc2krYvRbRd1NLXxZgDKWZviVDghZ3GHHBqnH9unQF4U9VfEopeAZRyofeyRpbqWEoHbBtP5GAjrQDt5SKRtfWd"
+          ],
+          "perTx": [
+            11171,
+            163535
+          ],
+          "totalCu": 174706
+        }
+      ],
+      "mean": 175689
+    }
+  ]
+}

--- a/scripts/cpi/measure-all-primitives.ts
+++ b/scripts/cpi/measure-all-primitives.ts
@@ -1,0 +1,309 @@
+/**
+ * Comprehensive primitive CU measurement.
+ *
+ * METHODOLOGY:
+ *   Each probe is submitted as a REAL EVM tx → resolved to Solana sig via
+ *   `rome_solanaTxForEvmTx` → `meta.computeUnitsConsumed` from Solana RPC.
+ *   3 samples per probe, mean reported.
+ *
+ *   Tier 1 (no setup) — PDA/ATA derivation, account reads, batch derive.
+ *   Tier 2 (requires setup) — wrap, unwrap, SPL transfer variants.
+ *
+ *   Tier 2 setup:
+ *     1. Transfer gas to probe contract (~0.05 USDC native gas)
+ *     2. Call probe.setup(deployerAddress, 1e16 wei) — activates probe's PDA,
+ *        creates ATAs, wraps starter balance.
+ *     3. Subsequent probes use the established state.
+ *
+ * Usage:
+ *   npx hardhat run scripts/cpi/measure-all-primitives.ts --network hadrian
+ */
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import {
+    Wallet,
+    JsonRpcProvider,
+    ContractFactory,
+    Contract,
+    Interface,
+} from "ethers";
+import benchArtifact from "../../artifacts/contracts/cpi/test/BenchProbe.sol/BenchProbe.json" with { type: "json" };
+
+const SAMPLES = 3;
+const SETUP_GAS_TRANSFER_WEI = 50_000_000_000_000_000n;       // 0.05 USDC native gas to probe
+const SETUP_INITIAL_WRAP_WEI = 10_000_000_000_000_000n;       // 0.01 USDC wrapped into probe ATA
+
+async function rome_solanaTxForEvmTx(rpcUrl: string, evmHash: string): Promise<string[]> {
+    const res = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "rome_solanaTxForEvmTx",
+            params: [evmHash],
+        }),
+    });
+    const body = (await res.json()) as { result?: string[]; error?: { message: string } };
+    if (body.error) throw new Error(`rome_solanaTxForEvmTx failed: ${body.error.message}`);
+    return body.result ?? [];
+}
+
+async function getSolanaCu(solanaRpc: string, sig: string): Promise<number> {
+    const res = await fetch(solanaRpc, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }],
+        }),
+    });
+    const body = (await res.json()) as { result?: { meta?: { computeUnitsConsumed?: number } } };
+    return body.result?.meta?.computeUnitsConsumed ?? 0;
+}
+
+async function totalCuForEvmTx(rpcUrl: string, solanaRpc: string, evmHash: string): Promise<{ sigs: string[]; totalCu: number; perTx: number[] }> {
+    let sigs: string[] = [];
+    for (let attempt = 0; attempt < 30; attempt++) {
+        sigs = await rome_solanaTxForEvmTx(rpcUrl, evmHash);
+        if (sigs.length > 0) break;
+        await new Promise(r => setTimeout(r, 2000));
+    }
+    if (sigs.length === 0) throw new Error(`rome_solanaTxForEvmTx returned empty after 60s for ${evmHash}`);
+    const perTx: number[] = [];
+    for (const sig of sigs) {
+        let cu = 0;
+        for (let attempt = 0; attempt < 10; attempt++) {
+            cu = await getSolanaCu(solanaRpc, sig);
+            if (cu > 0) break;
+            await new Promise(r => setTimeout(r, 1500));
+        }
+        perTx.push(cu);
+    }
+    return { sigs, perTx, totalCu: perTx.reduce((a, b) => a + b, 0) };
+}
+
+interface ProbeSpec {
+    label: string;
+    method: string;
+    args: unknown[];
+    group: string;
+    pairWith?: string;
+    /** Tier 2 probes need setup() done first. */
+    tier: 1 | 2;
+}
+
+async function main() {
+    const { networkConfig, networkName } = await hardhat.network.connect();
+    const urlField = (networkConfig as any).url;
+    const url: string = typeof urlField === "string"
+        ? urlField
+        : (typeof urlField?.get === "function" ? await urlField.get() : String(urlField));
+    const pk = await (networkConfig as any).accounts[0].get();
+    const chainId = (networkConfig as any).chainId as number;
+
+    const solanaRpc = chainId === 30001
+        ? "https://api.testnet.solana.com/"          // Aurelius
+        : "https://api.devnet.solana.com/";          // Hadrian / Marcus
+
+    const provider = new JsonRpcProvider(url);
+    const wallet = new Wallet(pk, provider);
+
+    console.log(`Network:    ${networkName} (chainId=${chainId})`);
+    console.log(`Signer:     ${wallet.address}`);
+    console.log(`EVM RPC:    ${url}`);
+    console.log(`Solana RPC: ${solanaRpc}\n`);
+
+    // 1. Deploy or reuse BenchProbe.
+    const deploymentFile = path.join(
+        process.cwd(),
+        "deployments",
+        `${networkName}.BenchProbe.json`
+    );
+    let probeAddress: string;
+    if (fs.existsSync(deploymentFile)) {
+        const existing = JSON.parse(fs.readFileSync(deploymentFile, "utf8"));
+        probeAddress = existing.address;
+        console.log(`BenchProbe (cached): ${probeAddress}\n`);
+    } else {
+        console.log("Deploying BenchProbe...");
+        const factory = new ContractFactory(
+            benchArtifact.abi,
+            benchArtifact.bytecode,
+            wallet
+        );
+        const probe = await factory.deploy();
+        await probe.waitForDeployment();
+        probeAddress = await probe.getAddress();
+        fs.mkdirSync(path.dirname(deploymentFile), { recursive: true });
+        fs.writeFileSync(
+            deploymentFile,
+            JSON.stringify({ address: probeAddress, deployedAt: new Date().toISOString() }, null, 2)
+        );
+        console.log(`BenchProbe deployed: ${probeAddress}\n`);
+    }
+
+    const probe = new Contract(probeAddress, benchArtifact.abi, wallet);
+    const iface = new Interface(benchArtifact.abi);
+
+    // 2. Setup state for Tier 2 probes if not already done.
+    let setupDone = false;
+    try {
+        setupDone = await probe.setupDone();
+    } catch (e: any) {
+        // Older ABI — assume not done
+        setupDone = false;
+    }
+    if (!setupDone) {
+        console.log("Tier 2 setup not done. Calling setup(dest, initialWrapWei) with msg.value...");
+        const setupTx = await probe.setup(wallet.address, SETUP_INITIAL_WRAP_WEI, {
+            value: SETUP_GAS_TRANSFER_WEI,
+            gasLimit: 15_000_000n,
+        });
+        await setupTx.wait();
+        console.log(`  setup tx: ${setupTx.hash}\n`);
+    } else {
+        console.log("Tier 2 setup already done.\n");
+    }
+
+    // 3. Resolve runtime values.
+    console.log("Resolving chain runtime values...");
+    const mintIdHex: string = await probe.probe_mintId();
+    const operatorHex: string = await probe.probe_operator();
+    console.log(`  mint_id:  ${mintIdHex}`);
+    console.log(`  operator: ${operatorHex}\n`);
+
+    // 4. Probe specs.
+    const probes: ProbeSpec[] = [
+        // Tier 1 — Baseline dispatch overhead
+        { label: "[baseline] probe_mintId",                                       method: "probe_mintId",                       args: [],                              group: "baseline", tier: 1 },
+        { label: "[baseline] probe_operator",                                     method: "probe_operator",                     args: [],                              group: "baseline", tier: 1 },
+
+        // Tier 1 — PDA derivation
+        { label: "OLD findPda × 1 (single derive)",                               method: "probe_findPda_single",               args: [42n],                           group: "pda", tier: 1 },
+        { label: "OLD findPda × 2 (two-hop ATA path)",                            method: "probe_findPda_twoHop",               args: [42n],                           group: "pda", tier: 1, pairWith: "OLD findPda × 1 (single derive)" },
+        { label: "NEW HelperProgram.pda(user)",                                   method: "probe_helperPda",                    args: [wallet.address],                group: "pda", tier: 1, pairWith: "OLD findPda × 1 (single derive)" },
+        { label: "NEW HelperProgram.ata(user, mint)",                             method: "probe_helperAta",                    args: [wallet.address, mintIdHex],     group: "ata", tier: 1, pairWith: "OLD findPda × 2 (two-hop ATA path)" },
+
+        // Tier 1 — Batch derive
+        { label: "OLD findPda × 7 (sequential)",                                  method: "probe_findPda_7sequential",          args: [100n],                          group: "batch", tier: 1 },
+        { label: "NEW pdas_batch_derive × 7",                                     method: "probe_pdasBatch_7",                  args: [200n],                          group: "batch", tier: 1, pairWith: "OLD findPda × 7 (sequential)" },
+
+        // Tier 1 — Account reads
+        { label: "OLD account_info (full marshal)",                               method: "probe_accountInfo",                  args: [mintIdHex],                     group: "account", tier: 1 },
+        { label: "NEW account_data_at (slice 0..82)",                             method: "probe_accountDataAt",                args: [mintIdHex, 0, 82],              group: "account", tier: 1, pairWith: "OLD account_info (full marshal)" },
+        { label: "NEW account_u64_at (offset 36)",                                method: "probe_accountU64At",                 args: [mintIdHex, 36],                 group: "account", tier: 1, pairWith: "OLD account_info (full marshal)" },
+        { label: "NEW account_lamports",                                          method: "probe_accountLamports",              args: [mintIdHex],                     group: "account", tier: 1, pairWith: "OLD account_info (full marshal)" },
+
+        // Tier 2 — Mutations (requires setup)
+        { label: "[T2] Wrap NEW (Withdraw.withdraw_to_ata)",                      method: "probe_wrap_new",                     args: [100_000_000_000_000n],          group: "wrap", tier: 2 },
+        { label: "[T2] Unwrap NEW (HelperProgram.deposit_from_ata)",              method: "probe_unwrap_new",                   args: [100_000_000_000_000n],          group: "wrap", tier: 2 },
+        { label: "[T2] SPL transfer NEW 3-arg (addr)",                            method: "probe_transfer_spl_helper_3arg",     args: [],                              group: "transfer", tier: 2 },
+        { label: "[T2] SPL transfer NEW 4-arg delegate",                          method: "probe_transfer_spl_helper_4arg",     args: [],                              group: "transfer", tier: 2, pairWith: "[T2] SPL transfer LEGACY (SplTokenLib + invoke)" },
+        { label: "[T2] SPL transfer LEGACY (SplTokenLib + invoke)",               method: "probe_transfer_spl_legacy",          args: [],                              group: "transfer", tier: 2 },
+
+        // Tier 3 — Universal-delegation (rome-evm-private #364, A1-A6)
+        // Side-by-side v1 (multi-call) vs new (single-dispatch precompile)
+        { label: "[T3] A3 OLD pda_with_salt (rome_evm_program_id + find_program_address)", method: "probe_a3_pdaWithSalt_OLD",            args: [wallet.address, "0x" + "11".repeat(32)],            group: "salted-pda", tier: 3 },
+        { label: "[T3] A3 NEW HelperProgram.pda_with_salt",                       method: "probe_a3_pdaWithSalt_NEW",           args: [wallet.address, "0x" + "11".repeat(32)],            group: "salted-pda", tier: 3, pairWith: "[T3] A3 OLD pda_with_salt (rome_evm_program_id + find_program_address)" },
+        { label: "[T3] A2 OLD approve (SplTokenLib.approve + invoke_signed)",     method: "probe_a2_approveSplRawDelegate_OLD", args: ["0x" + "22".repeat(32), 1n],                       group: "approve", tier: 3 },
+        { label: "[T3] A2 NEW HelperProgram.approve_spl_raw_delegate",            method: "probe_a2_approveSplRawDelegate_NEW", args: ["0x" + "22".repeat(32), 1n, 6],                    group: "approve", tier: 3, pairWith: "[T3] A2 OLD approve (SplTokenLib.approve + invoke_signed)" },
+    ];
+
+    // 5. Run probes.
+    const results: Array<{
+        label: string;
+        group: string;
+        tier: number;
+        pairWith?: string;
+        samples: Array<{ evmHash: string; sigs: string[]; perTx: number[]; totalCu: number }>;
+        mean: number | "n/a";
+    }> = [];
+
+    for (const p of probes) {
+        console.log(`Probing: ${p.label}`);
+        const data = iface.encodeFunctionData(p.method, p.args);
+        const samples: Array<{ evmHash: string; sigs: string[]; perTx: number[]; totalCu: number }> = [];
+        for (let i = 0; i < SAMPLES; i++) {
+            try {
+                const tx = await wallet.sendTransaction({
+                    to: probeAddress,
+                    data,
+                    gasLimit: 5_000_000n,
+                    type: 0,
+                });
+                await tx.wait();
+                const r = await totalCuForEvmTx(url, solanaRpc, tx.hash);
+                console.log(`  sample ${i+1}/${SAMPLES}: evmTx=${tx.hash.slice(0,10)}... sigs=${r.sigs.length} totalCu=${r.totalCu.toLocaleString()}`);
+                samples.push({ evmHash: tx.hash, sigs: r.sigs, perTx: r.perTx, totalCu: r.totalCu });
+            } catch (e: any) {
+                console.log(`  sample ${i+1}/${SAMPLES}: ERR ${e.message?.slice(0, 100)}`);
+                samples.push({ evmHash: "", sigs: [], perTx: [], totalCu: 0 });
+            }
+        }
+        const valid = samples.filter(s => s.totalCu > 0).map(s => s.totalCu);
+        const mean = valid.length > 0
+            ? Math.round(valid.reduce((a, b) => a + b, 0) / valid.length)
+            : "n/a" as const;
+        results.push({ label: p.label, group: p.group, tier: p.tier, pairWith: p.pairWith, samples, mean });
+        console.log();
+    }
+
+    // 6. Report.
+    console.log("\n" + "═".repeat(120));
+    console.log("CU MEASUREMENT RESULTS — Solana computeUnitsConsumed, mean across non-error samples");
+    console.log("═".repeat(120));
+
+    const meanOf = (label: string): number | undefined => {
+        const r = results.find(x => x.label === label);
+        return typeof r?.mean === "number" ? r.mean : undefined;
+    };
+
+    let lastGroup = "";
+    for (const r of results) {
+        if (r.group !== lastGroup) {
+            console.log(`\n─── ${r.group.toUpperCase()} ───`);
+            lastGroup = r.group;
+        }
+        const meanStr = typeof r.mean === "number" ? r.mean.toLocaleString().padStart(10) + " CU" : String(r.mean).padStart(13);
+        let delta = "";
+        if (r.pairWith) {
+            const base = meanOf(r.pairWith);
+            if (base !== undefined && typeof r.mean === "number") {
+                const diff = r.mean - base;
+                const pct = ((diff / base) * 100).toFixed(1);
+                const sign = diff < 0 ? "−" : "+";
+                delta = `   ${sign}${Math.abs(diff).toLocaleString()} CU (${pct}%) vs paired`;
+            }
+        }
+        console.log(`${r.label.padEnd(60)} ${meanStr}${delta}`);
+    }
+    console.log("\n" + "═".repeat(120));
+
+    // 7. Persist artifact.
+    const artifactPath = path.join(
+        process.cwd(),
+        "deployments",
+        `${networkName}.BenchProbe.bench.json`
+    );
+    fs.writeFileSync(artifactPath, JSON.stringify({
+        network: networkName,
+        chainId,
+        probeAddress,
+        mintId: mintIdHex,
+        operator: operatorHex,
+        solanaRpc,
+        runAt: new Date().toISOString(),
+        methodology: "submit probe tx → rome_solanaTxForEvmTx → Solana getTransaction → meta.computeUnitsConsumed",
+        results,
+    }, null, 2));
+    console.log(`\nArtifact: ${artifactPath}`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Brings the comprehensive [`BenchProbe.sol`](https://github.com/rome-protocol/rome-solidity/blob/feat-bench-probe-tier3/contracts/cpi/test/BenchProbe.sol) + [`measure-all-primitives.ts`](https://github.com/rome-protocol/rome-solidity/blob/feat-bench-probe-tier3/scripts/cpi/measure-all-primitives.ts) from the `pda-cost-probe` branch onto `master` (post-[#169](https://github.com/rome-protocol/rome-solidity/pull/169)), inlines the 2 SplTokenLib encoders that #169 pruned, and adds Tier 3 paired-comparison probes for the 2 new HelperProgram selectors shipped in [rome-evm-private #364](https://github.com/rome-protocol/rome-evm-private/pull/364) (consumed by [#165](https://github.com/rome-protocol/rome-solidity/pull/165)).

| Tier | Coverage |
|---|---|
| 1 | Baseline dispatch + PDA/ATA derivation + batch derive + account reads |
| 2 | Wrap / unwrap / SPL transfer (NEW 3-arg, NEW 4-arg delegate, LEGACY) |
| 3 | **Universal-delegation v1-vs-new pairs**: A2 (`approve_spl_raw_delegate`) + A3 (`pda_with_salt`) |

## Tier 3 results (Hadrian 2026-05-16, 3-sample mean, real on-chain Solana receipts)

| Selector | OLD path (v1) | OLD CU | NEW CU | Save | % |
|---|---|---:|---:|---:|---:|
| **A3** `pda_with_salt(user, salt)` (`0x5c6d04b3`) | `rome_evm_program_id + find_program_address([EXT_AUTH, user, salt])` | 208,668 | 115,188 | **−93,480** | **−44.8%** |
| **A2** `approve_spl_raw_delegate(...)` (`0x7881d453`) | `SplTokenLib.approve + CpiProgram.invoke_signed` | 329,917 | 175,689 | **−154,228** | **−46.7%** |

**Per-flow:** `RomeBridgeWithdraw.approveBurnETH + burnETH` Wormhole outbound = 1× A2 + 2× A3 = **−241,188 CU** per outbound bridge.

Full per-sample data with EVM tx hashes + Solana sigs preserved in [`deployments/hadrian.BenchProbe.bench.json`](https://github.com/rome-protocol/rome-solidity/blob/feat-bench-probe-tier3/deployments/hadrian.BenchProbe.bench.json) (66 probes × 3 samples each, all 22 measurement rows).

## Methodology

For each probe:
1. Real EVM tx submitted via `eth_sendRawTransaction`
2. EVM hash → Solana sig via `rome_solanaTxForEvmTx`
3. Solana sig → `meta.computeUnitsConsumed` via Solana RPC `getTransaction`
4. CU summed across all sigs (handles iterative-tx case)

Mean of 3 samples per probe reported. `rome_emulateTx` is NOT used (returns `Result<()>` — does not expose CU).

## Deviations from the pda-cost-probe branch

- **SplTokenLib.approve / transfer_checked inlined.** Both functions were pruned in [#169](https://github.com/rome-protocol/rome-solidity/pull/169) as confirmed-orphan. The probe re-encodes the raw SPL instructions inline (tag + LE-u64 amount + accounts) so the LEGACY/OLD probes still compile.
- **`probe_createPdaWithBump` dropped.** That probe calls `SystemProgram.create_program_address` which exists in the `pda-cost-probe` branch's `ISystemProgram` interface but was NOT merged to master. Re-add once the interface decl ships.

## Test plan

- [x] `npx hardhat compile` — 80 files, no errors, same pre-existing warnings as baseline
- [x] Deployed BenchProbe to Hadrian (chain 200010) — measurement run completed successfully
- [x] All 22 probe rows captured CU > 0; no probe reverted
- [x] 2026-05-14 baseline numbers reconfirmed within ~1% sampling noise
- [ ] Reviewer spot-check on inlined SPL encoders (`probe_transfer_spl_legacy` line 215; `probe_a2_approveSplRawDelegate_OLD` line 270)

## Replay

```bash
cd rome-solidity
rm -f deployments/hadrian.BenchProbe.json     # force redeploy
export HARDHAT_VAR_HADRIAN_PRIVATE_KEY=...
npx hardhat run scripts/cpi/measure-all-primitives.ts --network hadrian
```

Script auto-deploys + runs setup if `deployments/hadrian.BenchProbe.json` is absent, then runs all 22 probes × 3 samples.

## Cross-references

- Spec update PR (rome-specs): pending — Tier 3 rows + paired-comparison table being added to `active/technical/2026-05-14-rome-primitive-cu-baseline.md`
- Memory entry: `reference_rome_primitive_cu_baseline.md` updated with A2/A3 datapoints