### PR TITLE
fix(bootstrap-wrappers): add hadrian to DEVNET_NETWORKS

### DIFF
--- a/scripts/bridge/bootstrap-bridged-wrappers.ts
+++ b/scripts/bridge/bootstrap-bridged-wrappers.ts
@@ -48,7 +48,7 @@ const MAINNET_SET: WrapperSpec[] = [
 // SPL_MINTS_MAINNET. Update this list whenever a new chain is brought up.
 // Override via `BRIDGED_SET=devnet|mainnet` env var for one-off cases.
 const DEVNET_NETWORKS = new Set([
-  "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "augustus", "local",
+  "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "augustus", "hadrian", "local",
 ]);
 
 function resolveSet(networkName: string): WrapperSpec[] {


### PR DESCRIPTION
## Summary

One-line fix: `scripts/bridge/bootstrap-bridged-wrappers.ts:50-52` `DEVNET_NETWORKS` set was missing `hadrian` (chain 200010, testnet on Solana devnet). `resolveSet()` defaults unlisted networks to `SPL_MINTS_MAINNET`, which on Solana devnet either silently registers wrong mints or fails at the on-chain `add_spl_token_no_metadata` CPI.

Workaround until now was `BRIDGED_SET=devnet` env override — easy to forget when running `scripts/deploy-solidity.sh deploy-stack hadrian devnet` step 6.

## Why now

Unblocks Phase 2 of the [rome-ui precompile rewire + Hadrian redeploy plan](https://github.com/rome-protocol/rome-specs/blob/main/active/technical/2026-05-18-rome-ui-precompile-rewire-redeploy-plan.md). Phase 2 step 6 = `bootstrap-bridged-wrappers` on Hadrian; with `hadrian` in the set, the script picks the right mint set without env juggling.

## Test plan

- [ ] Local repro: `npx hardhat compile` (no functional contract change)
- [ ] Render check on GitHub diff
- [ ] Phase 2 execution will validate end-to-end on Hadrian