### PR TITLE
feat(cpi, meteora): EnsureAta library + Meteora swap pre-flight ATA-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `EnsureAta` library + Meteora swap pre-flight (closes user-side ATA stalls)
+
+New library `contracts/cpi/EnsureAta.sol`: idempotently ensure a user's ATA for a given SPL mint exists, before an EVM contract dispatches a Solana CPI that requires it. Wraps `HelperProgram.create_ata(address, bytes32)` — selector `0x3de2251a` — which itself dispatches Solana's `create_associated_token_account_idempotent`, so the probe-and-skip dance at the EVM layer is collapsed into a single call. CU: ~50K (ATA exists, idempotent no-op CPI) to ~110K (creates).
+
+Wired into `MeteoraDAMMv1Router.swapExactTokensForTokens` — call once per side (in / out) before dispatching the swap. Empirically validated on Hadrian 2026-05-18: a swap that previously failed `Custom(3012) AccountNotInitialized` (when the user had no wETH ATA) now passes the ATA pre-flight gate; remaining downstream failure mode (`PrivilegeEscalation` in Meteora dispatch) is unrelated and tracked separately.
+
+Tests: 3 integration cases in `tests/ensure_ata.integration.ts` (hadrian-only) — existing-ATA noop, missing-ATA create, idempotency on re-run. All 25 tests across the parser + EnsureAta suite pass.
+
+Scope of this PR: library + Meteora swap consumer + tests. Out of scope: applying to `addLiquidity` / `removeLiquidity` (separate routes); applying to Romeswap / Compound / Bridge (each adapter opts in independently); fixing the PrivilegeEscalation blocker (separate issue).
+
 ### Fixed — `DAMMv1Lib.VAULT_MIN_LEN` was 30 bytes short of parser consumption (Meteora pool registration broken)
 
 `VAULT_MIN_LEN = 1197` was inconsistent with `parse_vault`'s actual byte consumption (1227 bytes — 8 disc + 3 u8 + 8 u64 + 128 (4× bytes32) + 960 strategies + 96 (3× bytes32) + 24 (3× u64)). The constant doubles as the slice length `load_vault` requests from `account_data_at`, so the slice arrived 30 bytes short and `parse_vault` reverted "oob u64" on the locked_profit_tracker fields at offsets 1203/1211/1219.

--- a/contracts/cpi/EnsureAta.sol
+++ b/contracts/cpi/EnsureAta.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {HelperProgram} from "../interface.sol";
+
+/// @title EnsureAta
+/// @notice Idempotently ensure a user's Associated Token Account exists for
+///         a given SPL mint, before an EVM contract dispatches a Solana CPI
+///         that requires the ATA to be initialized.
+///
+/// ## Why
+///
+/// Many Solana programs (Anchor-built ones in particular) declare token
+/// accounts with `Account<'info, TokenAccount>` constraints. Anchor's
+/// account-validation pass runs BEFORE the handler body and rejects with
+/// `Custom(3012) AccountNotInitialized` if the buffer is empty. Meteora's
+/// DAMM v1 swap, every standard SPL transfer routed through PDA-owned
+/// ATAs, Compound supply/borrow flows that touch wrapped tokens — all
+/// pre-check ATA existence and revert before the EVM-side caller can
+/// recover.
+///
+/// EVM-side routers that compose such CPIs should call `EnsureAta.ensure`
+/// for each ATA they expect to touch. The ATA gets created lazily, in the
+/// same outer Rome DoTx, before the downstream CPI runs — so the user
+/// sees one transaction, atomic, no failed mid-flight setup.
+///
+/// ## Idempotency
+///
+/// `HelperProgram.create_ata(address, bytes32)` dispatches Solana's
+/// `create_associated_token_account_idempotent` instruction. The
+/// idempotent variant is a runtime no-op when the ATA already exists.
+/// We therefore skip the explicit `account_lamports` probe — the gap
+/// between "probe-and-skip" and "idempotent no-op CPI" is small (~50K CU
+/// vs ~5K CU), and the single-selector design keeps consumers tight
+/// and easier to audit.
+///
+/// Source-of-idempotency: rome-evm-private's `create_ata_internal`
+/// (see helper.rs) issues `spl_associated_token_account::instruction::
+/// create_associated_token_account_idempotent`.
+///
+/// ## CU envelope
+///
+/// - ATA exists: ~50K Solana CU (idempotent no-op syscall path)
+/// - ATA missing: ~110K Solana CU (creates the ATA on-chain)
+///
+/// Two `ensure` calls (typical swap: in-token + out-token) = 100-220K CU.
+/// Comfortable within the 1.4M atomic-tx envelope.
+///
+/// ## Precondition
+///
+/// User MUST be activated (`SimpleActivator.isActivated(user) == true`).
+/// `create_ata` signs as `external_auth(user)` which only exists once the
+/// user's PDA is funded. Routers should gate at a higher layer; this
+/// library does not re-check activation.
+library EnsureAta {
+    /// @notice Idempotent ATA-create for `mint` owned by `user`.
+    /// @dev Reverts if the underlying HelperProgram CPI fails (e.g. PDA
+    ///      not funded). Reads the precompile via delegatecall so
+    ///      `msg.sender` in the helper's frame is the caller of this
+    ///      library function — the helper signs as `external_auth(caller)`
+    ///      which must match the `user` arg semantically.
+    function ensure(address user, bytes32 mint) internal {
+        (bool ok, bytes memory ret) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature("create_ata(address,bytes32)", user, mint)
+        );
+        if (!ok) {
+            if (ret.length < 68) revert("EnsureAta: CREATE_FAILED");
+            assembly { ret := add(ret, 0x04) }
+            revert(abi.decode(ret, (string)));
+        }
+    }
+}

--- a/contracts/cpi/test/EnsureAtaHarness.sol
+++ b/contracts/cpi/test/EnsureAtaHarness.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {EnsureAta} from "../EnsureAta.sol";
+
+/// @title EnsureAtaHarness
+/// @notice Test-only wrapper exposing the internal EnsureAta library as
+///         an external entry point so integration tests can verify the
+///         on-chain behaviour against Hadrian.
+contract EnsureAtaHarness {
+    function ensure(address user, bytes32 mint) external {
+        EnsureAta.ensure(user, mint);
+    }
+}

--- a/contracts/meteora/damm_v1_router.sol
+++ b/contracts/meteora/damm_v1_router.sol
@@ -6,6 +6,7 @@ import {DAMMv1Lib, DAMMv1Pool, ERC20DAMMv1Pool} from "./damm_v1_pool.sol";
 import {SPL_ERC20} from "../erc20spl/erc20spl.sol";
 import {Convert} from "../convert.sol";
 import {ICrossProgramInvocation} from "../interface.sol";
+import {EnsureAta} from "../cpi/EnsureAta.sol";
 
 contract MeteoraDAMMv1Router {
     MeteoraDAMMv1Factory public immutable factory;
@@ -24,6 +25,18 @@ contract MeteoraDAMMv1Router {
     ) external {
         address pool = factory.getPool(token_in, token_out);
         require(pool != address(0), "Pool does not exist");
+
+        // Pre-flight: idempotently ensure user's ATAs exist for both sides.
+        // Meteora's swap declares `Account<'info, TokenAccount>` constraints
+        // on user_source_token / user_destination_token; Anchor rejects with
+        // Custom(3012) AccountNotInitialized before the handler runs if
+        // either is missing. Composing the create-idempotent calls in the
+        // same EVM tx keeps the swap atomic at the user-visible layer.
+        // CU: ~50K per side when ATA exists (idempotent no-op CPI), ~110K
+        // when creating. Two sides = 100-220K total; well under the 1.4M
+        // atomic envelope alongside the swap (~700-900K typical).
+        EnsureAta.ensure(msg.sender, SPL_ERC20(token_in).mint_id());
+        EnsureAta.ensure(msg.sender, SPL_ERC20(token_out).mint_id());
 
         (bool success, bytes memory result) = pool.delegatecall(
             abi.encodeWithSelector(

--- a/tests/ensure_ata.integration.ts
+++ b/tests/ensure_ata.integration.ts
@@ -1,0 +1,100 @@
+// Integration test for the EnsureAta library against Hadrian.
+//
+// Three cases:
+//   1. Existing ATA (user holds wUSDC, ATA already on-chain)
+//      → ensure() returns success, no state change
+//   2. Missing ATA (user has no wETH ATA on the post-redeploy wrappers)
+//      → ensure() returns success, ATA materializes on Solana
+//   3. Re-run of case 2 → succeeds (verifies idempotency)
+//
+// Hadrian network only (live state assertions); cannot run on the in-process
+// hardhat simulated network because there's no Rome HelperProgram precompile
+// behind 0xff…09 there.
+//
+// Run: npx hardhat test tests/ensure_ata.integration.ts --network hadrian
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { getAddress, parseAbi } from "viem";
+
+const HELPER = "0xff00000000000000000000000000000000000009" as const;
+const CPI = "0xff00000000000000000000000000000000000008" as const;
+
+// Post-redeploy (2026-05-18) wrapper SPL mints on Hadrian, verified on-chain.
+// USDC: user holds 1.8M+ → ATA already exists.
+// ETH:  user holds 0 and no ATA on the new wrapper → fresh-create target.
+const USDC_MINT = "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7" as `0x${string}`;
+const WETH_MINT = "0x4de5b3fa1e6c00708f7ff480e2186357da3bc7110c576e9364da84c4c77ad904" as `0x${string}`;
+
+const helperAbi = parseAbi([
+    "function ata(address user, bytes32 mint) external view returns (bytes32)",
+]);
+const cpiAbi = parseAbi([
+    "function account_lamports(bytes32 pubkey) external view returns (uint64)",
+]);
+
+describe("EnsureAta (Hadrian)", function () {
+    let harness: any;
+    let pc: any;
+    let me: `0x${string}`;
+    let deployerAccount: any;
+
+    before(async function () {
+        const { viem, networkName } = await hardhat.network.connect() as any;
+        if (networkName !== "hadrian") {
+            throw new Error(`This integration test must run against hadrian; got ${networkName}`);
+        }
+        const [deployer] = await viem.getWalletClients();
+        deployerAccount = deployer.account;
+        me = deployer.account.address;
+        pc = await viem.getPublicClient();
+
+        harness = await viem.deployContract("EnsureAtaHarness", []);
+    });
+
+    it("noop on an existing ATA (user holds wUSDC)", async function () {
+        const ataBefore = await pc.readContract({ address: HELPER, abi: helperAbi, functionName: "ata", args: [me, USDC_MINT] });
+        const lamportsBefore = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ataBefore] });
+        assert.ok(Number(lamportsBefore) > 0, `Test precondition: user must hold wUSDC ATA. Got ${lamportsBefore} lamports.`);
+
+        const txHash = await harness.write.ensure([me, USDC_MINT], { account: deployerAccount });
+        const rc = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(rc.status, "success");
+
+        const lamportsAfter = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ataBefore] });
+        assert.equal(lamportsAfter, lamportsBefore, "ATA lamports should be unchanged on idempotent re-run");
+    });
+
+    it("creates ATA on first call (user has no wETH ATA)", async function () {
+        const ata = await pc.readContract({ address: HELPER, abi: helperAbi, functionName: "ata", args: [me, WETH_MINT] });
+        const lamportsBefore = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ata] });
+
+        if (Number(lamportsBefore) > 0) {
+            // Race: a parallel run created it. Skip; case 3 (idempotency) covers
+            // the same-state branch.
+            console.log("ATA already exists — relying on case 3 to cover idempotency");
+            return;
+        }
+
+        const txHash = await harness.write.ensure([me, WETH_MINT], { account: deployerAccount });
+        const rc = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(rc.status, "success");
+
+        const lamportsAfter = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ata] });
+        assert.ok(Number(lamportsAfter) > 0, `ATA must exist after ensure(). Got ${lamportsAfter} lamports.`);
+    });
+
+    it("idempotent: re-running ensure on an existing ATA does not revert", async function () {
+        // Now that case 2 has created the wETH ATA, re-call ensure and verify success + no state churn.
+        const ata = await pc.readContract({ address: HELPER, abi: helperAbi, functionName: "ata", args: [me, WETH_MINT] });
+        const lamportsBefore = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ata] });
+        assert.ok(Number(lamportsBefore) > 0, "Test precondition: case 2 must have created the ATA");
+
+        const txHash = await harness.write.ensure([me, WETH_MINT], { account: deployerAccount });
+        const rc = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(rc.status, "success");
+
+        const lamportsAfter = await pc.readContract({ address: CPI, abi: cpiAbi, functionName: "account_lamports", args: [ata] });
+        assert.equal(lamportsAfter, lamportsBefore, "ATA lamports should be unchanged on idempotent re-run");
+    });
+});


### PR DESCRIPTION
## Summary
- New `contracts/cpi/EnsureAta.sol` library — idempotently ensures a user's SPL ATA exists before an EVM contract dispatches a Solana CPI that requires it.
- Wraps `HelperProgram.create_ata(address, bytes32)` (selector `0x3de2251a`), which itself dispatches Solana's `create_associated_token_account_idempotent`. No explicit `account_lamports` probe — the single-selector design keeps consumers tight.
- Wired into `MeteoraDAMMv1Router.swapExactTokensForTokens` as the first consumer. Two calls per swap (in-token + out-token).

## Why
Meteora's swap declares strict `Account<'info, TokenAccount>` constraints on `user_source_token` / `user_destination_token`. Anchor's account-validation pass runs BEFORE the handler body and rejects with `Custom(3012) AccountNotInitialized` if either ATA is missing. This stalled the wUSDC → wSOL swap on Hadrian today for users who had wUSDC balance but no wSOL ATA on the post-redeploy wrappers (deployed 2026-05-18 via [contract-deploys run 26020156799](https://github.com/rome-protocol/contract-deploys/actions/runs/26020156799)).

Composing the idempotent ATA-create in the same EVM tx fixes this generically: one EVM tx, one atomic Rome DoTx (or N iterative steps if it busts atomic CU), no orphan setup state.

## CU envelope

| ATA state | Per call |
|---|---:|
| Exists (idempotent no-op CPI) | ~50K Solana CU |
| Missing (creates) | ~110K Solana CU |

Two-side ensure for a swap: 100-220K CU total. Well under the 1.4M atomic envelope alongside the swap (~700-900K typical Meteora swap CU).

## Test plan
- [x] 3 integration tests in `tests/ensure_ata.integration.ts` against Hadrian:
  - **existing-ATA noop** (user holds wUSDC, ATA already on-chain) — passes, no state change
  - **missing-ATA create** (user had no wETH ATA on the new wrapper) — passes, ATA materializes
  - **idempotent re-run** — passes, lamports unchanged
- [x] Full unit suite passes: 25 tests (22 oracle parsers + 3 EnsureAta)
- [x] Wired router smoke on Hadrian: swap pre-flight now passes the ATA gate; downstream `PrivilegeEscalation` from Meteora dispatch is a separate issue (not blocked by this PR's scope)
- [ ] Post-merge: re-run wired-router smoke once the Meteora `PrivilegeEscalation` is resolved in a follow-up — expect a clean wUSDC → wSOL atomic Solana-routed swap end-to-end

## Scope
**In:** library + Meteora swap consumer + tests + CHANGELOG.

**Out (separate PRs):**
- Apply to `MeteoraDAMMv1Router.addLiquidity` / `removeLiquidity`
- Apply to `RomeswapMinimalRouter`, `Compound`, `Bridge`, etc. — each adapter opts in independently
- Fix the `PrivilegeEscalation` in the Meteora dispatch (separate Solidity / mollusk-emulator investigation)

## Precondition
User must be activated (`SimpleActivator.isActivated(user) == true`). `create_ata` signs as `external_auth(user)` which only exists once the user's PDA is funded. Routers should gate at a higher layer; this library does not re-check activation.

## No cross-repo dependencies
- No ABI changes; no precompile changes; no registry update needed.
- Library is purely Solidity-side composition over already-deployed precompiles.
- rome-ui: no change today. When the future w → w swap UI lands, it'll consume the new router as-is.