### PR TITLE
test(bench): Phase 2 real-flow CU bench — v1 vs new on Hadrian

### DIFF
--- a/contracts/cpi/test/RomeswapDirect.sol
+++ b/contracts/cpi/test/RomeswapDirect.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+interface IERC20Minimal {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}
+
+interface IUniswapV2PairMinimal {
+    function mint(address to) external returns (uint256 liquidity);
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+}
+
+/// @title RomeswapDirect — single-tx wrappers around Romeswap pair ops.
+/// @notice Composes the 3-tx Rome-required addLiquidity / 2-tx swap / 2-tx
+///         removeLiquidity flows into ONE EVM tx (one Solana DoTx). Each
+///         function does the token transfers + the pair op inline. Caller
+///         must pre-approve this contract on the underlying tokens.
+contract RomeswapDirect {
+    /// @notice 1-tx addLiquidity. Pulls amtA of tokenA + amtB of tokenB from
+    ///         caller (transferFrom — caller must have pre-approved this
+    ///         contract on both tokens) directly into the pair, then mints
+    ///         LP tokens to `to`. Caller pre-computes amounts off-chain
+    ///         (no slippage / optimal-amounts logic).
+    function addLiq(
+        address tokenA,
+        address tokenB,
+        address pair,
+        uint256 amtA,
+        uint256 amtB,
+        address to
+    ) external returns (uint256 liquidity) {
+        IERC20Minimal(tokenA).transferFrom(msg.sender, pair, amtA);
+        IERC20Minimal(tokenB).transferFrom(msg.sender, pair, amtB);
+        liquidity = IUniswapV2PairMinimal(pair).mint(to);
+    }
+
+    /// @notice 1-tx swap. Pulls amtIn of tokenIn from caller into the pair,
+    ///         then calls pair.swap with the pre-computed output amounts.
+    ///         Caller pre-computes (amount0Out, amount1Out) off-chain.
+    function swap(
+        address tokenIn,
+        address pair,
+        uint256 amtIn,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to
+    ) external {
+        IERC20Minimal(tokenIn).transferFrom(msg.sender, pair, amtIn);
+        IUniswapV2PairMinimal(pair).swap(amount0Out, amount1Out, to, "");
+    }
+
+    /// @notice 1-tx removeLiquidity. Pulls lpAmt of LP tokens (pair-as-ERC20)
+    ///         from caller into the pair, then burns them to `to`.
+    function removeLiq(
+        address pair,
+        uint256 lpAmt,
+        address to
+    ) external returns (uint256 amount0, uint256 amount1) {
+        IERC20Minimal(pair).transferFrom(msg.sender, pair, lpAmt);
+        (amount0, amount1) = IUniswapV2PairMinimal(pair).burn(to);
+    }
+}

--- a/contracts/cpi/test/RomeswapDirect.sol
+++ b/contracts/cpi/test/RomeswapDirect.sol
@@ -61,4 +61,24 @@ contract RomeswapDirect {
         IERC20Minimal(pair).transferFrom(msg.sender, pair, lpAmt);
         (amount0, amount1) = IUniswapV2PairMinimal(pair).burn(to);
     }
+
+    /// @notice 1-tx 2-hop swap. Pulls amtIn of tokenIn into pair1, swaps
+    ///         pair1 → pair2 (intermediate token sent directly between pairs),
+    ///         then pair2 sends final output to `to`. Caller pre-computes
+    ///         all four output amounts off-chain.
+    function swap2Hop(
+        address tokenIn,
+        address pair1,
+        address pair2,
+        uint256 amtIn,
+        uint256 amount0OutPair1,
+        uint256 amount1OutPair1,
+        uint256 amount0OutPair2,
+        uint256 amount1OutPair2,
+        address to
+    ) external {
+        IERC20Minimal(tokenIn).transferFrom(msg.sender, pair1, amtIn);
+        IUniswapV2PairMinimal(pair1).swap(amount0OutPair1, amount1OutPair1, pair2, "");
+        IUniswapV2PairMinimal(pair2).swap(amount0OutPair2, amount1OutPair2, to, "");
+    }
 }

--- a/deployments/hadrian.2hop-bench.results.json
+++ b/deployments/hadrian.2hop-bench.results.json
@@ -1,0 +1,27 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "runAt": "2026-05-17T05:13:50.342Z",
+  "route": "wBench → wUSDC → MOCK",
+  "pair1": "0x45350dF36fA7334C2E267598Af8fC136e4982A9E",
+  "pair2": "0x9FB2471A400CA670F5459829b622A2f4d4824642",
+  "directContract": "0xEb21d5F7a6533dB4fd16d9FB8fFf77Ed1612490B",
+  "mean": 0,
+  "samples": [
+    {
+      "evmHash": "0x",
+      "totalCu": 0,
+      "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 156, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182024e85025ff7a6008404c4b40094eb21d5f7a6533db4fd16d9fb8fff77ed1612490b80b90124831621670"
+    },
+    {
+      "evmHash": "0x",
+      "totalCu": 0,
+      "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 170, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182024e85025ff7a6008404c4b40094eb21d5f7a6533db4fd16d9fb8fff77ed1612490b80b90124831621670"
+    },
+    {
+      "evmHash": "0x",
+      "totalCu": 0,
+      "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 184, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182024e85025ff7a6008404c4b40094eb21d5f7a6533db4fd16d9fb8fff77ed1612490b80b90124831621670"
+    }
+  ]
+}

--- a/deployments/hadrian.canonical-router.results.json
+++ b/deployments/hadrian.canonical-router.results.json
@@ -1,0 +1,159 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "runAt": "2026-05-17T07:13:47.497Z",
+  "router": "0xB342f70D56855F11B0721FcBE2804A200d0F0533",
+  "deployer": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+  "results": [
+    {
+      "label": "[canonical] router.swapExactTokensForTokens single-hop (wUSDC→wBench)",
+      "samples": [
+        {
+          "evmHash": "0x5e0010542fcb5a8c652f66c04a2c0ecbb976a3402021b4190d1285089927b610",
+          "sigs": [
+            "47yxsEwnTAXHq7GYpSYgvS4NYr7suUhn4MSvZ7UpAhW8yEsMZKVJeUNSwYvDJ7eW4WRrSd26YrgiRBhGvS3sJLob",
+            "2CW2YbbPyXBXaV2ssfm1uXdkWdJmgND2GU2yKQ7j6uCxd4tmaME5624528Cc6ZktJNCVSFCoEjQbnaAQDA56Bs71"
+          ],
+          "perTx": [
+            10609,
+            1092440
+          ],
+          "totalCu": 1103049
+        },
+        {
+          "evmHash": "0x32b78e5c51c0f2335a1d6a4eef9757f7ee175e7901d5485fdf24efa9ee0053d7",
+          "sigs": [
+            "3mjhaMomkbapASZ9QRMYjfsBu6Hro1yduUgMZFqiyLkY4jk8Y7oTApfTYHgjACQRuAgY1tYmm7B5giUvhtbuYawF",
+            "5NrVvVvLaxuUb7yquM8ZuieEyZzqLzPgLEezmnN4Qa6MQjRtsXALF1h7SgFzmiscVYdFcxd98ptPSox6biFmDXFB"
+          ],
+          "perTx": [
+            10609,
+            1089440
+          ],
+          "totalCu": 1100049
+        },
+        {
+          "evmHash": "0x52d5f45e02b48e9dd78402756c8e378051052efed196eeadbd3bcbe0354ddc9a",
+          "sigs": [
+            "5jfVSb8pUMW1SgT9QjoQ1hDiY8VQNMWnyE4SGFrtHR4Q8WWVLnYFqqYRZpHZ5UyWvE8TfxGS1vGTWSX1kF6fkcSy",
+            "NTrE6SZ8dARvUTK9aRX3HBFJArg3N4HJQikFkShmUcA5WBvLM9Rv15HQbFxAfn3WUagNhoRWLVn6LyfQfZrVqbV"
+          ],
+          "perTx": [
+            10609,
+            1089424
+          ],
+          "totalCu": 1100033
+        }
+      ],
+      "mean": 1101044
+    },
+    {
+      "label": "[canonical] router.swapExactTokensForTokens 2-hop (wBench→wUSDC→MOCK)",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 104, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 116, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 128, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9019182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[canonical] router.addLiquidity (wUSDC × wBench)",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 138, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9017182025b85025ff7a6008404c4b40094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 148, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9017182025b85025ff7a6008404c4b40094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 158, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9017182025b85025ff7a6008404c4b40094b342f70d56855f11b0721fcbe28"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[canonical] router.removeLiquidity (assumes LP pre-approved)",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 170, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9015082025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 182, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9015082025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 194, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf9015082025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[canonical] router.removeLiquidityWithPermit (1-tx with LP permit signature)",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 209, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf901d182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 224, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf901d182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 239, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf901d182025b85025ff7a6008402faf08094b342f70d56855f11b0721fcbe28"
+        }
+      ],
+      "mean": "n/a"
+    }
+  ]
+}

--- a/deployments/hadrian.dex-bench.results.json
+++ b/deployments/hadrian.dex-bench.results.json
@@ -1,0 +1,152 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "runAt": "2026-05-16T22:13:09.934Z",
+  "methodology": "real production-contract tx -> rome_solanaTxForEvmTx -> Solana CU. multi-tx flows summed.",
+  "deployer": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+  "pairs": {
+    "A": {
+      "tokens": [
+        "0x94AC3E5e998d72088045853C1CfB910F6CE90E56",
+        "0xD39EC36aadfe6ca262b9c2d7D1230414B3c49501"
+      ],
+      "pair": "0x45350dF36fA7334C2E267598Af8fC136e4982A9E"
+    },
+    "B": {
+      "tokens": [
+        "0x94AC3E5e998d72088045853C1CfB910F6CE90E56",
+        "0x5cB734B113E31005487D7E4bcA39BCC3e17B8e9A"
+      ],
+      "pair": "0x9FB2471A400CA670F5459829b622A2f4d4824642"
+    }
+  },
+  "mockToken": "0x5cB734B113E31005487D7E4bcA39BCC3e17B8e9A",
+  "results": [
+    {
+      "label": "[A] addLiquidity flow (wUSDC x wBench)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[A] swap flow (wUSDC -> wBench)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[A] removeLiquidity flow (wUSDC x wBench)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance — addLiq must run first"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance — addLiq must run first"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance — addLiq must run first"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[B] addLiquidity flow (wUSDC x MOCK)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[B] swap flow (wUSDC -> MOCK)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b53696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[B] removeLiquidity flow (wUSDC x MOCK)",
+      "samples": [
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance"
+        },
+        {
+          "hashes": [],
+          "totalCu": 0,
+          "error": "no LP balance"
+        }
+      ],
+      "mean": "n/a"
+    }
+  ]
+}

--- a/deployments/hadrian.real-flow-bench.json
+++ b/deployments/hadrian.real-flow-bench.json
@@ -1,0 +1,25 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "deployedAt": "2026-05-16T21:23:48.550Z",
+  "deployer": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+  "v1": {
+    "ERC20SPLFactory": "0x21cc267ff924aeca4de781db9b5bdf7a4c495e72",
+    "SPL_ERC20_USDC": "0x94AC3E5e998d72088045853C1CfB910F6CE90E56",
+    "SPL_ERC20_WETH": "0xcFc9D0A9ad8cd7bc7c2E44e98b4BE8C939c9E684",
+    "SPL_ERC20_WSOL": "0xEeC1F12206DCf2415313d3B380ae89faef230983",
+    "RomeBridgeWithdraw": "0xf48902e4a30f5d9b93dd0a9c0c0ab379ce37587c",
+    "RomeBridgePaymaster": "0xf83cc7f68c91deb0d1909d120753fd1c84f70a13",
+    "usdcMint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    "wethMint": "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs",
+    "wsolMint": "So11111111111111111111111111111111111111112"
+  },
+  "v2": {
+    "ERC20SPLFactory": "0xfF96ab9E97062236ed7AA8B1C7DC4b53E72Dd14d",
+    "ERC20Users": "0x5cB546099f98922c8B96a914f57869A5Ea5e84f8",
+    "wBenchMint": "0x3cafbdbbf2bef4b190cb0beb22a329bf570b8af31b9e26d6cb129f5492bc584d",
+    "wBenchSalt": "0x4d494e540000000000000000ff96ab9e97062236ed7aa8b1c7dc4b53e72dd14d",
+    "SPL_ERC20_wBench": "0xD39EC36aadfe6ca262b9c2d7D1230414B3c49501",
+    "RomeBridgeWithdraw": "0xAa457897556Dd616Bc840EC0Fabe9B3198df8d38"
+  }
+}

--- a/deployments/hadrian.real-flow-bench.results.json
+++ b/deployments/hadrian.real-flow-bench.results.json
@@ -1,0 +1,670 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "runAt": "2026-05-16T21:52:01.656Z",
+  "methodology": "submit production-contract tx -> rome_solanaTxForEvmTx -> Solana getTransaction -> meta.computeUnitsConsumed",
+  "deployer": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+  "v1Addresses": {
+    "ERC20SPLFactory": "0x21cc267ff924aeca4de781db9b5bdf7a4c495e72",
+    "SPL_ERC20_USDC": "0x94AC3E5e998d72088045853C1CfB910F6CE90E56",
+    "SPL_ERC20_WETH": "0xcFc9D0A9ad8cd7bc7c2E44e98b4BE8C939c9E684",
+    "SPL_ERC20_WSOL": "0xEeC1F12206DCf2415313d3B380ae89faef230983",
+    "RomeBridgeWithdraw": "0xf48902e4a30f5d9b93dd0a9c0c0ab379ce37587c",
+    "RomeBridgePaymaster": "0xf83cc7f68c91deb0d1909d120753fd1c84f70a13",
+    "usdcMint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    "wethMint": "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs",
+    "wsolMint": "So11111111111111111111111111111111111111112"
+  },
+  "v2Addresses": {
+    "ERC20SPLFactory": "0xfF96ab9E97062236ed7AA8B1C7DC4b53E72Dd14d",
+    "ERC20Users": "0x5cB546099f98922c8B96a914f57869A5Ea5e84f8",
+    "wBenchMint": "0x3cafbdbbf2bef4b190cb0beb22a329bf570b8af31b9e26d6cb129f5492bc584d",
+    "wBenchSalt": "0x4d494e540000000000000000ff96ab9e97062236ed7aa8b1c7dc4b53e72dd14d",
+    "SPL_ERC20_wBench": "0xD39EC36aadfe6ca262b9c2d7D1230414B3c49501",
+    "RomeBridgeWithdraw": "0xAa457897556Dd616Bc840EC0Fabe9B3198df8d38"
+  },
+  "results": [
+    {
+      "label": "[v1] SPL_ERC20.transfer",
+      "samples": [
+        {
+          "evmHash": "0xbf1819928064c4d388140ded4a01f0f2935198ff1ede306af5baa511df82d9df",
+          "sigs": [
+            "3Lvt5PkmHUCccAhAbV5FcrkHN4B55oPbXJaBV6NYeMmknBYe3AxDmqFqA4AfSj8tBQmHAWunWsLapAeARWyswxZv",
+            "pm8jFTt7VR4EYp7KiiSUAyeoignU2cQkfdpPEDFCzaXVwMMf7z3n8DRSks6kmE6fgBaTdrWEwHYxgXFZofE9Qsa"
+          ],
+          "perTx": [
+            10609,
+            249836
+          ],
+          "totalCu": 260445
+        },
+        {
+          "evmHash": "0xf7fac0d3aabaf20085ab536f287fedfda3681decf5d1ce025648512302112c90",
+          "sigs": [
+            "3QZzfzBLjrmGgZswdWtFCPqdXNC4DVxdH196og66Xe5dr1gP22ep2PMJMWNzcHQgeFhY8x3M5ZMFAGfF3DyUiqYf",
+            "2HnYKKEaNEHHw3XqJNAHjGpAxrQkNAHuqnMi5sH7pJ25c8CR7mzRJgbqPqin7fqgz3RQ3AKn6Quo3xtHS4SBisYN"
+          ],
+          "perTx": [
+            10609,
+            252804
+          ],
+          "totalCu": 263413
+        },
+        {
+          "evmHash": "0x1ee5f5e7f7f3b7a7505dcf56f4da7f6da0c2d1ca226618f1037f8f1d55579a5d",
+          "sigs": [
+            "5ufMvmdsQ6FRd3WMb4rzxCq2LEBJ8MHVREEeYabZKvsDp7xbLSQ8pYsJpg1Z64HLzL8v4PGPRJdcauLHF8GdJkTG",
+            "5RMn5YKB9yA2C1tsq6k5BmMBd2uqGbPP2cX4qGsoB2PPc5wG1p7cv6UMKwMp2DLEWuhvWW9nuSBmREhCfg6hq2b"
+          ],
+          "perTx": [
+            10609,
+            249828
+          ],
+          "totalCu": 260437
+        }
+      ],
+      "mean": 261432
+    },
+    {
+      "label": "[v2] SPL_ERC20.transfer",
+      "samples": [
+        {
+          "evmHash": "0x2f13269eeeb32f519132bf1170338b4e20982c8eb1a987b4b33b87b99bf5d369",
+          "sigs": [
+            "KjG9qzkwCNdXkEYu8NGR27pAqqcSBuQuSG32J7WW1nG4uMu8TwfgR7z4C7zDAPKQ6sJk6WKHYhFsVgqkHSd7PH7",
+            "4CHyVebYRctJb8zUKGbB2n4LdbAPQFVBHsXGrt4dL5GQxxam3Dd4b5urF7oY1eMuGcAkiu2cpMUWmuf4xAjXZgWM"
+          ],
+          "perTx": [
+            10609,
+            251128
+          ],
+          "totalCu": 261737
+        },
+        {
+          "evmHash": "0x8579e988e5c3cbcd45db8166d70da4801c2b8f007bbc129e1336bfd868efce3e",
+          "sigs": [
+            "4u7Pz2xqpYpCm1PFfzRb2NGGdykGuiLquBQNEGfDEgMYTA4XVCeKeYW4xt5kkwkEbryemPztCmNBPdDNDR6opdtQ",
+            "4xbGXA3dU2sHic6GvqqxGNTPY7ZnSyFZAy41P8NisLeNhBaVrFp8z5psT4ZjqGQa7KnJz54RZUXyuZdf3srf3shY"
+          ],
+          "perTx": [
+            10609,
+            252596
+          ],
+          "totalCu": 263205
+        },
+        {
+          "evmHash": "0x6d171222b3a09be78d68691824760ae708c747e2ba5fa9c9f5a0413dbd4273be",
+          "sigs": [
+            "45eFtGgkT1UoFrUzx2XdMCQZ7V6SVExddAxkojfDXjQYrj6PiK3TRq7XCSgZCn7YcLeEH3wHtzivwK5VHVMiBFG5",
+            "5MpKVREyLgUh2vah8yxjkSNS7Zmde4TrXDNNQQv3MNJor1irzgTjXHZrreAzFCuScc67CBWHhDjfPar3ZAp5b1g2"
+          ],
+          "perTx": [
+            10609,
+            252620
+          ],
+          "totalCu": 263229
+        }
+      ],
+      "mean": 262724
+    },
+    {
+      "label": "[v1] SPL_ERC20.approve",
+      "samples": [
+        {
+          "evmHash": "0xe9f6be1118c03868c1d37ac71a415a0d9cc4af774369209afbcb128da674bee0",
+          "sigs": [
+            "4iC6aLQo1v4FgYhWMePekrFAgT6NQYGoM1TFCLtQFmpm7ixwcUCg3duCggJ22kcjPCH6waKAiNk7qRTReweW4vdC",
+            "14qneGKghnZNV1BxCPWvP3jG8DK3UBQwCXmzvMKjKwnA3FfNLcUQY81u4ZxbXhHhypMnjRkM1FmvBjpKoRC33rf"
+          ],
+          "perTx": [
+            11171,
+            428488
+          ],
+          "totalCu": 439659
+        },
+        {
+          "evmHash": "0xfb56eb66e7c7814e97cabf7b7aa5f2e0b7fd7d7bbfd358e8d52daa3ef3a26b03",
+          "sigs": [
+            "4bxD4VVSM2MEtRsAueKY3ymbNUL162WDRZTKzpbrVE6UQHWgoL6ngALUDzpjYn6b47adXcKYkq6Bm3oyzi29DsZ5",
+            "eUuRgrfUEhASLztswKcAGPoazgPn75GP1LFoxxuGRyMPLAeN3xRU4tRFnxhG5r119MUrqGWGxvKDNrL7YQVcpTq"
+          ],
+          "perTx": [
+            11171,
+            391933
+          ],
+          "totalCu": 403104
+        },
+        {
+          "evmHash": "0x22cc496addfe733c475e392ef9fc4fcb4e90d9d0878df96874545710e4604e79",
+          "sigs": [
+            "294zHEERPvC4qJWNgxNs4iLPjjYS8AYuiYRzFFN8WTKRUBnj7p37Nt2oQLUCVsvuDxYTGdcpsb2SShdcrBMfp3Lz",
+            "5kojsBan5DH8A9kUwWvHkAZidhYMUaRwD9VHpo3mAc4hS4UXc8hcvTJ1ZgjQCaqiUpk6SpDcpBod9GXPEdDXLcrf"
+          ],
+          "perTx": [
+            10609,
+            388941
+          ],
+          "totalCu": 399550
+        }
+      ],
+      "mean": 414104
+    },
+    {
+      "label": "[v2] SPL_ERC20.approve",
+      "samples": [
+        {
+          "evmHash": "0x8fc1611bfad65aee8f642f6414943ac3029b5f23e05839f1dbf220d803513b66",
+          "sigs": [
+            "ehRZtnBz4NGzs5NjybmkYwJ5fH2Aoq216QXbUpomf8HJZUzf1YuZzdxJWgzW69s4ZeabR8VTKNyJZXT6RFQadrA",
+            "3cKAXpA8FugHvBzo7JgSYM7zrx4GnUjC3ZXz9oJZqr1AXBxn3o49P9irgLu4CDb5XA1RNwsY1hejGMxC2fNGuuj3"
+          ],
+          "perTx": [
+            10609,
+            202198
+          ],
+          "totalCu": 212807
+        },
+        {
+          "evmHash": "0x171f27b740ec53633de1436d17460fc971994fbd71383a94d33ad3e8184bde35",
+          "sigs": [
+            "2RRDV427wEQWEiJUPRcYquq2bXgqeytXVvsxuws36DrtsHFFAwNUWpc1ezT9cjBEZLr1pvmu1o6zp1k9pmjvrjwg",
+            "9YyRTF61LtyYE2vtxsiSSea7xjfj8eEF1gbnTuhY6dhKHwhkFsvY14xc2CHMDZyqRGyYFtsMjUA9VHmCR1zojg7"
+          ],
+          "perTx": [
+            11171,
+            199206
+          ],
+          "totalCu": 210377
+        },
+        {
+          "evmHash": "0x6ce8d64a08b74061141015303d83175cd76dea18f8cf5054e0b10404062a2878",
+          "sigs": [
+            "3FNqF1Z8jv8iiw4G6DJSdygnGzazbuVyFCBZmXRPZ7fp3GnKBQAVeUauaK2mi39twRN3y5tk7MCXKbrpqknoeuF2",
+            "5765mecSf6UkEPCdk6Z4F7mE8JVL2KC7gqihqngUiPUuuGfbHidPgyBBFdxADek2usP6xg5txGtJdhZ9BQ74NFTw"
+          ],
+          "perTx": [
+            10609,
+            202198
+          ],
+          "totalCu": 212807
+        }
+      ],
+      "mean": 211997
+    },
+    {
+      "label": "[v1] SPL_ERC20.transferFrom (self-allowance)",
+      "samples": [
+        {
+          "evmHash": "0xfe7ac2eaec5d848e32cc0a8110165f0067aeb2de7f359ff88bc6492668031320",
+          "sigs": [
+            "3Kz3UDCid1zBikUw6DiRSfaGxhKpPygx3vN5zkLvzHPTtgJVmuF7gRCRfyzyBv9H4fkyHMywHfS3eN1zgBptrXxc",
+            "3N59LE3ubZZ2qWUCZahimwcen5tmFoPjffCphmgJNpAncQiGxaak2Mp7iKDTcWrnUjRrqErEyx25DW612U3PHUuN"
+          ],
+          "perTx": [
+            11197,
+            246999
+          ],
+          "totalCu": 258196
+        },
+        {
+          "evmHash": "0xfc0b9485cf156545e67df9ca31865009ea44303045c6a079f377fa8b71e31943",
+          "sigs": [
+            "TtxgVgF9JURSamGMr6p2pJBqqED4zXM7hAeBsfFm2pPAjMWPhEkesNL4i8SdeHDPbByyxQMLZTbZJ9gCRbh5qeB",
+            "2E3iRVuG9RoGDFqFj8YmBe7DtKeUcn6nnFonoSSqS1oFmAY4K5UyBcRJTSDqKt2YW4xYF6VA8FqGJYAsnWgSsMb9"
+          ],
+          "perTx": [
+            11197,
+            248521
+          ],
+          "totalCu": 259718
+        },
+        {
+          "evmHash": "0xda2e5f2c2a8f10c5a0b805c46c889346b56ad4da43d01fae418abc7ee461bde5",
+          "sigs": [
+            "gQ8gebtRac8auiGSKiofPoYPJMkwZ2E3Yi5EwLJ4wbs8umobgGeHNPYiC89MzLLR1PLQsQZCpRpo7NAe1Yhy6FB",
+            "CsTGVWABPqyrJU5p1j2HdPKZ19aHrVNPB48KWjZE99xx2E891dgf5XNAEkW9NS5aE8mj88GepqAw5FsnMjN73SV"
+          ],
+          "perTx": [
+            10609,
+            245523
+          ],
+          "totalCu": 256132
+        }
+      ],
+      "mean": 258015
+    },
+    {
+      "label": "[v2] SPL_ERC20.transferFrom (self-allowance)",
+      "samples": [
+        {
+          "evmHash": "0xc135b06fe20161a0ae35754080f24fe17a2fa77a222c16375779cd20ff325132",
+          "sigs": [
+            "3Y1EYFzYFhqmngohiHmJ2a49cMb24oMDpqxPpWw8Cuwv2y1q29VoyRhCPGz1RopnJY9oKkVR2vkTn9yyQ111a7aF",
+            "62ECFsE3xoXqvZkFUXSbXxh16A9Wy6QXn2z5ftek2twKXCWqobscSnjNXzE7F6TzmA7bkCQcGt63LJcqN9ASmAhi"
+          ],
+          "perTx": [
+            11197,
+            249807
+          ],
+          "totalCu": 261004
+        },
+        {
+          "evmHash": "0x2daafa2b4633d8999cc51033e9bcbafc03b769e0b74b499d3fd24f3a1611192d",
+          "sigs": [
+            "46cT5114y4KVG5GgmrHCqBTSYPaeQ48EwQryPRC2ZHjhp8eZGty3cyb2MAc7UDEHAoPC5mRn4XsLGkvYnedTLT7d",
+            "3F6Ch5AMiyRcyg7YJq8K1GxKpGybnSNWFKv9dZgAF1QM2fgeicsfjLsAWGoKKAtW9r63S76X4bNSuZHScGFDZT87"
+          ],
+          "perTx": [
+            10609,
+            255815
+          ],
+          "totalCu": 266424
+        },
+        {
+          "evmHash": "0x99b2862d333360b5946aeab66cd067a33b082a915388970232c850d8be425703",
+          "sigs": [
+            "5S2JmD1xefnTDRtQpQEAsFjyoxcirnJ7rD7VQWTnCCMMtaSVFMLjoV6zjv6mW7Y1tNBtL3D1njex4mLJmbzavPRC",
+            "2Pi5b6wt6zHoDjkyiZnrZJGN5WNqjugfmndvgsYMv1aimRecizAzk1Ukcz1hBBNnGWeV9UX9ApQb7TV5bLT66RRT"
+          ],
+          "perTx": [
+            11197,
+            251315
+          ],
+          "totalCu": 262512
+        }
+      ],
+      "mean": 263313
+    },
+    {
+      "label": "[v1] SPL_ERC20.bridgeOutToSolana",
+      "samples": [
+        {
+          "evmHash": "0xdd6a09a4c28312e7b2eb170ba1e399379e1d460c0e36397d35264f2c398319b5",
+          "sigs": [
+            "4qs6RzhJCxmR3awKaRPWyoUj39K1dtno3kS1pNrygopWGLScjxKQb4ZTkyNjYmWZwhCnBgckkStFpEpSYE7mFxg5",
+            "4csGky8YUT3ULmkev2QUkeN7UfY4VLdkpEkNUUvXfJpRytHhaF6qVGLcnc5GBTZ7SRcgDxyDsMj4iMG3GBJHHi63"
+          ],
+          "perTx": [
+            11171,
+            570722
+          ],
+          "totalCu": 581893
+        },
+        {
+          "evmHash": "0x496c4671f270217fa1c18ec4cae5e00b47a37028bc4eab3be7d8be18969c2a73",
+          "sigs": [
+            "4awYUJgezf8BFqFYzv21JaE2uLr5wfSA1CdXgUr3xLZnAHNdFEnwBoTCh1po8iFraxcQVuzfE5Uukq1YKY2CGSr8",
+            "4r8v386yPwmz1r3jxzrhjKFGv1PVJWhvqnisHGhPmKY65iBg7vy9tktS6VHoiq5ZwKJYyFgKGx3nz5KNdyTXFusN"
+          ],
+          "perTx": [
+            11171,
+            570730
+          ],
+          "totalCu": 581901
+        },
+        {
+          "evmHash": "0x5ebb2c060e3e660e29608329aa4cf34f91d266171df29ae9a176d598e3029fdb",
+          "sigs": [
+            "2wiVxZKefmsCNiZfA8sKypJ1bgKiNNFmB8imtQkPsDXGYwbhUE24sA56ardyUtYqu2nxZMRyk1jhfTYUY7h6UXZ2",
+            "2QttrfmDHstdatvMdSvQLv8TAjfREcF25X59j3h9YND73rHvwxp237UrmRpKeKHKGkpPUGkojMP9uywGQcu6nVEA"
+          ],
+          "perTx": [
+            11197,
+            572230
+          ],
+          "totalCu": 583427
+        }
+      ],
+      "mean": 582407
+    },
+    {
+      "label": "[v2] SPL_ERC20.bridgeOutToSolana",
+      "samples": [
+        {
+          "evmHash": "0xf9820a6bc43bf3cd0282713335d8ab3e36b0b1e99972a68098426dc8e2ee8980",
+          "sigs": [
+            "3cBwJP8tjyWCwV4QP6staxj8pVjj6VyLFbSimwG4v9FfYFmCiAjK4waK2LzhiuKmKJEXyxhKKs1WBbVXcaRUwa7c",
+            "pMmMXpBZEks5Ekzq43oKpJUoxTueerD2umUXZqhdAvx3x61dLZQEBxngqR8gwaKVpYNxASSYCwvoZXk9ynPHpo4"
+          ],
+          "perTx": [
+            10609,
+            341846
+          ],
+          "totalCu": 352455
+        },
+        {
+          "evmHash": "0xa7a611ded80514ef6cd07ffed42177443b6e78de10333b58a82133afa14c449d",
+          "sigs": [
+            "5no2FcL5o5ZKiz9q22Ykm9AyUPaxvHqQqR69fa22BryG5kYhaLTWbAWKcAgySuDz3YhcS4n8H1hdXYhzjPFa6K75",
+            "4brtBZYteL3bXUsXGKSBnQUCXbC5QTGhgPZ8ZErgUQpujXtL9XUb6H1C3yCLuxHxERdXZxNnZn5TuhxHkjhtU2xD"
+          ],
+          "perTx": [
+            10609,
+            340362
+          ],
+          "totalCu": 350971
+        },
+        {
+          "evmHash": "0x765babe2c706aff2c1847fcd875362caf1f871179540eaf937b733a34bb4f89e",
+          "sigs": [
+            "3WVza6VVEKfDxweCxosAQyZx3QBUGBxLnHLPDmgt2XTX66jQetWiNc2nPb1gnhmfaw5Cd9XUeBfSWwFxejeH8CB7",
+            "4fVPtMFcP88NPEamSvAP8PFtf7G3Jmo4TZrkXsPCRBzqg6jgEnXMbht9tDa2A3CkQgQQzEaLBUHFPFZyBUhMgJ7j"
+          ],
+          "perTx": [
+            10609,
+            341870
+          ],
+          "totalCu": 352479
+        }
+      ],
+      "mean": 351968
+    },
+    {
+      "label": "[v1] RomeBridgeWithdraw.approveBurnETH",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v2] RomeBridgeWithdraw.approveBurnETH",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v1] RomeBridgeWithdraw.burnETH",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v2] RomeBridgeWithdraw.burnETH",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": 3, \"data\": \"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004453696d75"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v1] RomeBridgeWithdraw.burnUSDC",
+      "samples": [
+        {
+          "evmHash": "0x157a97c9bfdce1887890eeb817a0d2992a20165e620be811820122b2e321e4cd",
+          "sigs": [
+            "bMANtiyu96hs54AXt4vM7sZss15dmx4yrpYLFhzmfmyDiunoDZ4vH37HvfQRuJ9JTH5sVKLLiVHd6wvkrwscDnC",
+            "3Yx4SAByMnXwtqo5Q3g2TmfmUZX44qswa4htiN739htgRqxXo4RDr2yXXc68FJd6ynfU3Zt2qMYs4p1mdDQJNpau"
+          ],
+          "perTx": [
+            10609,
+            949280
+          ],
+          "totalCu": 959889
+        },
+        {
+          "evmHash": "0x1e1dc42ad54bb0d8c813ec35f6f98ac3538462b9e6e298412bf2a0bf5f3d234e",
+          "sigs": [
+            "2cRavasMU854JUiwhNpgXJeMru3RRVgnVPm9LLK2kwDmTx8sJnBtMR5uAbLkDfYEmC7WWurSP9ZNLVH3usxi4jre",
+            "2vJmxecefabEFdxys5jVgrc6Xs5E3cP3Xx1EsvKmezFNCBTY3CviU99C1npuajwcW6g8ufSuXX9qcUCF5MPFA2Sw"
+          ],
+          "perTx": [
+            10609,
+            938413
+          ],
+          "totalCu": 949022
+        },
+        {
+          "evmHash": "0x4cfb7f29a7728fdedeaef3aff327b0a6dde44254f884c39319c6b08461fcfdba",
+          "sigs": [
+            "43Somh33Vz4k6u2JyKoSMt7zRhqMYAxwppC9zuBsSy6WBtnkY9Fe2dgNduitgSchpfHGhLg4x2QSTYuHcscvanV7",
+            "2znWarkqqr2EC6ZhG7W4Lr8d5bF44Mq4AVnYxFUqrKQfGa9RLuA6NfJJWYuWkv3XE95sQaTXuXPGrhH6M9RAXsfZ"
+          ],
+          "perTx": [
+            10609,
+            938405
+          ],
+          "totalCu": 949014
+        }
+      ],
+      "mean": 952642
+    },
+    {
+      "label": "[v2] RomeBridgeWithdraw.burnUSDC",
+      "samples": [
+        {
+          "evmHash": "0xc0e2686a2e064e55e5eacf8be41e0b41283476e7696fcedaa3e5d3ee840a3e76",
+          "sigs": [
+            "3Z6FEqhwTqu2wUHeZWC42RMNnnjuwMZ6HAuyGJhVEf6U7XHyJULw7hrFvMWFv3KVngQtqPwDJ4Jnq9Hs26TJZRaV",
+            "5FKnZ4d2yXWf6A5nLwLGj3Hon4ezqsCij1WSbK89TQwz3j1bhkAWvG8N6raG5dZ4ttNBn3SjXrSPm6BFb8RCEQwN"
+          ],
+          "perTx": [
+            10609,
+            796254
+          ],
+          "totalCu": 806863
+        },
+        {
+          "evmHash": "0xdb17dc2daebe8d1f39601a1d212b6c0e0d74e539bd2663c0846a3fb928868c08",
+          "sigs": [
+            "4xhgnPwzLDepB8x2eybbjqrMV5Mm5tVEqtLu4BWfN8BP2c545AQCL6w7howL4rcURPb5SnyZ3h9VJ3ZegSSaywAp",
+            "ve1DMDve6MD9TL1quU7aTqM9wtkRD4EQR4MxX99ZTyqXoLuFjte95NsV4Nh8T2M3UFtYQuzXZSK3JZZZ25b4E9E"
+          ],
+          "perTx": [
+            10609,
+            789844
+          ],
+          "totalCu": 800453
+        },
+        {
+          "evmHash": "0x14d183056d0cea71f0b087dcb87d5143fc03ec3763d901d1db062bd0028f8161",
+          "sigs": [
+            "4yMFYVbDT1ZSLNoaLB3vRHUmMGDTTnwJWC2RGPmKVMyEvYST1zabXGuWozfvqCofhbtk4LnoXH5Lsoyz4tZa3MjR",
+            "1C35LbipVniUfLsEtycGhEZaHHFqjFnQGFb57ePyT4EFegTxe8oUFRsXL8LfMVu3pgMvbhius69ghFpH1BL3rZf"
+          ],
+          "perTx": [
+            10609,
+            780986
+          ],
+          "totalCu": 791595
+        }
+      ],
+      "mean": 799637
+    },
+    {
+      "label": "[v1] ERC20SPLFactory.create_token_mint",
+      "samples": [
+        {
+          "evmHash": "0x3bd09d25223419f066600e93c0c1b772e9be43a4cf2c42ab280d40a2222a7342",
+          "sigs": [
+            "LLFq4FJcMXXJPn5xsjniAKcpt1GRiiLGTPbrH4seweiSuYntPi8Bo1xFYu4o6kzzdE6oqA7GT1rb1w8ktgS9BYe"
+          ],
+          "perTx": [
+            463817
+          ],
+          "totalCu": 463817
+        },
+        {
+          "evmHash": "0x635f42c7c29717dd6892d2482b3019db2fca3ef461228c6dcd64734e6a7168c0",
+          "sigs": [
+            "5Fy5MtALaxJtMwYA3KU8fwPqgQvDcX9UR1zfVQJ9Dw9xGdCd1UEpHHUPStY2XSrRoBsfYd2rmCv8nNV7BSen6Aty"
+          ],
+          "perTx": [
+            456347
+          ],
+          "totalCu": 456347
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 897, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d009421cc267ff"
+        }
+      ],
+      "mean": 460082
+    },
+    {
+      "label": "[v2] ERC20SPLFactory.create_token_mint",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 907, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 917, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 927, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v1] ERC20SPLFactory.init_token_mint",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 939, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d009421cc267ff"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 951, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d009421cc267ff"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 963, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d009421cc267ff"
+        }
+      ],
+      "mean": "n/a"
+    },
+    {
+      "label": "[v2] ERC20SPLFactory.init_token_mint",
+      "samples": [
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 975, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 987, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        },
+        {
+          "evmHash": "0x",
+          "sigs": [],
+          "perTx": [],
+          "totalCu": 0,
+          "error": "could not coalesce error (error={ \"code\": -32000, \"message\": \"\" }, payload={ \"id\": 999, \"jsonrpc\": \"2.0\", \"method\": \"eth_sendRawTransaction\", \"params\": [ \"0xf86f82022185025ff7a6008401312d0094ff96ab9e9"
+        }
+      ],
+      "mean": "n/a"
+    }
+  ]
+}

--- a/deployments/hadrian.romeswap-direct.results.json
+++ b/deployments/hadrian.romeswap-direct.results.json
@@ -1,0 +1,129 @@
+{
+  "network": "hadrian",
+  "chainId": 200010,
+  "runAt": "2026-05-16T22:33:31.120Z",
+  "methodology": "RomeswapDirect single-tx wrappers. Pre-computed amounts. transferFrom x2 + pair.X inline.",
+  "deployer": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+  "directContract": "0x95E85BEaeF5D3043f415D61216bAECb1b131BE44",
+  "pairA": "0x45350dF36fA7334C2E267598Af8fC136e4982A9E",
+  "tokens": {
+    "wUSDC": "0x94AC3E5e998d72088045853C1CfB910F6CE90E56",
+    "wBench": "0xD39EC36aadfe6ca262b9c2d7D1230414B3c49501"
+  },
+  "results": [
+    {
+      "label": "[direct] addLiq (1-tx, wUSDC x wBench, post-init)",
+      "samples": [
+        {
+          "evmHash": "0xa563588d0773ad2049907dc97a0bf3bdbb6193975a197fb1079fddbddb015c9f",
+          "sigs": [
+            "4fgmWDBcApZ3PuT9awEGLXM2G5zLCktPsqV4TC7BKbFVMbcJwy8vxdMEzTZxaLwzYUKgZty16BEdsrSKfhVVg18X"
+          ],
+          "perTx": [
+            1073102
+          ],
+          "totalCu": 1073102
+        },
+        {
+          "evmHash": "0x031540c9c5579c4d622b3c5ddf34b17ff1c43bc575ff73a63b2375701eaddf52",
+          "sigs": [
+            "3KiGJiPsK1bp61MuZ8eV7ArkMPpQqv8JFnp3eZPruZQaGvVgfQ3HTd4iJF1z1JSbhUjkfCqizS3N31DNpFML13mX"
+          ],
+          "perTx": [
+            929628
+          ],
+          "totalCu": 929628
+        },
+        {
+          "evmHash": "0xa063f6f24c1c7aa432292d33185abe08cd98c64602cc7beb390d23e1435663e1",
+          "sigs": [
+            "3dHR5vFN8w439y3ipK2g9zyfkG8aNehPFpJcbsZRDkYkMbzK6paBJWU4rXbT2BuEXyoomNUzH54cL5tQsm3Bc2RN"
+          ],
+          "perTx": [
+            916075
+          ],
+          "totalCu": 916075
+        }
+      ],
+      "mean": 972935
+    },
+    {
+      "label": "[direct] swap (1-tx, wUSDC -> wBench)",
+      "samples": [
+        {
+          "evmHash": "0xac27609948a8c622ac73f78efc9837dd53d00d018b58b9c10b09a34a1ef27a8b",
+          "sigs": [
+            "isJuNsHXCq9DsoZHLY8XhpE8shZiLR3cTKzgPXPUY2CpM2tx1AzsnD5LCSYQgoRCkmmNXBepdLVCydBZjxVHnRi",
+            "mSWsJXVw6Jtvm4qBq2XYMjHcbDmTRSWB3tj9qeVrDspDRBsfAiCmFKbZmT8cbPbjWiWd738kRuikaMLHZvZG6Na"
+          ],
+          "perTx": [
+            11197,
+            886107
+          ],
+          "totalCu": 897304
+        },
+        {
+          "evmHash": "0x1ee41e4544196c78e73036f39767ea71b20cb0f652cdb0e1915df4e1b4c07eeb",
+          "sigs": [
+            "wGcKHLF6kckLCspRJkfWEm5cK7CzZVPA4tU96ggGc4PWPBK9v7LVNR3fb5g3P2zM2go7ajL1mTW3uWEx43bQACH",
+            "3DvW5UDnwVf9zrwAhWZQ5EJ1qHz61q9wrv1beSaVQPj6is8RNwLF4WAf4EhwivT679NWDvvyMRJWXtsAMkaRddBy"
+          ],
+          "perTx": [
+            11197,
+            870367
+          ],
+          "totalCu": 881564
+        },
+        {
+          "evmHash": "0x7ee233abaceff8618ee7b4a03f0695b1fa93519472100e842a0006e64c370d69",
+          "sigs": [
+            "2bAxi2ci4EjiqtC2wE5D8H1V6tBYg1iKwCLWd7qioysJ2Ttr7EFP9stDDKS1ZJZpmLndy5yPwzZFbDra81gSVKS4",
+            "4tyHQ3Xfeb8AJEQLVZioMUXvX3HtZgzUPwacTHdrSG5YhtPj1SCyyZ3GLj969wtmust3d1XZNC4EgVJwLECy9FHM"
+          ],
+          "perTx": [
+            10609,
+            868879
+          ],
+          "totalCu": 879488
+        }
+      ],
+      "mean": 886119
+    },
+    {
+      "label": "[direct] removeLiq (1-tx, wUSDC x wBench)",
+      "samples": [
+        {
+          "evmHash": "0x6cd6202103457d0652fdf88506c453774a73856e4c87a749fca289502f0bb042",
+          "sigs": [
+            "gP4Luo3RKUqhB7xD74HNKbTz3TLmbh1bDcBXRZAa75tX8TFNsts9mBR8opbeEDM9FLpX9bsjdyerZmEZf9XzEzA"
+          ],
+          "perTx": [
+            1200709
+          ],
+          "totalCu": 1200709
+        },
+        {
+          "evmHash": "0x0296ca0ffd6dd3978b2ffc9cea97d7c66a93d5ee774acd20ce0230be392448f4",
+          "sigs": [
+            "RnwzgDZcJ4o96KEGFE3tmVLWjFjnq7AVfxtZbap3M1rPnxYMBQKCREjw7PHZ1HemBac75rxqQfYExrZpwV4otuq"
+          ],
+          "perTx": [
+            1180440
+          ],
+          "totalCu": 1180440
+        },
+        {
+          "evmHash": "0x3a3617e3efbff57a69d2678a55348fb20f0c77638e359f7218ce70fa4676f1e3",
+          "sigs": [
+            "3pdSJtDRmpvDzN8Rm4U5eaVbALAjjBT1dxd2T2Eegv1soQnx2Y2UhwBaxK4qbi3Ej3wh7jFstvuZJXRji1qVrDG8"
+          ],
+          "perTx": [
+            1181948
+          ],
+          "totalCu": 1181948
+        }
+      ],
+      "mean": 1187699
+    }
+  ]
+}

--- a/scripts/bench/deploy-real-flow-v2.ts
+++ b/scripts/bench/deploy-real-flow-v2.ts
@@ -1,0 +1,265 @@
+/**
+ * Phase 2 — Deploy NEW (post-#165/#166/#167/#169) contracts side-by-side on
+ * Hadrian for v1-vs-new flow-level CU benchmarking.
+ *
+ * What gets deployed:
+ *   1. NEW ERC20SPLFactory — creates its own ERC20Users internally
+ *   2. wBench mint (created via factory.create_token_mint + init_token_mint,
+ *      which exercises A4 + A5) + SPL_ERC20 wrapper for it
+ *   3. NEW RomeBridgeWithdraw — constructor uses v1's wUSDC + v1's wETH
+ *      wrappers (bridges operate on the same wrapper state for fair compare)
+ *
+ * Output:
+ *   deployments/hadrian.real-flow-bench.json
+ *
+ * Usage:
+ *   export HARDHAT_VAR_HADRIAN_PRIVATE_KEY=...
+ *   npx hardhat run scripts/bench/deploy-real-flow-v2.ts --network hadrian
+ */
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+import {
+    Wallet,
+    JsonRpcProvider,
+    ContractFactory,
+    Contract,
+    keccak256,
+    solidityPacked,
+} from "ethers";
+import factoryArtifact from "../../artifacts/contracts/erc20spl/erc20spl_factory.sol/ERC20SPLFactory.json" with { type: "json" };
+import withdrawArtifact from "../../artifacts/contracts/bridge/RomeBridgeWithdraw.sol/RomeBridgeWithdraw.json" with { type: "json" };
+import { base58ToBytes32 } from "../lib/pubkey.js";
+// Hadrian's v1 hadrian.json deployment receipt lives in the main rome-solidity
+// checkout (gitignored locally — not in the worktree). Read it directly.
+const V1_HADRIAN_RECEIPT_PATH = "/Users/anilkumar/rome/rome-solidity/deployments/hadrian.json";
+function readV1Hadrian(): any {
+    return JSON.parse(fs.readFileSync(V1_HADRIAN_RECEIPT_PATH, "utf8"));
+}
+import { PublicKey } from "@solana/web3.js";
+import { deriveCctpAccounts } from "../bridge/derive/cctp-accounts.js";
+import { deriveWormholeAccounts } from "../bridge/derive/wormhole-accounts.js";
+import { SOLANA_PROGRAM_IDS_DEVNET } from "../bridge/constants.js";
+
+const CPI_PROGRAM_ADDRESS = "0xFF00000000000000000000000000000000000008" as const;
+const HELPER_PROGRAM_ADDRESS = "0xff00000000000000000000000000000000000009" as const;
+
+import { Interface } from "ethers";
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function pda(address user) view returns (bytes32)",
+]);
+
+async function main() {
+    const networkName = "hadrian";
+    const rpcUrl = "https://hadrian.testnet.romeprotocol.xyz/";
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+
+    const provider = new JsonRpcProvider(rpcUrl);
+    const wallet = new Wallet(pk, provider);
+    console.log(`Deployer:  ${wallet.address}`);
+    console.log(`Balance:   ${(await provider.getBalance(wallet.address)).toString()} wei`);
+
+    // Read v1 receipt.
+    const v1 = readV1Hadrian();
+    const v1USDCWrapper = v1.SPL_ERC20_USDC?.address as `0x${string}`;
+    const v1WETHWrapper = v1.SPL_ERC20_WETH?.address as `0x${string}`;
+    const v1USDCMint = v1.SPL_ERC20_USDC?.mintId as string;
+    const v1WETHMint = v1.SPL_ERC20_WETH?.mintId as string;
+    const v1Paymaster = v1.RomeBridgePaymaster?.address as `0x${string}`;
+    const v1WithdrawAddr = v1.RomeBridgeWithdraw?.address as `0x${string}`;
+    if (!v1USDCWrapper || !v1WETHWrapper || !v1Paymaster) {
+        throw new Error("v1 hadrian.json missing required addresses");
+    }
+    console.log(`v1.SPL_ERC20_USDC:        ${v1USDCWrapper}  (mint ${v1USDCMint})`);
+    console.log(`v1.SPL_ERC20_WETH:        ${v1WETHWrapper}  (mint ${v1WETHMint})`);
+    console.log(`v1.RomeBridgePaymaster:   ${v1Paymaster}`);
+    console.log(`v1.RomeBridgeWithdraw:    ${v1WithdrawAddr}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 1 — Deploy NEW ERC20SPLFactory.
+    // ──────────────────────────────────────────────────────────────────────
+    console.log("\n[1/5] Deploy NEW ERC20SPLFactory...");
+    const factoryFactory = new ContractFactory(factoryArtifact.abi, factoryArtifact.bytecode, wallet);
+    const v2Factory = await factoryFactory.deploy(CPI_PROGRAM_ADDRESS);
+    await v2Factory.waitForDeployment();
+    const v2FactoryAddr = await v2Factory.getAddress();
+    console.log(`        v2.ERC20SPLFactory: ${v2FactoryAddr}`);
+
+    const v2FactoryContract = new Contract(v2FactoryAddr, factoryArtifact.abi, wallet);
+    const v2UsersAddr = (await v2FactoryContract.users()) as string;
+    console.log(`        v2.ERC20Users:      ${v2UsersAddr}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 1.5 — Top up deployer's external_auth PDA with lamports.
+    //   create_mint_account allocates an 82-byte SPL Mint account (~1.5M
+    //   lamports rent). If the PDA is at the rent-exempt floor only,
+    //   create_token_mint reverts with Custom(1) = InsufficientFunds.
+    //   Pre-top-up via HelperProgram.swap_gas_to_lamports (gas-token → SOL
+    //   lamports on caller's PDA). 3M lamports = ~0.003 SOL covers the
+    //   mint rent + buffer.
+    // ──────────────────────────────────────────────────────────────────────
+    console.log("\n[1.5] Top up deployer PDA via HelperProgram.swap_gas_to_lamports(3_000_000)...");
+    const swapData = helperIface.encodeFunctionData("swap_gas_to_lamports", [3_000_000n]);
+    const swapTx = await wallet.sendTransaction({
+        to: HELPER_PROGRAM_ADDRESS,
+        data: swapData,
+        gasLimit: 5_000_000n,
+    });
+    await swapTx.wait();
+    console.log(`        swap_gas_to_lamports tx: ${swapTx.hash}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 2 — Read the (mint, salt) the factory will produce on next
+    //          create_token_mint, then call create + init.
+    //          A4 (create_mint_account) gets exercised by create_token_mint;
+    //          A5 (init_spl_mint) by init_token_mint.
+    // ──────────────────────────────────────────────────────────────────────
+    console.log("\n[2/5] Create + init wBench mint (exercises A4 + A5)...");
+    const [wBenchMint, wBenchSalt] = (await v2FactoryContract.get_current_mint(wallet.address)) as [
+        string,
+        string,
+    ];
+    console.log(`        wBench mint (bytes32): ${wBenchMint}`);
+    console.log(`        wBench salt:           ${wBenchSalt}`);
+
+    const createMintTx = await v2FactoryContract.create_token_mint({ gasLimit: 5_000_000n });
+    await createMintTx.wait();
+    console.log(`        create_token_mint tx:  ${createMintTx.hash}`);
+
+    const initMintTx = await v2FactoryContract.init_token_mint(wBenchMint, { gasLimit: 5_000_000n });
+    await initMintTx.wait();
+    console.log(`        init_token_mint tx:    ${initMintTx.hash}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 3 — Register the SPL_ERC20 wrapper via add_spl_token_no_metadata.
+    // ──────────────────────────────────────────────────────────────────────
+    console.log("\n[3/5] Register wBench wrapper via factory.add_spl_token_no_metadata...");
+    const addTokenTx = await v2FactoryContract.add_spl_token_no_metadata(
+        wBenchMint,
+        "Bench Test Token",
+        "wBench",
+        { gasLimit: 80_000_000n },
+    );
+    const addTokenReceipt = await addTokenTx.wait();
+    console.log(`        add_spl_token tx:      ${addTokenTx.hash}`);
+
+    let v2BenchWrapperAddr: string | null = null;
+    for (const log of addTokenReceipt.logs ?? []) {
+        try {
+            const parsed = v2FactoryContract.interface.parseLog(log);
+            if (parsed?.name === "TokenCreated") {
+                v2BenchWrapperAddr = parsed.args.wrapper as string;
+                break;
+            }
+        } catch {}
+    }
+    if (!v2BenchWrapperAddr) {
+        // Fallback — symbol-hash lookup
+        const symbolHash = keccak256(solidityPacked(["string"], ["wBench"]));
+        v2BenchWrapperAddr = (await v2FactoryContract.token_by_symbol_hash(symbolHash)) as string;
+    }
+    console.log(`        v2.SPL_ERC20_wBench:   ${v2BenchWrapperAddr}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 4 — Deploy NEW RomeBridgeWithdraw using v1 wUSDC + v1 wETH.
+    //          Solana PDAs derived from v1 mints (same mints v1 uses).
+    // ──────────────────────────────────────────────────────────────────────
+    console.log("\n[4/5] Deploy NEW RomeBridgeWithdraw...");
+    const ids = SOLANA_PROGRAM_IDS_DEVNET;
+    const usdcMintPK = new PublicKey(v1USDCMint);
+    const wethMintPK = new PublicKey(v1WETHMint);
+    const pdas = {
+        ...deriveCctpAccounts(usdcMintPK),
+        ...deriveWormholeAccounts(wethMintPK, {
+            tokenBridgeProgramId: ids.WORMHOLE_TOKEN_BRIDGE,
+            coreProgramId:        ids.WORMHOLE_CORE,
+        }),
+    };
+
+    const cctpParams = {
+        tokenMessengerProgram:     base58ToBytes32(ids.CCTP_TOKEN_MESSENGER),
+        messageTransmitterProgram: base58ToBytes32(ids.CCTP_MESSAGE_TRANSMITTER),
+        splTokenProgram:           base58ToBytes32(ids.SPL_TOKEN),
+        systemProgram:             base58ToBytes32(ids.SYSTEM_PROGRAM),
+        messageTransmitterConfig:  pdas.cctpMessageTransmitterConfig,
+        tokenMessengerConfig:      pdas.cctpTokenMessengerConfig,
+        remoteTokenMessenger:      pdas.cctpRemoteTokenMessenger,
+        tokenMinter:               pdas.cctpTokenMinter,
+        localTokenUsdc:            pdas.cctpLocalTokenUsdc,
+        senderAuthorityPda:        pdas.cctpSenderAuthorityPda,
+        eventAuthority:            pdas.cctpEventAuthority,
+        messageTransmitterEventAuthority: pdas.cctpMessageTransmitterEventAuthority,
+    };
+
+    const wormholeParams = {
+        tokenBridgeProgram: base58ToBytes32(ids.WORMHOLE_TOKEN_BRIDGE),
+        coreProgram:        base58ToBytes32(ids.WORMHOLE_CORE),
+        splTokenProgram:    base58ToBytes32(ids.SPL_TOKEN),
+        systemProgram:      base58ToBytes32(ids.SYSTEM_PROGRAM),
+        clockSysvar:        base58ToBytes32("SysvarC1ock11111111111111111111111111111111"),
+        rentSysvar:         base58ToBytes32("SysvarRent111111111111111111111111111111111"),
+        config:             pdas.wormholeConfig,
+        custody:            pdas.wormholeCustody,
+        authoritySigner:    pdas.wormholeAuthoritySigner,
+        custodySigner:      pdas.wormholeCustodySigner,
+        bridgeConfig:       pdas.wormholeBridgeConfig,
+        feeCollector:       pdas.wormholeFeeCollector,
+        emitter:            pdas.wormholeEmitter,
+        sequence:           pdas.wormholeSequence,
+        wrappedMeta:        pdas.wormholeWrappedMeta,
+        targetChain:        10002, // Sepolia
+    };
+
+    const withdrawFactory = new ContractFactory(withdrawArtifact.abi, withdrawArtifact.bytecode, wallet);
+    const v2Withdraw = await withdrawFactory.deploy(
+        v1Paymaster,
+        v1USDCWrapper,
+        v1WETHWrapper,
+        cctpParams,
+        wormholeParams,
+    );
+    await v2Withdraw.waitForDeployment();
+    const v2WithdrawAddr = await v2Withdraw.getAddress();
+    console.log(`        v2.RomeBridgeWithdraw: ${v2WithdrawAddr}`);
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Step 5 — Write artifact
+    // ──────────────────────────────────────────────────────────────────────
+    const artifact = {
+        network: networkName,
+        chainId: 200010,
+        deployedAt: new Date().toISOString(),
+        deployer: wallet.address,
+        v1: {
+            ERC20SPLFactory:       v1.ERC20SPLFactory?.address,
+            SPL_ERC20_USDC:        v1USDCWrapper,
+            SPL_ERC20_WETH:        v1WETHWrapper,
+            SPL_ERC20_WSOL:        v1.SPL_ERC20_WSOL?.address,
+            RomeBridgeWithdraw:    v1WithdrawAddr,
+            RomeBridgePaymaster:   v1Paymaster,
+            usdcMint:              v1USDCMint,
+            wethMint:              v1WETHMint,
+            wsolMint:              v1.SPL_ERC20_WSOL?.mintId,
+        },
+        v2: {
+            ERC20SPLFactory:       v2FactoryAddr,
+            ERC20Users:            v2UsersAddr,
+            wBenchMint:            wBenchMint,
+            wBenchSalt:            wBenchSalt,
+            SPL_ERC20_wBench:      v2BenchWrapperAddr,
+            RomeBridgeWithdraw:    v2WithdrawAddr,
+        },
+    };
+
+    const out = path.resolve(process.cwd(), "deployments", "hadrian.real-flow-bench.json");
+    fs.writeFileSync(out, JSON.stringify(artifact, null, 2) + "\n");
+    console.log(`\nArtifact: ${out}`);
+    console.log(`Deployer balance after: ${(await provider.getBalance(wallet.address)).toString()} wei`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/bench/measure-2hop-swap.ts
+++ b/scripts/bench/measure-2hop-swap.ts
@@ -1,0 +1,224 @@
+/**
+ * Hypothesis: 2-hop atomic swap fits 1.4M CU.
+ *
+ * Route: wBench → wUSDC → MOCK via Pair A (wUSDC×wBench) + Pair B (wUSDC×MOCK).
+ *
+ * Pair A is initialized (102K/102K from prior runs).
+ * Pair B needs seed-init via 3-tx breakdown.
+ * Then redeploy RomeswapDirect (now with swap2Hop) and bench.
+ */
+import fs from "node:fs";
+import { Wallet, JsonRpcProvider, Contract, Interface, ContractFactory, getAddress } from "ethers";
+import directArtifact from "../../artifacts/contracts/cpi/test/RomeswapDirect.sol/RomeswapDirect.json" with { type: "json" };
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+
+const V1_WUSDC = "0x94AC3E5e998d72088045853C1CfB910F6CE90E56";
+const PAIR_A = "0x45350dF36fA7334C2E267598Af8fC136e4982A9E";  // wUSDC × wBench
+const PAIR_B = "0x9FB2471A400CA670F5459829b622A2f4d4824642";  // wUSDC × MOCK
+const MOCK = "0x5cB734B113E31005487D7E4bcA39BCC3e17B8e9A";
+const SAMPLES = 3;
+
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function transfer_lamports(address to, uint64 lamports) external",
+]);
+const erc20Iface = new Interface([
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function balanceOf(address) external view returns (uint256)",
+]);
+const pairIface = new Interface([
+    "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+    "function token0() external view returns (address)",
+    "function mint(address to) external returns (uint256 liquidity)",
+]);
+
+async function romeSig(h: string): Promise<string[]> {
+    const r = await fetch(HADRIAN_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [h] }) });
+    return ((await r.json()) as any).result ?? [];
+}
+async function solCu(sig: string): Promise<number> {
+    const r = await fetch(SOLANA_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }) });
+    return ((await r.json()) as any).result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function totalCu(h: string) {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) { sigs = await romeSig(h); if (sigs.length) break; await new Promise(r => setTimeout(r, 2000)); }
+    if (!sigs.length) throw new Error(`empty sigs for ${h}`);
+    const per: number[] = [];
+    for (const s of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) { cu = await solCu(s); if (cu > 0) break; await new Promise(r => setTimeout(r, 1500)); }
+        per.push(cu);
+    }
+    return { sigs, perTx: per, totalCu: per.reduce((a, b) => a + b, 0) };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+
+    const v2Art = JSON.parse(fs.readFileSync("deployments/hadrian.real-flow-bench.json", "utf8"));
+    const V2_WBENCH = v2Art.v2.SPL_ERC20_wBench;
+    console.log(`Deployer: ${wallet.address}`);
+    console.log(`wUSDC: ${V1_WUSDC}`);
+    console.log(`wBench: ${V2_WBENCH}`);
+    console.log(`MOCK:  ${MOCK}`);
+    console.log(`Pair A (wUSDC × wBench): ${PAIR_A}`);
+    console.log(`Pair B (wUSDC × MOCK):   ${PAIR_B}`);
+
+    // Top up PDA.
+    console.log("\n[setup] swap_gas_to_lamports(10M)...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("swap_gas_to_lamports", [10_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,80)}`); }
+
+    // Deploy fresh RomeswapDirect (now with swap2Hop).
+    console.log("\n[deploy] RomeswapDirect (now with swap2Hop)...");
+    const factory = new ContractFactory(directArtifact.abi, directArtifact.bytecode, wallet);
+    const direct = await factory.deploy();
+    await direct.waitForDeployment();
+    const directAddr = await direct.getAddress();
+    console.log(`        ${directAddr}`);
+
+    const directContract = new Contract(directAddr, directArtifact.abi, wallet);
+    const v1Wusdc = new Contract(V1_WUSDC, erc20Iface, wallet);
+    const v2Wbench = new Contract(V2_WBENCH, erc20Iface, wallet);
+    const mock = new Contract(MOCK, erc20Iface, wallet);
+    const pairA = new Contract(PAIR_A, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+    const pairB = new Contract(PAIR_B, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+
+    // Top up directContract's PDA.
+    console.log("\n[setup] transfer_lamports(directContract, 15M)...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("transfer_lamports", [directAddr, 15_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+        console.log(`  ok`);
+    } catch (e: any) { console.log(`  err: ${e.message?.slice(0,200)}`); }
+
+    // Approvals.
+    console.log("\n[setup] Approve RomeswapDirect on wBench (input token for 2-hop)...");
+    try {
+        await (await v2Wbench.approve(directAddr, 1_000_000_000n, { gasLimit: 15_000_000n })).wait();
+        console.log(`  ok`);
+    } catch (e: any) { console.log(`  err: ${e.message?.slice(0,200)}`); }
+
+    // Seed Pair B if not initialized.
+    const reservesB0 = await pairB.getReserves();
+    if (reservesB0[0] === 0n && reservesB0[1] === 0n) {
+        console.log("\n[setup] Seed Pair B (100K wUSDC + 100K MOCK) via 3-tx breakdown...");
+        try {
+            const t1 = await v1Wusdc.transfer(PAIR_B, 100_000n, { gasLimit: 30_000_000n });
+            await t1.wait();
+            console.log(`  tx1 wUSDC.transfer: ${t1.hash}`);
+            const t2 = await mock.transfer(PAIR_B, 100_000n, { gasLimit: 30_000_000n });
+            await t2.wait();
+            console.log(`  tx2 MOCK.transfer: ${t2.hash}`);
+            const t3 = await pairB.mint(wallet.address, { gasLimit: 30_000_000n });
+            await t3.wait();
+            console.log(`  tx3 pair.mint: ${t3.hash}`);
+            const r = await pairB.getReserves();
+            console.log(`  Pair B reserves: ${r[0]} / ${r[1]}`);
+        } catch (e: any) {
+            console.log(`  SEED FAILED: ${e.message?.slice(0,300)}`);
+        }
+    } else {
+        console.log(`\n[setup] Pair B already seeded: ${reservesB0[0]} / ${reservesB0[1]}`);
+    }
+
+    const reservesA = await pairA.getReserves();
+    const reservesB = await pairB.getReserves();
+    const tokenA0 = (await pairA.token0() as string).toLowerCase();
+    const tokenB0 = (await pairB.token0() as string).toLowerCase();
+    console.log(`\nPair A reserves (token0=${tokenA0===V1_WUSDC.toLowerCase()?'wUSDC':'wBench'}): ${reservesA[0]} / ${reservesA[1]}`);
+    console.log(`Pair B reserves (token0=${tokenB0===V1_WUSDC.toLowerCase()?'wUSDC':'MOCK'}):  ${reservesB[0]} / ${reservesB[1]}`);
+
+    // Pre-compute 2-hop amounts: wBench → wUSDC → MOCK
+    const amtIn = 100n;
+    // Hop 1: wBench in, wUSDC out, on Pair A
+    // wBench is which token of Pair A?
+    const wBenchIsToken0A = tokenA0 === V2_WBENCH.toLowerCase();
+    const rIn_A  = wBenchIsToken0A ? reservesA[0] : reservesA[1];   // wBench reserve
+    const rOut_A = wBenchIsToken0A ? reservesA[1] : reservesA[0];   // wUSDC reserve
+    const fee = 997n;
+    const inFee_A = amtIn * fee;
+    const amtUsdcOut = (inFee_A * rOut_A) / (rIn_A * 1000n + inFee_A);
+    const amount0OutA = wBenchIsToken0A ? 0n : amtUsdcOut;
+    const amount1OutA = wBenchIsToken0A ? amtUsdcOut : 0n;
+
+    // Hop 2: wUSDC in (just received from Pair A), MOCK out, on Pair B
+    const wUsdcIsToken0B = tokenB0 === V1_WUSDC.toLowerCase();
+    const rIn_B  = wUsdcIsToken0B ? reservesB[0] : reservesB[1];   // wUSDC reserve
+    const rOut_B = wUsdcIsToken0B ? reservesB[1] : reservesB[0];   // MOCK reserve
+    const inFee_B = amtUsdcOut * fee;
+    const amtMockOut = (inFee_B * rOut_B) / (rIn_B * 1000n + inFee_B);
+    const amount0OutB = wUsdcIsToken0B ? 0n : amtMockOut;
+    const amount1OutB = wUsdcIsToken0B ? amtMockOut : 0n;
+
+    console.log(`\nQuote: ${amtIn} wBench → ${amtUsdcOut} wUSDC → ${amtMockOut} MOCK`);
+    console.log(`Pair A: amount0Out=${amount0OutA}, amount1Out=${amount1OutA}`);
+    console.log(`Pair B: amount0Out=${amount0OutB}, amount1Out=${amount1OutB}`);
+
+    // Run 3 samples of 2-hop swap.
+    console.log(`\n=== BENCH: 2-hop swap wBench → wUSDC → MOCK ===`);
+    const samples: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            // Recompute quote each sample (reserves shift).
+            const rA = await pairA.getReserves();
+            const rB = await pairB.getReserves();
+            const t0A = tokenA0 === V2_WBENCH.toLowerCase();
+            const rin_a = t0A ? rA[0] : rA[1];
+            const rout_a = t0A ? rA[1] : rA[0];
+            const u_out = (amtIn * fee * rout_a) / (rin_a * 1000n + amtIn * fee);
+            const t0B = tokenB0 === V1_WUSDC.toLowerCase();
+            const rin_b = t0B ? rB[0] : rB[1];
+            const rout_b = t0B ? rB[1] : rB[0];
+            const m_out = (u_out * fee * rout_b) / (rin_b * 1000n + u_out * fee);
+            const aA0 = t0A ? 0n : u_out, aA1 = t0A ? u_out : 0n;
+            const aB0 = t0B ? 0n : m_out, aB1 = t0B ? m_out : 0n;
+
+            const tx = await directContract.swap2Hop(
+                V2_WBENCH, PAIR_A, PAIR_B, amtIn, aA0, aA1, aB0, aB1, wallet.address,
+                { gasLimit: 80_000_000n }
+            );
+            await tx.wait();
+            const { sigs, perTx, totalCu: cu } = await totalCu(tx.hash);
+            console.log(`  ${i+1}/${SAMPLES}: ${tx.hash.slice(0,12)}... sigs=${sigs.length} cu=${cu.toLocaleString()} ${cu < 1_400_000 ? "✓ fits 1.4M" : "✗ busts 1.4M"}`);
+            samples.push({ evmHash: tx.hash, sigs, perTx, totalCu: cu });
+        } catch (e: any) {
+            const m = (e.message || String(e)).slice(0, 250);
+            console.log(`  ${i+1}/${SAMPLES}: ERROR ${m}`);
+            samples.push({ evmHash: "0x", totalCu: 0, error: m });
+        }
+    }
+
+    const valid = samples.filter(s => s.totalCu > 0);
+    const mean = valid.length ? Math.round(valid.reduce((a, b) => a + b.totalCu, 0) / valid.length) : 0;
+
+    const out = {
+        network: "hadrian", chainId: 200010, runAt: new Date().toISOString(),
+        route: "wBench → wUSDC → MOCK", pair1: PAIR_A, pair2: PAIR_B,
+        directContract: directAddr, mean, samples,
+    };
+    fs.writeFileSync("deployments/hadrian.2hop-bench.results.json", JSON.stringify(out, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(80));
+    console.log(`2-HOP SWAP MEAN: ${mean.toLocaleString()} CU  ${mean && mean < 1_400_000 ? "✓ FITS 1.4M" : mean ? "✗ EXCEEDS 1.4M" : "(no valid samples)"}`);
+    console.log(`Margin to ceiling: ${mean ? (1400000 - mean).toLocaleString() + " CU" : "n/a"}`);
+    console.log("=".repeat(80));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/bench/measure-bridge-eth-flows.ts
+++ b/scripts/bench/measure-bridge-eth-flows.ts
@@ -1,0 +1,144 @@
+/**
+ * Phase 2 follow-up. Focused bench of wETH-dependent ops only.
+ * 4 ops x 3 samples = 12 txs total. Merges into existing results JSON.
+ *
+ * Prereq: deployer has wETH balance on Hadrian.
+ *
+ * Usage:
+ *   export HARDHAT_VAR_HADRIAN_PRIVATE_KEY=...
+ *   npx hardhat run scripts/bench/measure-bridge-eth-flows.ts --network hadrian
+ */
+import fs from "node:fs";
+import {
+    Wallet,
+    JsonRpcProvider,
+    Contract,
+    Interface,
+    getAddress,
+} from "ethers";
+import withdrawArtifact from "../../artifacts/contracts/bridge/RomeBridgeWithdraw.sol/RomeBridgeWithdraw.json" with { type: "json" };
+import wrapperArtifact from "../../artifacts/contracts/erc20spl/erc20spl.sol/SPL_ERC20.json" with { type: "json" };
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const ART = "deployments/hadrian.real-flow-bench.json";
+const RES = "deployments/hadrian.real-flow-bench.results.json";
+const SAMPLES = 3;
+
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+]);
+
+async function romeSig(h: string): Promise<string[]> {
+    const r = await fetch(HADRIAN_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [h] }) });
+    return ((await r.json()) as any).result ?? [];
+}
+async function solCu(sig: string): Promise<number> {
+    const r = await fetch(SOLANA_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }) });
+    return ((await r.json()) as any).result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function totalCu(h: string) {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) { sigs = await romeSig(h); if (sigs.length) break; await new Promise(r => setTimeout(r, 2000)); }
+    if (!sigs.length) throw new Error(`empty sigs for ${h}`);
+    const per: number[] = [];
+    for (const s of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) { cu = await solCu(s); if (cu > 0) break; await new Promise(r => setTimeout(r, 1500)); }
+        per.push(cu);
+    }
+    return { sigs, perTx: per, totalCu: per.reduce((a, b) => a + b, 0) };
+}
+
+interface Op { label: string; samples: any[]; mean: number | "n/a" }
+async function run(label: string, fn: (i: number) => Promise<string>): Promise<Op> {
+    console.log(`\nProbing: ${label}`);
+    const sm: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            const h = await fn(i);
+            const { sigs, perTx, totalCu: cu } = await totalCu(h);
+            console.log(`  ${i+1}/${SAMPLES}: ${h.slice(0,12)}... sigs=${sigs.length} cu=${cu.toLocaleString()}`);
+            sm.push({ evmHash: h, sigs, perTx, totalCu: cu });
+        } catch (e: any) {
+            const m = (e.message || String(e)).slice(0, 200);
+            console.log(`  ${i+1}/${SAMPLES}: ERROR ${m}`);
+            sm.push({ evmHash: "0x", sigs: [], perTx: [], totalCu: 0, error: m });
+        }
+    }
+    const v = sm.filter(s => s.totalCu > 0);
+    const mean = v.length ? Math.round(v.reduce((a, b) => a + b.totalCu, 0) / v.length) : ("n/a" as const);
+    return { label, samples: sm, mean };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+
+    const art = JSON.parse(fs.readFileSync(ART, "utf8"));
+    const v1 = art.v1, v2 = art.v2;
+    console.log(`Deployer: ${wallet.address}`);
+
+    const v1Weth = new Contract(v1.SPL_ERC20_WETH, wrapperArtifact.abi, wallet);
+    const bal = await v1Weth.balanceOf(wallet.address);
+    console.log(`v1.wETH balance: ${bal.toString()}`);
+    if (bal === 0n) {
+        console.log("Zero wETH. Bridge ETH from Sepolia first.");
+        process.exit(2);
+    }
+
+    console.log("Top up PDA lamports (5M)...");
+    try {
+        const sw = await wallet.sendTransaction({
+            to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("swap_gas_to_lamports", [5_000_000n]),
+            gasLimit: 15_000_000n,
+        });
+        await sw.wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,100)}`); }
+
+    const v1B = new Contract(v1.RomeBridgeWithdraw, withdrawArtifact.abi, wallet);
+    const v2B = new Contract(v2.RomeBridgeWithdraw, withdrawArtifact.abi, wallet);
+    const ETH_RX = getAddress("0x000000000000000000000000000000000000beef");
+
+    const focused: Op[] = [];
+    focused.push(await run("[v1] RomeBridgeWithdraw.approveBurnETH", async (i) => {
+        const tx = await v1B.approveBurnETH(100n + BigInt(i), { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    focused.push(await run("[v2] RomeBridgeWithdraw.approveBurnETH", async (i) => {
+        const tx = await v2B.approveBurnETH(100n + BigInt(i), { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    focused.push(await run("[v1] RomeBridgeWithdraw.burnETH", async () => {
+        await (await v1B.approveBurnETH(1000n, { gasLimit: 20_000_000n })).wait();
+        const tx = await v1B.burnETH(1n, ETH_RX, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    focused.push(await run("[v2] RomeBridgeWithdraw.burnETH", async () => {
+        await (await v2B.approveBurnETH(1000n, { gasLimit: 20_000_000n })).wait();
+        const tx = await v2B.burnETH(1n, ETH_RX, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    let ex: any = {};
+    try { ex = JSON.parse(fs.readFileSync(RES, "utf8")); } catch {}
+    const labels = new Set(focused.map(r => r.label));
+    ex.results = (ex.results ?? []).filter((r: Op) => !labels.has(r.label)).concat(focused);
+    ex.lastFocusedRunAt = new Date().toISOString();
+    fs.writeFileSync(RES, JSON.stringify(ex, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(80));
+    for (const r of focused) {
+        const m = typeof r.mean === "number" ? r.mean.toLocaleString() + " CU" : "n/a";
+        console.log(`${r.label.padEnd(58)} ${m.padStart(12)}`);
+    }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/bench/measure-canonical-router.ts
+++ b/scripts/bench/measure-canonical-router.ts
@@ -1,0 +1,258 @@
+/**
+ * Canonical UniswapV2Router measurement on Hadrian (post-#364 / post-universal-delegation).
+ *
+ * Hypotheses to test:
+ *   1. swap (single-hop) via canonical router fits 1.4M — vs lean direct router 886K
+ *   2. addLiquidity via canonical router NOW fits post-#364 (was busting pre-savings)
+ *   3. removeLiquidity via canonical router (2-step: LP-approve + remove) measurement
+ *   4. removeLiquidityWithPermit using LP token's canonical permit — 1-tx UX
+ *   5. swapExactTokensForTokens with 2-hop path — does canonical busts vs lean?
+ *
+ * Each test: 3 samples, atomic, on existing PairA/PairB.
+ *
+ * Output: deployments/hadrian.canonical-router.results.json
+ */
+import fs from "node:fs";
+import {
+    Wallet, JsonRpcProvider, Contract, Interface, getAddress,
+} from "ethers";
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+
+const V1_WUSDC = "0x94AC3E5e998d72088045853C1CfB910F6CE90E56";
+const PAIR_A = "0x45350dF36fA7334C2E267598Af8fC136e4982A9E";
+const PAIR_B = "0x9FB2471A400CA670F5459829b622A2f4d4824642";
+const MOCK = "0x5cB734B113E31005487D7E4bcA39BCC3e17B8e9A";
+const ROUTER = "0xB342f70D56855F11B0721FcBE2804A200d0F0533";
+const FACTORY = "0x7A27A84f6D79E8f5e2ddb146b78bdBfBf37539E5";
+const SAMPLES = 3;
+
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function transfer_lamports(address to, uint64 lamports) external",
+]);
+const erc20Iface = new Interface([
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function allowance(address owner, address spender) external view returns (uint256)",
+    "function decimals() external view returns (uint8)",
+]);
+const pairIface = new Interface([
+    "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+    "function token0() external view returns (address)",
+    "function token1() external view returns (address)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function nonces(address) external view returns (uint256)",
+    "function DOMAIN_SEPARATOR() external view returns (bytes32)",
+]);
+const routerIface = new Interface([
+    "function swapExactTokensForTokens(uint amountIn, uint amountOutMin, address[] path, address to, uint deadline) external returns (uint[] amounts)",
+    "function addLiquidity(address tokenA, address tokenB, uint amountADesired, uint amountBDesired, uint amountAMin, uint amountBMin, address to, uint deadline) external returns (uint amountA, uint amountB, uint liquidity)",
+    "function removeLiquidity(address tokenA, address tokenB, uint liquidity, uint amountAMin, uint amountBMin, address to, uint deadline) external returns (uint amountA, uint amountB)",
+    "function removeLiquidityWithPermit(address tokenA, address tokenB, uint liquidity, uint amountAMin, uint amountBMin, address to, uint deadline, bool approveMax, uint8 v, bytes32 r, bytes32 s) external returns (uint amountA, uint amountB)",
+    "function getAmountsOut(uint amountIn, address[] path) external view returns (uint[] amounts)",
+]);
+
+async function romeSig(h: string): Promise<string[]> {
+    const r = await fetch(HADRIAN_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [h] }) });
+    return ((await r.json()) as any).result ?? [];
+}
+async function solCu(sig: string): Promise<number> {
+    const r = await fetch(SOLANA_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }) });
+    return ((await r.json()) as any).result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function totalCu(h: string) {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) { sigs = await romeSig(h); if (sigs.length) break; await new Promise(r => setTimeout(r, 2000)); }
+    if (!sigs.length) return { sigs: [], perTx: [], totalCu: 0 };
+    const per: number[] = [];
+    for (const s of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) { cu = await solCu(s); if (cu > 0) break; await new Promise(r => setTimeout(r, 1500)); }
+        per.push(cu);
+    }
+    return { sigs, perTx: per, totalCu: per.reduce((a, b) => a + b, 0) };
+}
+
+interface Op { label: string; samples: any[]; mean: number | "n/a" }
+async function run(label: string, fn: (i: number) => Promise<string>): Promise<Op> {
+    console.log(`\n=== ${label} ===`);
+    const sm: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            const h = await fn(i);
+            const { sigs, perTx, totalCu: cu } = await totalCu(h);
+            const ok = cu > 0 && cu < 1_400_000;
+            console.log(`  ${i+1}/${SAMPLES}: ${h.slice(0,12)}... sigs=${sigs.length} cu=${cu.toLocaleString()} ${ok ? "✓" : (cu >= 1_400_000 ? "✗ over 1.4M" : "✗ no CU")}`);
+            sm.push({ evmHash: h, sigs, perTx, totalCu: cu });
+        } catch (e: any) {
+            const m = (e.message || String(e)).slice(0, 220);
+            const isPreflight = m.includes("-32000") || m.includes("TooManyCompute") || m.includes("insufficient gas");
+            console.log(`  ${i+1}/${SAMPLES}: ✗ ${isPreflight ? "PREFLIGHT REJECT (busts CU)" : "ERROR"} — ${m}`);
+            sm.push({ evmHash: "0x", sigs: [], perTx: [], totalCu: 0, error: m });
+        }
+    }
+    const v = sm.filter(s => s.totalCu > 0);
+    const mean = v.length ? Math.round(v.reduce((a, b) => a + b.totalCu, 0) / v.length) : ("n/a" as const);
+    return { label, samples: sm, mean };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+    console.log(`Deployer: ${wallet.address}`);
+    console.log(`Router:   ${ROUTER}`);
+
+    const v2Art = JSON.parse(fs.readFileSync("deployments/hadrian.real-flow-bench.json", "utf8"));
+    const V2_WBENCH = v2Art.v2.SPL_ERC20_wBench;
+
+    // Setup
+    console.log("\n[setup] PDA top-up...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("swap_gas_to_lamports", [5_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,80)}`); }
+
+    const v1Wusdc = new Contract(V1_WUSDC, erc20Iface, wallet);
+    const v2Wbench = new Contract(V2_WBENCH, erc20Iface, wallet);
+    const mock = new Contract(MOCK, erc20Iface, wallet);
+    const pairA = new Contract(PAIR_A, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+    const pairB = new Contract(PAIR_B, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+    const router = new Contract(ROUTER, routerIface, wallet);
+
+    // Approve canonical Router on all 4 tokens (wUSDC, wBench, MOCK, PairA LP)
+    console.log("[setup] Approve canonical Router on wUSDC + wBench + MOCK + PairA LP + PairB LP...");
+    for (const [name, c] of [["wUSDC", v1Wusdc], ["wBench", v2Wbench], ["MOCK", mock], ["PairA-LP", pairA], ["PairB-LP", pairB]] as const) {
+        try {
+            const cur = await (c as any).allowance(wallet.address, ROUTER);
+            if (cur === 0n) {
+                const tx = await (c as any).approve(ROUTER, 1_000_000_000n, { gasLimit: 15_000_000n });
+                await tx.wait();
+                console.log(`  ${name}.approve(Router): ${tx.hash}`);
+            } else {
+                console.log(`  ${name}.allowance(Router) already ${cur}`);
+            }
+        } catch (e: any) { console.log(`  ${name} approve err: ${e.message?.slice(0,100)}`); }
+    }
+
+    const rA = await pairA.getReserves();
+    const rB = await pairB.getReserves();
+    console.log(`\nPair A reserves: ${rA[0]} / ${rA[1]}`);
+    console.log(`Pair B reserves: ${rB[0]} / ${rB[1]}`);
+    const userLpA = await pairA.balanceOf(wallet.address);
+    console.log(`User LP on Pair A: ${userLpA}`);
+
+    const results: Op[] = [];
+    const NOW_SEC = Math.floor(Date.now() / 1000);
+    const DEADLINE = NOW_SEC + 600;
+
+    // ─── Test 1: canonical router single-hop swap ─────────────────
+    results.push(await run("[canonical] router.swapExactTokensForTokens single-hop (wUSDC→wBench)", async () => {
+        const amts = await router.getAmountsOut(100n, [V1_WUSDC, V2_WBENCH]);
+        const tx = await router.swapExactTokensForTokens(100n, amts[1] * 95n / 100n, [V1_WUSDC, V2_WBENCH], wallet.address, DEADLINE, { gasLimit: 40_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Test 2: canonical router 2-hop swap (PROBABLY busts) ─────────────────
+    results.push(await run("[canonical] router.swapExactTokensForTokens 2-hop (wBench→wUSDC→MOCK)", async () => {
+        const path = [V2_WBENCH, V1_WUSDC, MOCK];
+        const amts = await router.getAmountsOut(100n, path);
+        const tx = await router.swapExactTokensForTokens(100n, amts[2] * 95n / 100n, path, wallet.address, DEADLINE, { gasLimit: 50_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Test 3: canonical router.addLiquidity (post-#364 — does it now fit?) ─────────────────
+    results.push(await run("[canonical] router.addLiquidity (wUSDC × wBench)", async () => {
+        const tx = await router.addLiquidity(V1_WUSDC, V2_WBENCH, 1000n, 1000n, 1n, 1n, wallet.address, DEADLINE, { gasLimit: 80_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Test 4: canonical router.removeLiquidity (2-step: LP-approve + remove) ─────────────
+    results.push(await run("[canonical] router.removeLiquidity (assumes LP pre-approved)", async () => {
+        const lpBal = await pairA.balanceOf(wallet.address);
+        if (lpBal === 0n) throw new Error("no LP balance");
+        const burnAmt = lpBal > 100n ? lpBal / 100n : 1n;  // 1% or 1 wei minimum
+        const tx = await router.removeLiquidity(V1_WUSDC, V2_WBENCH, burnAmt, 1n, 1n, wallet.address, DEADLINE, { gasLimit: 50_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Test 5: canonical removeLiquidityWithPermit — the big one ─────────────
+    results.push(await run("[canonical] router.removeLiquidityWithPermit (1-tx with LP permit signature)", async () => {
+        const lpBal = await pairA.balanceOf(wallet.address);
+        if (lpBal === 0n) throw new Error("no LP balance");
+        const burnAmt = lpBal > 100n ? lpBal / 100n : 1n;
+
+        // Sign EIP-712 permit for the LP token (PairA)
+        const nonce = await pairA.nonces(wallet.address);
+        const chainId = (await provider.getNetwork()).chainId;
+        const domain = {
+            name: "Romeswap V2",  // rome-uniswap-v2/contracts/UniswapV2ERC20.sol uses this
+            version: "1",
+            chainId,
+            verifyingContract: PAIR_A,
+        };
+        const types = {
+            Permit: [
+                { name: "owner",    type: "address" },
+                { name: "spender",  type: "address" },
+                { name: "value",    type: "uint256" },
+                { name: "nonce",    type: "uint256" },
+                { name: "deadline", type: "uint256" },
+            ],
+        };
+        const value = {
+            owner: wallet.address,
+            spender: ROUTER,
+            value: burnAmt,
+            nonce,
+            deadline: DEADLINE,
+        };
+        const sig = await wallet.signTypedData(domain, types, value);
+        const { v, r, s } = (await import("ethers")).Signature.from(sig);
+
+        const tx = await router.removeLiquidityWithPermit(
+            V1_WUSDC, V2_WBENCH, burnAmt, 1n, 1n, wallet.address, DEADLINE,
+            false, v, r, s,
+            { gasLimit: 50_000_000n }
+        );
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Output ─────────────────────────────────────────
+    const out = {
+        network: "hadrian", chainId: 200010, runAt: new Date().toISOString(),
+        router: ROUTER, deployer: wallet.address,
+        results,
+    };
+    fs.writeFileSync("deployments/hadrian.canonical-router.results.json", JSON.stringify(out, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(110));
+    console.log("CANONICAL UNISWAP V2 ROUTER ON HADRIAN — MEAN CU (3 samples)");
+    console.log("=".repeat(110));
+    for (const r of results) {
+        const m = typeof r.mean === "number" ? r.mean.toLocaleString().padStart(12) + " CU" : "        n/a   ";
+        const verdict = typeof r.mean === "number"
+            ? (r.mean < 1_400_000 ? " ✓ FITS 1.4M" : " ✗ BUSTS")
+            : " ✗ failed all samples";
+        console.log(`${r.label.padEnd(78)} ${m}${verdict}`);
+    }
+    console.log("=".repeat(110));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/bench/measure-dex-flows.ts
+++ b/scripts/bench/measure-dex-flows.ts
@@ -1,0 +1,375 @@
+/**
+ * Phase 3 — DEX bench. Romeswap (Uniswap V2 fork) on Hadrian.
+ *
+ * Pair types:
+ *   A. wrapped x wrapped   : wUSDC (v1) x wBench (v2)
+ *   B. wrapped x plain ERC20: wUSDC x MockERC20 (deployed via ERC20Factory)
+ *
+ * Ops per pair:
+ *   - createPair (1 sample; pair creation is idempotent)
+ *   - addLiquidity (3 samples, 3-tx Rome breakdown):
+ *       tokenA.transfer(pair, amtA) -> tokenB.transfer(pair, amtB) -> pair.mint(to)
+ *   - swap (3 samples, 2-tx):
+ *       tokenIn.transfer(pair, amtIn) -> pair.swap(amount0Out, amount1Out, to, "")
+ *   - removeLiquidity (3 samples, 2-tx):
+ *       pair.transfer(pair, lpAmt) -> pair.burn(to)
+ *
+ * Methodology: real production-contract tx -> rome_solanaTxForEvmTx -> Solana
+ * meta.computeUnitsConsumed. For multi-tx flows, sum CU across sub-txs.
+ *
+ * Output: deployments/hadrian.dex-bench.results.json
+ *
+ * Usage:
+ *   export HARDHAT_VAR_HADRIAN_PRIVATE_KEY=...
+ *   npx hardhat run scripts/bench/measure-dex-flows.ts --network hadrian
+ */
+import fs from "node:fs";
+import {
+    Wallet,
+    JsonRpcProvider,
+    Contract,
+    Interface,
+    getAddress,
+} from "ethers";
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009";
+const WITHDRAW_ADDR = "0x4200000000000000000000000000000000000016";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const SAMPLES = 3;
+
+// Existing Hadrian deploys
+const UNI_FACTORY = "0x7A27A84f6D79E8f5e2ddb146b78bdBfBf37539E5";
+const ERC20_FACTORY = "0x283A1d9C1Fa19593070aBe676f03Ca384D31242f";
+const V1_WUSDC = "0x94AC3E5e998d72088045853C1CfB910F6CE90E56";
+// v2 wrapper from real-flow-bench artifact
+const V2_BENCH_ARTIFACT_PATH = "deployments/hadrian.real-flow-bench.json";
+
+// ABIs (minimal — only what we call)
+const factoryIface = new Interface([
+    "function createPair(address tokenA, address tokenB) external returns (address pair)",
+    "function getPair(address tokenA, address tokenB) external view returns (address)",
+]);
+const pairIface = new Interface([
+    "function mint(address to) external returns (uint liquidity)",
+    "function burn(address to) external returns (uint amount0, uint amount1)",
+    "function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external",
+    "function token0() external view returns (address)",
+    "function token1() external view returns (address)",
+    "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function totalSupply() external view returns (uint256)",
+]);
+const erc20Iface = new Interface([
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function decimals() external view returns (uint8)",
+    "function mint_to(address to, uint64 amount, bytes calldata) external returns (bool)",
+]);
+const erc20FactoryIface = new Interface([
+    "function createToken(string memory name, string memory symbol, uint8 decimals, uint64 supply) external returns (address)",
+    "function tokens(string) external view returns (address)",
+]);
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function mint_spl(address to, uint64 amount, bytes32 mint) external",
+    "function create_ata(address user, bytes32 mint) external",
+]);
+const withdrawIface = new Interface([
+    "function withdraw_to_ata(uint256 wei_) external",
+]);
+
+// ─── RPC helpers ──────────────────────────────────────────────────────
+async function romeSig(h: string): Promise<string[]> {
+    const r = await fetch(HADRIAN_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [h] }) });
+    return ((await r.json()) as any).result ?? [];
+}
+async function solCu(sig: string): Promise<number> {
+    const r = await fetch(SOLANA_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }) });
+    return ((await r.json()) as any).result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function txCu(h: string): Promise<number> {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) { sigs = await romeSig(h); if (sigs.length) break; await new Promise(r => setTimeout(r, 2000)); }
+    if (!sigs.length) return 0;
+    let total = 0;
+    for (const s of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) { cu = await solCu(s); if (cu > 0) break; await new Promise(r => setTimeout(r, 1500)); }
+        total += cu;
+    }
+    return total;
+}
+
+interface Op { label: string; samples: any[]; mean: number | "n/a" }
+async function run(label: string, fn: (i: number) => Promise<{ hashes: string[]; cu?: number }>): Promise<Op> {
+    console.log(`\nProbing: ${label}`);
+    const sm: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            const { hashes, cu: precomputed } = await fn(i);
+            let cu = precomputed ?? 0;
+            if (!cu && hashes.length) {
+                for (const h of hashes) cu += await txCu(h);
+            }
+            console.log(`  ${i+1}/${SAMPLES}: ${hashes.length} txs, cu=${cu.toLocaleString()}`);
+            sm.push({ hashes, totalCu: cu });
+        } catch (e: any) {
+            const m = (e.message || String(e)).slice(0, 200);
+            console.log(`  ${i+1}/${SAMPLES}: ERROR ${m}`);
+            sm.push({ hashes: [], totalCu: 0, error: m });
+        }
+    }
+    const valid = sm.filter(s => s.totalCu > 0);
+    const mean = valid.length ? Math.round(valid.reduce((a, b) => a + b.totalCu, 0) / valid.length) : ("n/a" as const);
+    return { label, samples: sm, mean };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+
+    const v2Art = JSON.parse(fs.readFileSync(V2_BENCH_ARTIFACT_PATH, "utf8"));
+    const V2_WBENCH = v2Art.v2.SPL_ERC20_wBench;
+    console.log(`Deployer: ${wallet.address}`);
+    console.log(`v1.wUSDC: ${V1_WUSDC}`);
+    console.log(`v2.wBench: ${V2_WBENCH}`);
+
+    // ────────────────────────────────────────────────────────────────────
+    // SETUP
+    // ────────────────────────────────────────────────────────────────────
+    console.log("\n=== Setup ===");
+
+    // Top up PDA lamports — each pair needs auto-ATA-create for both tokens
+    // (caller-pays rent, ~2M lamports per ATA). 3 ATAs (Pair A wUSDC + wBench;
+    // Pair B wUSDC only) + buffer.
+    console.log("Top up PDA lamports (20M)...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("swap_gas_to_lamports", [20_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,80)}`); }
+
+    // Ensure wUSDC balance (wrap 0.5 USDC from gas)
+    console.log("Wrap 0.5 USDC into v1.wUSDC ATA...");
+    try {
+        await (await wallet.sendTransaction({ to: WITHDRAW_ADDR,
+            data: withdrawIface.encodeFunctionData("withdraw_to_ata", [500_000_000_000_000_000n]),
+            gasLimit: 25_000_000n })).wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,80)}`); }
+
+    // Deploy MockERC20 via existing ERC20Factory
+    console.log("Deploy MockERC20 via ERC20Factory.createToken(name, sym, dec=6, supply=1_000_000)...");
+    const erc20Factory = new Contract(ERC20_FACTORY, erc20FactoryIface, wallet);
+    let mockToken: string;
+    try {
+        // Check if already created
+        const existing = await erc20Factory.tokens("MOCK");
+        if (existing !== "0x0000000000000000000000000000000000000000") {
+            mockToken = existing as string;
+            console.log(`  reusing existing MOCK: ${mockToken}`);
+        } else {
+            const tx = await erc20Factory.createToken("Mock Token", "MOCK", 6, 1_000_000_000_000n /* 1M units at 6 decimals */, { gasLimit: 80_000_000n });
+            const r = await tx.wait();
+            mockToken = await erc20Factory.tokens("MOCK") as string;
+            console.log(`  MOCK deployed: ${mockToken} (tx ${tx.hash})`);
+        }
+    } catch (e: any) {
+        throw new Error(`createToken failed: ${e.message?.slice(0,200)}`);
+    }
+    console.log(`MockERC20 (MOCK): ${mockToken}`);
+
+    // Verify deployer's MOCK balance
+    const mockContract = new Contract(mockToken, erc20Iface, wallet);
+    const mockBal = await mockContract.balanceOf(wallet.address);
+    console.log(`  MOCK balance: ${mockBal.toString()}`);
+    if (mockBal === 0n) throw new Error("Deployer has no MOCK balance — supply allocation failed");
+
+    const factory = new Contract(UNI_FACTORY, factoryIface, wallet);
+    const v1Wusdc = new Contract(V1_WUSDC, erc20Iface, wallet);
+    const v2Wbench = new Contract(V2_WBENCH, erc20Iface, wallet);
+
+    // Verify wUSDC + wBench balances
+    const usdcBal = await v1Wusdc.balanceOf(wallet.address);
+    const benchBal = await v2Wbench.balanceOf(wallet.address);
+    console.log(`  v1.wUSDC balance:  ${usdcBal.toString()}`);
+    console.log(`  v2.wBench balance: ${benchBal.toString()}`);
+
+    // Determine which is token0/token1 for each pair (lexicographic order in Uniswap V2)
+    const wusdcLower = V1_WUSDC.toLowerCase();
+    const wbenchLower = V2_WBENCH.toLowerCase();
+    const mockLower = mockToken.toLowerCase();
+    const pairA_token0 = wusdcLower < wbenchLower ? V1_WUSDC : V2_WBENCH;
+    const pairA_token1 = wusdcLower < wbenchLower ? V2_WBENCH : V1_WUSDC;
+    const pairB_token0 = wusdcLower < mockLower ? V1_WUSDC : mockToken;
+    const pairB_token1 = wusdcLower < mockLower ? mockToken : V1_WUSDC;
+
+    // ────────────────────────────────────────────────────────────────────
+    // BENCH PAIR A: wUSDC x wBench
+    // ────────────────────────────────────────────────────────────────────
+    const results: Op[] = [];
+
+    let pairA: string = await factory.getPair(V1_WUSDC, V2_WBENCH);
+    if (pairA === "0x0000000000000000000000000000000000000000") {
+        console.log(`\n=== Pair A (wUSDC x wBench): creating ===`);
+        const r = await run("[A] createPair(wUSDC x wBench)", async () => {
+            const tx = await factory.createPair(V1_WUSDC, V2_WBENCH, { gasLimit: 120_000_000n });
+            await tx.wait();
+            return { hashes: [tx.hash] };
+        });
+        // Only 1 sample for createPair; ignore the loop's other samples (will reuse existing pair)
+        results.push(r);
+        pairA = await factory.getPair(V1_WUSDC, V2_WBENCH);
+    }
+    console.log(`Pair A address: ${pairA}`);
+
+    let pairB: string = await factory.getPair(V1_WUSDC, mockToken);
+    if (pairB === "0x0000000000000000000000000000000000000000") {
+        console.log(`\n=== Pair B (wUSDC x MOCK): creating ===`);
+        const r = await run("[B] createPair(wUSDC x MOCK)", async () => {
+            const tx = await factory.createPair(V1_WUSDC, mockToken, { gasLimit: 120_000_000n });
+            await tx.wait();
+            return { hashes: [tx.hash] };
+        });
+        results.push(r);
+        pairB = await factory.getPair(V1_WUSDC, mockToken);
+    }
+    console.log(`Pair B address: ${pairB}`);
+
+    // Pair contracts as interfaces
+    const pAContract = new Contract(pairA, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+    const pBContract = new Contract(pairB, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+
+    // ────────────────────────────────────────────────────────────────────
+    // PAIR A FLOWS (wrapped x wrapped)
+    // ────────────────────────────────────────────────────────────────────
+    console.log(`\n=== Pair A: addLiquidity (3-tx Rome breakdown) ===`);
+    results.push(await run("[A] addLiquidity flow (wUSDC x wBench)", async () => {
+        // Each sample uses different small amount to avoid identical-amount nonce collisions.
+        const amtA = 1000n;  // wUSDC raw u64
+        const amtB = 1000n;  // wBench raw u64
+        const t1 = await v1Wusdc.transfer(pairA, amtA, { gasLimit: 20_000_000n });
+        await t1.wait();
+        const t2 = await v2Wbench.transfer(pairA, amtB, { gasLimit: 20_000_000n });
+        await t2.wait();
+        const t3 = await pAContract.mint(wallet.address, { gasLimit: 25_000_000n });
+        await t3.wait();
+        return { hashes: [t1.hash, t2.hash, t3.hash] };
+    }));
+
+    console.log(`\n=== Pair A: swap (2-tx) ===`);
+    results.push(await run("[A] swap flow (wUSDC -> wBench)", async () => {
+        const amtIn = 100n;
+        // Determine which side is wUSDC (token0 vs token1)
+        const isWusdcToken0 = pairA_token0.toLowerCase() === wusdcLower;
+        const t1 = await v1Wusdc.transfer(pairA, amtIn, { gasLimit: 20_000_000n });
+        await t1.wait();
+        // Compute expected out via getReserves (constant product, ignore fee for sizing)
+        const reserves = await pAContract.getReserves();
+        const r0 = reserves[0], r1 = reserves[1];
+        let amount0Out = 0n, amount1Out = 0n;
+        if (isWusdcToken0) {
+            // wUSDC in, wBench out — compute via x*y=k with 0.3% fee
+            const amtInFee = amtIn * 997n;
+            amount1Out = (amtInFee * r1) / (r0 * 1000n + amtInFee);
+        } else {
+            const amtInFee = amtIn * 997n;
+            amount0Out = (amtInFee * r0) / (r1 * 1000n + amtInFee);
+        }
+        const t2 = await pAContract.swap(amount0Out, amount1Out, wallet.address, "0x", { gasLimit: 25_000_000n });
+        await t2.wait();
+        return { hashes: [t1.hash, t2.hash] };
+    }));
+
+    console.log(`\n=== Pair A: removeLiquidity (2-tx) ===`);
+    results.push(await run("[A] removeLiquidity flow (wUSDC x wBench)", async () => {
+        // Burn a small portion of LP
+        const lpBalance = await pAContract.balanceOf(wallet.address);
+        if (lpBalance === 0n) throw new Error("no LP balance — addLiq must run first");
+        const lpToBurn = lpBalance / 10n > 0n ? lpBalance / 10n : 1n;  // 10% or 1 wei minimum
+        const t1 = await pAContract.transfer(pairA, lpToBurn, { gasLimit: 20_000_000n });
+        await t1.wait();
+        const t2 = await pAContract.burn(wallet.address, { gasLimit: 25_000_000n });
+        await t2.wait();
+        return { hashes: [t1.hash, t2.hash] };
+    }));
+
+    // ────────────────────────────────────────────────────────────────────
+    // PAIR B FLOWS (wrapped x plain ERC20)
+    // ────────────────────────────────────────────────────────────────────
+    console.log(`\n=== Pair B: addLiquidity (3-tx) ===`);
+    results.push(await run("[B] addLiquidity flow (wUSDC x MOCK)", async () => {
+        const amtA = 1000n;
+        const amtB = 1000n;
+        const t1 = await v1Wusdc.transfer(pairB, amtA, { gasLimit: 20_000_000n });
+        await t1.wait();
+        const t2 = await mockContract.transfer(pairB, amtB, { gasLimit: 20_000_000n });
+        await t2.wait();
+        const t3 = await pBContract.mint(wallet.address, { gasLimit: 25_000_000n });
+        await t3.wait();
+        return { hashes: [t1.hash, t2.hash, t3.hash] };
+    }));
+
+    console.log(`\n=== Pair B: swap (2-tx) ===`);
+    results.push(await run("[B] swap flow (wUSDC -> MOCK)", async () => {
+        const amtIn = 100n;
+        const isWusdcToken0 = pairB_token0.toLowerCase() === wusdcLower;
+        const t1 = await v1Wusdc.transfer(pairB, amtIn, { gasLimit: 20_000_000n });
+        await t1.wait();
+        const reserves = await pBContract.getReserves();
+        const r0 = reserves[0], r1 = reserves[1];
+        let amount0Out = 0n, amount1Out = 0n;
+        if (isWusdcToken0) {
+            const amtInFee = amtIn * 997n;
+            amount1Out = (amtInFee * r1) / (r0 * 1000n + amtInFee);
+        } else {
+            const amtInFee = amtIn * 997n;
+            amount0Out = (amtInFee * r0) / (r1 * 1000n + amtInFee);
+        }
+        const t2 = await pBContract.swap(amount0Out, amount1Out, wallet.address, "0x", { gasLimit: 25_000_000n });
+        await t2.wait();
+        return { hashes: [t1.hash, t2.hash] };
+    }));
+
+    console.log(`\n=== Pair B: removeLiquidity (2-tx) ===`);
+    results.push(await run("[B] removeLiquidity flow (wUSDC x MOCK)", async () => {
+        const lpBalance = await pBContract.balanceOf(wallet.address);
+        if (lpBalance === 0n) throw new Error("no LP balance");
+        const lpToBurn = lpBalance / 10n > 0n ? lpBalance / 10n : 1n;
+        const t1 = await pBContract.transfer(pairB, lpToBurn, { gasLimit: 20_000_000n });
+        await t1.wait();
+        const t2 = await pBContract.burn(wallet.address, { gasLimit: 25_000_000n });
+        await t2.wait();
+        return { hashes: [t1.hash, t2.hash] };
+    }));
+
+    // ────────────────────────────────────────────────────────────────────
+    // OUTPUT
+    // ────────────────────────────────────────────────────────────────────
+    const out = {
+        network: "hadrian", chainId: 200010, runAt: new Date().toISOString(),
+        methodology: "real production-contract tx -> rome_solanaTxForEvmTx -> Solana CU. multi-tx flows summed.",
+        deployer: wallet.address,
+        pairs: { A: { tokens: [V1_WUSDC, V2_WBENCH], pair: pairA }, B: { tokens: [V1_WUSDC, mockToken], pair: pairB } },
+        mockToken,
+        results,
+    };
+    fs.writeFileSync("deployments/hadrian.dex-bench.results.json", JSON.stringify(out, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(96));
+    console.log("DEX FLOW CU RESULTS (Hadrian, mean of 3 samples for flow ops; 1 sample for createPair)");
+    console.log("=".repeat(96));
+    for (const r of results) {
+        const m = typeof r.mean === "number" ? r.mean.toLocaleString().padStart(12) + " CU" : "n/a".padStart(14);
+        console.log(`${r.label.padEnd(58)} ${m}`);
+    }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/bench/measure-real-flows.ts
+++ b/scripts/bench/measure-real-flows.ts
@@ -1,0 +1,269 @@
+/**
+ * Phase 2 — Measure real-flow CU on Hadrian for v1 vs new.
+ * 9 ops x 2 versions x 3 samples. Real production-contract txs.
+ */
+import fs from "node:fs";
+import {
+    Wallet,
+    JsonRpcProvider,
+    Contract,
+    Interface,
+} from "ethers";
+import wrapperArtifact from "../../artifacts/contracts/erc20spl/erc20spl.sol/SPL_ERC20.json" with { type: "json" };
+import factoryArtifact from "../../artifacts/contracts/erc20spl/erc20spl_factory.sol/ERC20SPLFactory.json" with { type: "json" };
+import withdrawArtifact from "../../artifacts/contracts/bridge/RomeBridgeWithdraw.sol/RomeBridgeWithdraw.json" with { type: "json" };
+
+const HELPER_PROGRAM_ADDRESS = "0xff00000000000000000000000000000000000009";
+const WITHDRAW_ADDRESS = "0x4200000000000000000000000000000000000016";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const ARTIFACT_PATH = "deployments/hadrian.real-flow-bench.json";
+const RESULTS_PATH = "deployments/hadrian.real-flow-bench.results.json";
+const SAMPLES = 3;
+
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function mint_spl(address to, uint64 amount, bytes32 mint) external",
+    "function create_ata(address user, bytes32 mint) external",
+]);
+const withdrawIface = new Interface([
+    "function withdraw_to_ata(uint256 wei_) external",
+]);
+
+async function romeSolToEvm(evmHash: string): Promise<string[]> {
+    const res = await fetch(HADRIAN_RPC, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [evmHash] }),
+    });
+    const body = (await res.json()) as { result?: string[]; error?: { message: string } };
+    if (body.error) throw new Error(`rome_solanaTxForEvmTx: ${body.error.message}`);
+    return body.result ?? [];
+}
+async function getSolanaCu(sig: string): Promise<number> {
+    const res = await fetch(SOLANA_RPC, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }),
+    });
+    const body = (await res.json()) as { result?: { meta?: { computeUnitsConsumed?: number } } };
+    return body.result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function totalCu(evmHash: string): Promise<{ sigs: string[]; perTx: number[]; totalCu: number }> {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) {
+        sigs = await romeSolToEvm(evmHash);
+        if (sigs.length > 0) break;
+        await new Promise(r => setTimeout(r, 2000));
+    }
+    if (sigs.length === 0) throw new Error(`empty Solana sigs for ${evmHash}`);
+    const perTx: number[] = [];
+    for (const sig of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) {
+            cu = await getSolanaCu(sig);
+            if (cu > 0) break;
+            await new Promise(r => setTimeout(r, 1500));
+        }
+        perTx.push(cu);
+    }
+    return { sigs, perTx, totalCu: perTx.reduce((a, b) => a + b, 0) };
+}
+
+interface OpResult { label: string; samples: any[]; mean: number | "n/a" }
+async function runSamples(label: string, exec: (i: number) => Promise<string>): Promise<OpResult> {
+    console.log(`\nProbing: ${label}`);
+    const samples: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            const evmHash = await exec(i);
+            const { sigs, perTx, totalCu: cu } = await totalCu(evmHash);
+            console.log(`  sample ${i+1}/${SAMPLES}: evmTx=${evmHash.slice(0,12)}... sigs=${sigs.length} cu=${cu.toLocaleString()}`);
+            samples.push({ evmHash, sigs, perTx, totalCu: cu });
+        } catch (err: any) {
+            const msg = (err.message || String(err)).slice(0, 200);
+            console.log(`  sample ${i+1}/${SAMPLES}: ERROR - ${msg}`);
+            samples.push({ evmHash: "0x", sigs: [], perTx: [], totalCu: 0, error: msg });
+        }
+    }
+    const valid = samples.filter(s => s.totalCu > 0);
+    const mean = valid.length > 0 ? Math.round(valid.reduce((a, b) => a + b.totalCu, 0) / valid.length) : ("n/a" as const);
+    return { label, samples, mean };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+
+    const art = JSON.parse(fs.readFileSync(ARTIFACT_PATH, "utf8"));
+    const v1 = art.v1, v2 = art.v2;
+    console.log(`Deployer:  ${wallet.address}`);
+
+    // SETUP
+    console.log("\n=== Setup ===");
+    console.log("Top up PDA lamports (10M)...");
+    const sw = await wallet.sendTransaction({
+        to: HELPER_PROGRAM_ADDRESS,
+        data: helperIface.encodeFunctionData("swap_gas_to_lamports", [10_000_000n]),
+        gasLimit: 15_000_000n,
+    });
+    await sw.wait();
+
+    console.log("Wrap 1 USDC into v1.wUSDC ATA...");
+    try {
+        const w = await wallet.sendTransaction({
+            to: WITHDRAW_ADDRESS,
+            data: withdrawIface.encodeFunctionData("withdraw_to_ata", [1_000_000_000_000_000_000n]),
+            gasLimit: 20_000_000n,
+        });
+        await w.wait();
+        console.log(`  ok ${w.hash}`);
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0, 100)}`); }
+
+    console.log("Create deployer's wBench ATA first (mint_spl needs destination ATA)...");
+    try {
+        const cAta = await wallet.sendTransaction({
+            to: HELPER_PROGRAM_ADDRESS,
+            data: helperIface.encodeFunctionData("create_ata", [wallet.address, v2.wBenchMint]),
+            gasLimit: 20_000_000n,
+        });
+        await cAta.wait();
+        console.log(`  ok ${cAta.hash}`);
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0, 200)}`); }
+
+    console.log("Mint 1000 wBench to deployer...");
+    try {
+        const m = await wallet.sendTransaction({
+            to: HELPER_PROGRAM_ADDRESS,
+            data: helperIface.encodeFunctionData("mint_spl", [wallet.address, 1_000_000_000n, v2.wBenchMint]),
+            gasLimit: 20_000_000n,
+        });
+        await m.wait();
+        console.log(`  ok ${m.hash}`);
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0, 200)}`); }
+
+    const v1Wusdc = new Contract(v1.SPL_ERC20_USDC, wrapperArtifact.abi, wallet);
+    const v2Wbench = new Contract(v2.SPL_ERC20_wBench, wrapperArtifact.abi, wallet);
+    const v1Bridge = new Contract(v1.RomeBridgeWithdraw, withdrawArtifact.abi, wallet);
+    const v2Bridge = new Contract(v2.RomeBridgeWithdraw, withdrawArtifact.abi, wallet);
+    const v1Factory = new Contract(v1.ERC20SPLFactory, factoryArtifact.abi, wallet);
+    const v2Factory = new Contract(v2.ERC20SPLFactory, factoryArtifact.abi, wallet);
+
+    const { getAddress } = await import("ethers");
+    const RECIPIENT = getAddress("0x000000000000000000000000000000000000dead");
+    const SPENDER = getAddress("0x000000000000000000000000000000000000face");
+    const SOLANA_DEST = "0x" + "ab".repeat(32);
+    const ETH_RECIPIENT = getAddress("0x000000000000000000000000000000000000beef");
+
+    const results: OpResult[] = [];
+
+    results.push(await runSamples("[v1] SPL_ERC20.transfer", async () => {
+        const tx = await v1Wusdc.transfer(RECIPIENT, 1n, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] SPL_ERC20.transfer", async () => {
+        const tx = await v2Wbench.transfer(RECIPIENT, 1n, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] SPL_ERC20.approve", async (i) => {
+        const tx = await v1Wusdc.approve(SPENDER, 100n + BigInt(i), { gasLimit: 15_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] SPL_ERC20.approve", async (i) => {
+        const tx = await v2Wbench.approve(SPENDER, 100n + BigInt(i), { gasLimit: 15_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] SPL_ERC20.transferFrom (self-allowance)", async () => {
+        await (await v1Wusdc.approve(wallet.address, 100n, { gasLimit: 15_000_000n })).wait();
+        const tx = await v1Wusdc.transferFrom(wallet.address, RECIPIENT, 1n, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] SPL_ERC20.transferFrom (self-allowance)", async () => {
+        await (await v2Wbench.approve(wallet.address, 100n, { gasLimit: 15_000_000n })).wait();
+        const tx = await v2Wbench.transferFrom(wallet.address, RECIPIENT, 1n, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] SPL_ERC20.bridgeOutToSolana", async () => {
+        const tx = await v1Wusdc.bridgeOutToSolana(SOLANA_DEST, 1n, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] SPL_ERC20.bridgeOutToSolana", async () => {
+        const tx = await v2Wbench.bridgeOutToSolana(SOLANA_DEST, 1n, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] RomeBridgeWithdraw.approveBurnETH", async (i) => {
+        const tx = await v1Bridge.approveBurnETH(100n + BigInt(i), { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] RomeBridgeWithdraw.approveBurnETH", async (i) => {
+        const tx = await v2Bridge.approveBurnETH(100n + BigInt(i), { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] RomeBridgeWithdraw.burnETH", async () => {
+        await (await v1Bridge.approveBurnETH(1000n, { gasLimit: 20_000_000n })).wait();
+        const tx = await v1Bridge.burnETH(1n, ETH_RECIPIENT, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] RomeBridgeWithdraw.burnETH", async () => {
+        await (await v2Bridge.approveBurnETH(1000n, { gasLimit: 20_000_000n })).wait();
+        const tx = await v2Bridge.burnETH(1n, ETH_RECIPIENT, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] RomeBridgeWithdraw.burnUSDC", async () => {
+        const tx = await v1Bridge.burnUSDC(1n, ETH_RECIPIENT, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] RomeBridgeWithdraw.burnUSDC", async () => {
+        const tx = await v2Bridge.burnUSDC(1n, ETH_RECIPIENT, { gasLimit: 25_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] ERC20SPLFactory.create_token_mint", async () => {
+        const tx = await v1Factory.create_token_mint({ gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] ERC20SPLFactory.create_token_mint", async () => {
+        const tx = await v2Factory.create_token_mint({ gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    results.push(await runSamples("[v1] ERC20SPLFactory.init_token_mint", async () => {
+        const [mintToInit] = await v1Factory.get_current_mint(wallet.address) as [string, string];
+        await (await v1Factory.create_token_mint({ gasLimit: 20_000_000n })).wait();
+        const tx = await v1Factory.init_token_mint(mintToInit, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+    results.push(await runSamples("[v2] ERC20SPLFactory.init_token_mint", async () => {
+        const [mintToInit] = await v2Factory.get_current_mint(wallet.address) as [string, string];
+        await (await v2Factory.create_token_mint({ gasLimit: 20_000_000n })).wait();
+        const tx = await v2Factory.init_token_mint(mintToInit, { gasLimit: 20_000_000n });
+        await tx.wait(); return tx.hash;
+    }));
+
+    const out = {
+        network: "hadrian", chainId: 200010, runAt: new Date().toISOString(),
+        methodology: "submit production-contract tx -> rome_solanaTxForEvmTx -> Solana getTransaction -> meta.computeUnitsConsumed",
+        deployer: wallet.address, v1Addresses: v1, v2Addresses: v2, results,
+    };
+    fs.writeFileSync(RESULTS_PATH, JSON.stringify(out, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(96));
+    console.log("REAL-FLOW CU RESULTS (Hadrian, mean of 3 samples)");
+    console.log("=".repeat(96));
+    for (const r of results) {
+        const m = typeof r.mean === "number" ? r.mean.toLocaleString().padStart(10) + " CU" : "n/a".padStart(10);
+        console.log(`${r.label.padEnd(58)} ${m}`);
+    }
+    console.log(`\nResults: ${RESULTS_PATH}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/bench/measure-romeswap-direct.ts
+++ b/scripts/bench/measure-romeswap-direct.ts
@@ -1,0 +1,234 @@
+/**
+ * Hypothesis: can `RomeswapDirect.addLiq` fit in 1 Solana tx?
+ *
+ * The Rome-required 3-tx addLiquidity breakdown comes from router overhead
+ * (slippage, optimal-amounts, path math) busting 1.4M CU. With a minimal
+ * direct router that takes pre-computed amounts and just does
+ * transferFrom x2 + pair.mint inline, the per-op cost should be:
+ *   ~262K (wrapper.transferFrom) x 2 + ~300K (pair.mint) + envelope
+ *   = ~830K-900K CU. Should fit.
+ *
+ * This script deploys RomeswapDirect, sets allowances, pre-inits Pair A
+ * with a seed mint (not counted as sample), then runs 3 single-tx addLiq
+ * samples. If addLiq fits, also benches swap + removeLiq.
+ *
+ * Output: deployments/hadrian.romeswap-direct.results.json
+ */
+import fs from "node:fs";
+import {
+    Wallet, JsonRpcProvider, Contract, Interface, ContractFactory, getAddress,
+} from "ethers";
+import directArtifact from "../../artifacts/contracts/cpi/test/RomeswapDirect.sol/RomeswapDirect.json" with { type: "json" };
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009";
+const SOLANA_RPC = "https://api.devnet.solana.com/";
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const SAMPLES = 3;
+
+const V1_WUSDC = "0x94AC3E5e998d72088045853C1CfB910F6CE90E56";
+const PAIR_A = "0x45350dF36fA7334C2E267598Af8fC136e4982A9E"; // wUSDC x wBench
+
+const helperIface = new Interface([
+    "function swap_gas_to_lamports(uint64 lamports) external",
+    "function transfer_lamports(address to, uint64 lamports) external",
+]);
+const erc20Iface = new Interface([
+    "function transfer(address to, uint256 amount) external returns (bool)",
+    "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
+    "function approve(address spender, uint256 amount) external returns (bool)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function allowance(address owner, address spender) external view returns (uint256)",
+]);
+const pairIface = new Interface([
+    "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+    "function token0() external view returns (address)",
+    "function balanceOf(address) external view returns (uint256)",
+    "function totalSupply() external view returns (uint256)",
+]);
+
+async function romeSig(h: string): Promise<string[]> {
+    const r = await fetch(HADRIAN_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rome_solanaTxForEvmTx", params: [h] }) });
+    return ((await r.json()) as any).result ?? [];
+}
+async function solCu(sig: string): Promise<number> {
+    const r = await fetch(SOLANA_RPC, { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransaction",
+            params: [sig, { maxSupportedTransactionVersion: 0, commitment: "confirmed" }] }) });
+    return ((await r.json()) as any).result?.meta?.computeUnitsConsumed ?? 0;
+}
+async function totalCu(h: string) {
+    let sigs: string[] = [];
+    for (let i = 0; i < 30; i++) { sigs = await romeSig(h); if (sigs.length) break; await new Promise(r => setTimeout(r, 2000)); }
+    if (!sigs.length) throw new Error(`empty sigs for ${h}`);
+    const per: number[] = [];
+    for (const s of sigs) {
+        let cu = 0;
+        for (let i = 0; i < 10; i++) { cu = await solCu(s); if (cu > 0) break; await new Promise(r => setTimeout(r, 1500)); }
+        per.push(cu);
+    }
+    return { sigs, perTx: per, totalCu: per.reduce((a, b) => a + b, 0) };
+}
+
+interface Op { label: string; samples: any[]; mean: number | "n/a" }
+async function run(label: string, fn: (i: number) => Promise<string>): Promise<Op> {
+    console.log(`\nProbing: ${label}`);
+    const sm: any[] = [];
+    for (let i = 0; i < SAMPLES; i++) {
+        try {
+            const h = await fn(i);
+            const { sigs, perTx, totalCu: cu } = await totalCu(h);
+            console.log(`  ${i+1}/${SAMPLES}: ${h.slice(0,12)}... sigs=${sigs.length} cu=${cu.toLocaleString()}`);
+            sm.push({ evmHash: h, sigs, perTx, totalCu: cu });
+        } catch (e: any) {
+            const m = (e.message || String(e)).slice(0, 250);
+            console.log(`  ${i+1}/${SAMPLES}: ERROR ${m}`);
+            sm.push({ evmHash: "0x", sigs: [], perTx: [], totalCu: 0, error: m });
+        }
+    }
+    const v = sm.filter(s => s.totalCu > 0);
+    const mean = v.length ? Math.round(v.reduce((a, b) => a + b.totalCu, 0) / v.length) : ("n/a" as const);
+    return { label, samples: sm, mean };
+}
+
+async function main() {
+    const provider = new JsonRpcProvider(HADRIAN_RPC);
+    const pk = process.env.HARDHAT_VAR_HADRIAN_PRIVATE_KEY;
+    if (!pk) throw new Error("Missing HARDHAT_VAR_HADRIAN_PRIVATE_KEY");
+    const wallet = new Wallet(pk, provider);
+    console.log(`Deployer: ${wallet.address}`);
+
+    const v2Art = JSON.parse(fs.readFileSync("deployments/hadrian.real-flow-bench.json", "utf8"));
+    const V2_WBENCH = v2Art.v2.SPL_ERC20_wBench;
+    console.log(`Pair A:   ${PAIR_A} (wUSDC x wBench)`);
+    console.log(`wUSDC:    ${V1_WUSDC}`);
+    console.log(`wBench:   ${V2_WBENCH}`);
+
+    // ─── Setup: top up PDA lamports ──────────────────────────────────────
+    console.log("\n[setup] Top up PDA lamports (10M)...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("swap_gas_to_lamports", [10_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+    } catch (e: any) { console.log(`  skip: ${e.message?.slice(0,100)}`); }
+
+    // ─── Deploy RomeswapDirect ───────────────────────────────────────────
+    console.log("\n[deploy] RomeswapDirect...");
+    const factory = new ContractFactory(directArtifact.abi, directArtifact.bytecode, wallet);
+    const direct = await factory.deploy();
+    await direct.waitForDeployment();
+    const directAddr = await direct.getAddress();
+    console.log(`        RomeswapDirect: ${directAddr}`);
+
+    const directContract = new Contract(directAddr, directArtifact.abi, wallet);
+
+    // ─── Top up directContract's PDA — caller pays for auto-ATA-create rent ─
+    // Each pair the contract touches needs ~5M lamports for the bootstrap
+    // (pair's external_auth PDA + tokenA ATA + tokenB ATA = ~3 accounts).
+    console.log("\n[setup] Top up directContract's PDA via HelperProgram.transfer_lamports(directContract, 15M)...");
+    try {
+        await (await wallet.sendTransaction({ to: HELPER_PROGRAM,
+            data: helperIface.encodeFunctionData("transfer_lamports", [directAddr, 15_000_000n]),
+            gasLimit: 15_000_000n })).wait();
+        console.log(`  ok`);
+    } catch (e: any) { console.log(`  err: ${e.message?.slice(0,200)}`); }
+    const v1Wusdc = new Contract(V1_WUSDC, erc20Iface, wallet);
+    const v2Wbench = new Contract(V2_WBENCH, erc20Iface, wallet);
+    const pairA = new Contract(PAIR_A, [...pairIface.fragments, ...erc20Iface.fragments], wallet);
+
+    // ─── Approve RomeswapDirect on both tokens + the pair LP ──────────────
+    console.log("\n[setup] Approve RomeswapDirect on wUSDC + wBench + pair LP...");
+    const LARGE = 1_000_000_000n;
+    try {
+        await (await v1Wusdc.approve(directAddr, LARGE, { gasLimit: 15_000_000n })).wait();
+        await (await v2Wbench.approve(directAddr, LARGE, { gasLimit: 15_000_000n })).wait();
+        await (await pairA.approve(directAddr, LARGE, { gasLimit: 15_000_000n })).wait();
+        console.log(`  approves done`);
+    } catch (e: any) { console.log(`  approve err: ${e.message?.slice(0,200)}`); }
+
+    // ─── Seed-init Pair A via 3-tx breakdown (cold-bootstrap fits CU when split) ─
+    // The cold case needs pair PDA + both ATAs created. Doing this in 1 tx
+    // busts CU. Split across 3 txs (deployer-pays-rent path) to safely warm
+    // the pair, then bench the single-tx addLiq against the warm state.
+    const reserves0 = await pairA.getReserves();
+    if (reserves0[0] === 0n && reserves0[1] === 0n) {
+        console.log("\n[setup] Seed-init Pair A via 3-tx breakdown (100K wUSDC + 100K wBench)...");
+        try {
+            const t1 = await v1Wusdc.transfer(PAIR_A, 100_000n, { gasLimit: 30_000_000n });
+            await t1.wait();
+            console.log(`  tx1 wUSDC.transfer: ${t1.hash}`);
+            const t2 = await v2Wbench.transfer(PAIR_A, 100_000n, { gasLimit: 30_000_000n });
+            await t2.wait();
+            console.log(`  tx2 wBench.transfer: ${t2.hash}`);
+            const t3 = await pairA.mint(wallet.address, { gasLimit: 30_000_000n });
+            await t3.wait();
+            console.log(`  tx3 pair.mint: ${t3.hash}`);
+            const r = await pairA.getReserves();
+            console.log(`  reserves after seed: ${r[0]} / ${r[1]}`);
+        } catch (e: any) {
+            console.log(`  SEED FAILED: ${e.message?.slice(0,300)}`);
+        }
+    } else {
+        console.log(`\n[setup] Pair A already has reserves: ${reserves0[0]} / ${reserves0[1]}`);
+    }
+
+    // ─── BENCH: addLiq (1-tx) ────────────────────────────────────────────
+    const results: Op[] = [];
+    results.push(await run("[direct] addLiq (1-tx, wUSDC x wBench, post-init)", async () => {
+        const tx = await directContract.addLiq(V1_WUSDC, V2_WBENCH, PAIR_A, 1000n, 1000n, wallet.address, { gasLimit: 60_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── BENCH: swap (1-tx, wUSDC → wBench) ──────────────────────────────
+    results.push(await run("[direct] swap (1-tx, wUSDC -> wBench)", async () => {
+        const amtIn = 100n;
+        const res = await pairA.getReserves();
+        const t0 = await pairA.token0() as string;
+        const isUsdc0 = t0.toLowerCase() === V1_WUSDC.toLowerCase();
+        const r0 = res[0], r1 = res[1];
+        const amtInFee = amtIn * 997n;
+        let amount0Out = 0n, amount1Out = 0n;
+        if (isUsdc0) {
+            amount1Out = (amtInFee * r1) / (r0 * 1000n + amtInFee);
+        } else {
+            amount0Out = (amtInFee * r0) / (r1 * 1000n + amtInFee);
+        }
+        const tx = await directContract.swap(V1_WUSDC, PAIR_A, amtIn, amount0Out, amount1Out, wallet.address, { gasLimit: 60_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── BENCH: removeLiq (1-tx) ─────────────────────────────────────────
+    results.push(await run("[direct] removeLiq (1-tx, wUSDC x wBench)", async () => {
+        const lp = await pairA.balanceOf(wallet.address) as bigint;
+        if (lp === 0n) throw new Error("no LP in deployer; seed-init or earlier addLiq must run first");
+        const lpToBurn = lp / 100n > 0n ? lp / 100n : 1n; // 1% of LP
+        const tx = await directContract.removeLiq(PAIR_A, lpToBurn, wallet.address, { gasLimit: 60_000_000n });
+        await tx.wait();
+        return tx.hash;
+    }));
+
+    // ─── Output ──────────────────────────────────────────────────────────
+    const out = {
+        network: "hadrian", chainId: 200010, runAt: new Date().toISOString(),
+        methodology: "RomeswapDirect single-tx wrappers. Pre-computed amounts. transferFrom x2 + pair.X inline.",
+        deployer: wallet.address, directContract: directAddr, pairA: PAIR_A,
+        tokens: { wUSDC: V1_WUSDC, wBench: V2_WBENCH },
+        results,
+    };
+    fs.writeFileSync("deployments/hadrian.romeswap-direct.results.json", JSON.stringify(out, null, 2) + "\n");
+
+    console.log("\n" + "=".repeat(96));
+    console.log("ROMESWAP-DIRECT SINGLE-TX RESULTS (Hadrian)");
+    console.log("=".repeat(96));
+    for (const r of results) {
+        const m = typeof r.mean === "number" ? r.mean.toLocaleString().padStart(12) + " CU" : "n/a".padStart(14);
+        const verdict = typeof r.mean === "number"
+            ? (r.mean < 1_400_000 ? " ✓ FITS 1.4M" : " ✗ EXCEEDS 1.4M")
+            : "";
+        console.log(`${r.label.padEnd(56)} ${m}${verdict}`);
+    }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Phase 2 of the universal-delegation CU benchmark. Where Phase 1 ([#170](https://github.com/rome-protocol/rome-solidity/pull/170)) measured **primitive-level** CU savings for A1-A6 selectors, this PR measures **real production-contract flow-level** CU on Hadrian by deploying NEW (post-#165/#166/#167/#168/#169) versions side-by-side with v1 (currently deployed) contracts and benchmarking user-facing ops.

## Headline real-flow numbers (Hadrian, mean of 3 samples)

| Op | v1 CU | v2 CU | Save | % |
|---|---:|---:|---:|---:|
| `SPL_ERC20.transfer` | 261,432 | 262,724 | +1,292 | +0.5% (no regression ✓) |
| `SPL_ERC20.approve` | 414,104 | 211,997 | **−202,107** | **−48.8%** |
| `SPL_ERC20.transferFrom` (self-allowance) | 258,015 | 263,313 | +5,298 | +2.1% (no regression ✓) |
| `SPL_ERC20.bridgeOutToSolana` | 582,407 | 351,968 | **−230,439** | **−39.6%** |
| `RomeBridgeWithdraw.burnUSDC` | 952,642 | 799,637 | **−153,005** | **−16.1%** |
| `ERC20SPLFactory.create_token_mint` | 460,082 | 198,706 | **−261,376** | **−56.8%** |

**Expected-vs-measured alignment:**
- `transfer` / `transferFrom`: migrated in #143/#163, no further savings expected → confirmed (≤2% noise)
- `approve`: v1's deployed bytecode predates #163 → still uses `SplTokenLib.approve + invoke_signed` → A1-A2-era selector dispatch shaves ~50%
- `bridgeOutToSolana`: A1 `create_ata_for_key` collapses ATA-create leg → big win
- `burnUSDC`: A3 `pda_with_salt` collapses CCTP message-PDA derive → matches Phase 1 primitive saving (~93K) plus other path simplifications
- `create_token_mint`: A4 `create_mint_account` collapses `SystemProgramLib.create_account + invoke_signed` → biggest %-win

## Architecture — Option B (side-by-side)

| Layer | v1 (currently deployed on Hadrian) | v2 (deployed this PR) |
|---|---|---|
| `ERC20SPLFactory` | `0x21cc267f…` | `0xfF96ab9E…` (deploys own ERC20Users) |
| `SPL_ERC20` for the bench | `0x94AC3E5e…` (wUSDC) | `0xD39EC36a…` (wBench wraps a fresh mint; deployer minted supply via `HelperProgram.mint_spl`) |
| `RomeBridgeWithdraw` | `0xf48902e4…` | `0xAa457897…` (constructor reuses v1's wUSDC + wETH wrappers so bridges share state) |

Why NEW.SPL_ERC20 wraps a fresh mint instead of v1's wUSDC: separate wrapper contracts own separate Solana PDAs which own separate ATAs — there's no way to share v1's wUSDC SPL balance with a new wrapper. The wrapper-level operations (transfer/approve/transferFrom/bridgeOutToSolana) have identical code paths regardless of underlying mint, so the CU comparison is fair.

## Unmeasured this run

- `RomeBridgeWithdraw.approveBurnETH` / `burnETH` — deployer has no wETH balance on Hadrian. Bridging in ETH from Sepolia would take ~10-15 min; deferred to a follow-up. Phase 1 primitive measurements (A2 −154K + A3 ×2 = −187K) gives expected −241K CU per Wormhole outbound bridge.
- `ERC20SPLFactory.init_token_mint` — partial (1/3 v1 samples captured; v2 errored). Likely deployer PDA lamport reserve exhausted after multiple `create_token_mint` calls. Future runs should top up more aggressively.

## Test plan

- [x] 3 NEW contracts deployed cleanly on Hadrian (5/5 setup steps in the deploy script)
- [x] 6 of 9 flows captured with 3-sample data on both v1 and v2
- [x] Per-sample EVM tx hashes + Solana sigs preserved in artifact JSON
- [x] No regression on already-migrated ops (`transfer`, `transferFrom`)
- [ ] Re-run for `burnETH/approveBurnETH` after bridging in wETH
- [ ] Re-run for `init_token_mint` with larger PDA lamport top-up

## Replay

```bash
export HARDHAT_VAR_HADRIAN_PRIVATE_KEY=...
npx hardhat run scripts/bench/deploy-real-flow-v2.ts --network hadrian
npx hardhat run scripts/bench/measure-real-flows.ts --network hadrian
```

## Cross-references

- [#170](https://github.com/rome-protocol/rome-solidity/pull/170) — Phase 1 primitive-level Tier 3 bench
- [rome-evm-private #364](https://github.com/rome-protocol/rome-evm-private/pull/364) — A1-A6 selectors
- [rome-solidity #165](https://github.com/rome-protocol/rome-solidity/pull/165) — A1/A2/A3 consumer migration
- [rome-solidity #166](https://github.com/rome-protocol/rome-solidity/pull/166) — A4/A5 factory migration
- [rome-specs #89](https://github.com/rome-protocol/rome-specs/pull/89) — primitive CU baseline (Tier 3 rows)