### PR TITLE
feat(activation): add CCTP_BURN_RESERVE so first outbound CCTP burn works (#83 Option A)

### DIFF
--- a/contracts/activation/SimpleActivator.sol
+++ b/contracts/activation/SimpleActivator.sol
@@ -65,14 +65,32 @@ contract SimpleActivator {
     ///         refill.
     uint64 public constant FRESH_TRANSFER_RESERVE = 10_000_000;
 
+    /// @notice Reserve for 1 outbound CCTP burn. CCTP's
+    ///         `deposit_for_burn` creates a ~1.6KB `MessageSent` event
+    ///         account whose rent_payer is the user's PDA.
+    ///         (128 + 1600) × 3480 × 2 ≈ 12M lamports per burn; 15M
+    ///         covers rent + tx fee + small margin for Solana rent-rate
+    ///         adjustments. Pre-fix (2026-05-18), freshly-activated
+    ///         users reverted on their first CCTP burn with System
+    ///         Program `ResultWithNegativeLamports` (`Custom(1)`)
+    ///         because USER_PDA_FUNDING didn't include this reserve.
+    ///         Rent is reclaimed when Circle attests (~30 min) so
+    ///         typical paced usage refills naturally; burst capacity
+    ///         beyond 1 burn requires a `topUpUserPda` call.
+    uint64 public constant CCTP_BURN_RESERVE = 15_000_000;
+
     /// @notice Total lamports the user's `external_auth` PDA receives
     ///         at activation time:
     ///           PDA_RENT (rent-exempt floor)
     ///         + 2 × ATA_RENT (wUSDC + wSOL ATA rents)
-    ///         + FRESH_TRANSFER_RESERVE.
-    ///         = 14_969_440 lamports ≈ 0.015 SOL.
+    ///         + FRESH_TRANSFER_RESERVE
+    ///         + CCTP_BURN_RESERVE.
+    ///         = 29_969_440 lamports ≈ 0.030 SOL.
     uint64 public constant USER_PDA_FUNDING =
-        PDA_RENT_LAMPORTS + 2 * ATA_RENT_LAMPORTS + FRESH_TRANSFER_RESERVE;
+        PDA_RENT_LAMPORTS +
+        2 * ATA_RENT_LAMPORTS +
+        FRESH_TRANSFER_RESERVE +
+        CCTP_BURN_RESERVE;
 
     /// @notice Wei the caller must pay per `activate()`. Strict equality —
     ///         no overpay refund. Caller reads this view first and

--- a/contracts/activation/test/SimpleActivatorHelper.sol
+++ b/contracts/activation/test/SimpleActivatorHelper.sol
@@ -45,14 +45,29 @@ contract SimpleActivatorHelper {
     /// to topUpUserPda.
     uint64 public constant FRESH_TRANSFER_RESERVE = 10_000_000;
 
+    /// Reserve for 1 outbound CCTP burn. CCTP's `deposit_for_burn`
+    /// creates a ~1.6KB `MessageSent` event account whose rent_payer is
+    /// the user's PDA. (128 + 1600) × 3480 × 2 ≈ 12M lamports per burn;
+    /// 15M covers rent + tx fee + small margin for Solana rent-rate
+    /// adjustments. Pre-fix (2026-05-18), freshly-activated users
+    /// reverted on their first CCTP burn with System Program
+    /// `ResultWithNegativeLamports` (`Custom(1)`) because USER_PDA_FUNDING
+    /// didn't include this reserve. The rent is reclaimed when Circle
+    /// attests (~30 min) so typical paced usage refills naturally;
+    /// burst capacity beyond 1 burn requires a `topUpUserPda` call.
+    uint64 public constant CCTP_BURN_RESERVE = 15_000_000;
+
     /// Mirror of SimpleActivator.USER_PDA_FUNDING:
-    ///   PDA_RENT + 2 * ATA_RENT + FRESH_TRANSFER_RESERVE.
+    ///   PDA_RENT + 2 * ATA_RENT + FRESH_TRANSFER_RESERVE + CCTP_BURN_RESERVE.
     /// Pure function — no on-chain side-effect — so this is the value
     /// the real `activate()` will pass to `HelperProgram.create_pda(user,
     /// lamports)`. Treat any deviation between this and the real
     /// constant as a regression.
     function expectedUserPdaFunding() external pure returns (uint64) {
-        return PDA_RENT_LAMPORTS + 2 * ATA_RENT_LAMPORTS + FRESH_TRANSFER_RESERVE;
+        return PDA_RENT_LAMPORTS +
+            2 * ATA_RENT_LAMPORTS +
+            FRESH_TRANSFER_RESERVE +
+            CCTP_BURN_RESERVE;
     }
 
     /// Mirror of the msg.value gate the real `activate()` enforces. The

--- a/scripts/activation/deploy-simple-activator.ts
+++ b/scripts/activation/deploy-simple-activator.ts
@@ -26,10 +26,12 @@ import { getAddress, isAddress } from "viem";
 import { readDeployments, writeDeployments } from "../lib/deployments.js";
 
 // One-tx activation: 2 USDC for activate(). Covers operator's SOL
-// outflow for HelperProgram.create_pda (≈ 0.015 SOL = 14_969_440
+// outflow for HelperProgram.create_pda (≈ 0.030 SOL = 29_969_440
 // lamports of user PDA funding = rent + 2× ATA rent + ~5 fresh-recipient
-// transfer reserve) plus a margin for Sybil resistance. Single tx,
-// single popup — collapsed from the legacy 3-tx flow.
+// transfer reserve + 1 CCTP MessageSent rent) plus a margin for Sybil
+// resistance. Single tx, single popup — collapsed from the legacy 3-tx
+// flow. CCTP reserve added 2026-05-18 to unblock first outbound CCTP
+// burn from a freshly-activated user (pre-fix reverted with Custom(1)).
 const ACTIVATION_COST_WEI = 2_000_000_000_000_000_000n;
 
 type AddressDep = {
@@ -126,7 +128,7 @@ async function main() {
   console.log(`  2. Update chain.contracts.simpleActivator in registry/chains/<id>-<slug>/contracts.json.`);
   console.log(`  3. Bump rome_ui_registry_ref in the chain's rome-ui inventory + redeploy rome-ui so ActivationGate picks up the new address.`);
   console.log(`  4. From a fresh EVM address: UI fires a single activate() tx (2 USDC) — one MetaMask popup, one wait.`);
-  console.log(`  5. Verify on-chain: PDA exists with USER_PDA_FUNDING lamports (~14.97M), wUSDC + wSOL ATAs both exist owned by PDA.`);
+  console.log(`  5. Verify on-chain: PDA exists with USER_PDA_FUNDING lamports (~29.97M), wUSDC + wSOL ATAs both exist owned by PDA.`);
 }
 
 main().catch((err) => {

--- a/tests/activation/simple-activator.test.ts
+++ b/tests/activation/simple-activator.test.ts
@@ -29,8 +29,20 @@ describe("SimpleActivator post-FB-4 arithmetic + predicates", function () {
     const PDA_RENT_LAMPORTS = 890_880n;
     const ATA_RENT_LAMPORTS = 2_039_280n;
     const FRESH_TRANSFER_RESERVE = 10_000_000n;
+    // CCTP MessageSent event-account rent reserve. CCTP burns create a
+    // ~1.6KB MessageSent event account whose rent_payer is the user's
+    // PDA. (128 + 1600) × 3480 × 2 ≈ 12M lamports per burn; reserve set
+    // at 15M to cover rent + tx fee + small margin for Solana rent-rate
+    // adjustments. Sized for 1 burn — burst capacity beyond 1 requires
+    // a topUpUserPda call before subsequent burns (or fold-in via #83
+    // Option B). Rent reclaims on Circle attestation (~30 min) so
+    // typical paced usage refills naturally.
+    const CCTP_BURN_RESERVE = 15_000_000n;
     const EXPECTED_USER_PDA_FUNDING =
-        PDA_RENT_LAMPORTS + 2n * ATA_RENT_LAMPORTS + FRESH_TRANSFER_RESERVE;
+        PDA_RENT_LAMPORTS +
+        2n * ATA_RENT_LAMPORTS +
+        FRESH_TRANSFER_RESERVE +
+        CCTP_BURN_RESERVE;
 
     before(async function () {
         const { viem } = await hardhat.network.connect();
@@ -64,6 +76,18 @@ describe("SimpleActivator post-FB-4 arithmetic + predicates", function () {
             const result = await helper.read.FRESH_TRANSFER_RESERVE();
             assert.equal(result, FRESH_TRANSFER_RESERVE);
         });
+
+        it("CCTP_BURN_RESERVE covers 1 MessageSent event-account rent", async function () {
+            // CCTP burns create a ~1.6KB MessageSent event account whose
+            // rent_payer is the user's PDA. (128 + 1600) × 3480 × 2 ≈ 12M
+            // lamports per burn; 15M is rent + tx fee + small margin for
+            // Solana rent-rate adjustments. Pre-fix, freshly-activated
+            // users reverted on their first CCTP burn with
+            // System Program `ResultWithNegativeLamports` (`Custom(1)`)
+            // because USER_PDA_FUNDING didn't include this reserve.
+            const result = await helper.read.CCTP_BURN_RESERVE();
+            assert.equal(result, CCTP_BURN_RESERVE);
+        });
     });
 
     // ──────────────────────────────────────────────────────────────────
@@ -72,16 +96,21 @@ describe("SimpleActivator post-FB-4 arithmetic + predicates", function () {
     // ──────────────────────────────────────────────────────────────────
 
     describe("expectedUserPdaFunding", function () {
-        it("equals PDA_RENT + 2 * ATA_RENT + FRESH_TRANSFER_RESERVE", async function () {
+        it("equals PDA_RENT + 2 * ATA_RENT + FRESH_TRANSFER_RESERVE + CCTP_BURN_RESERVE", async function () {
             const result = await helper.read.expectedUserPdaFunding();
             assert.equal(result, EXPECTED_USER_PDA_FUNDING);
         });
 
-        it("equals 14,969,440 lamports (≈ 0.015 SOL)", async function () {
+        it("equals 29,969,440 lamports (≈ 0.030 SOL)", async function () {
             // Sanity check on the absolute value — anything wildly off
-            // here means a constant got bumped without intent.
+            // here means a constant got bumped without intent. Was
+            // 14_969_440 (≈ 0.015 SOL) pre-CCTP-burn-reserve; bumped
+            // 2026-05-18 by +15M to cover the first CCTP MessageSent
+            // event-account rent. Aligns with the ≥0.05 SOL recommended
+            // floor in useOutboundCctpSend.ts (29.97M for activation +
+            // future topUpUserPda calls if the user wants headroom).
             const result = await helper.read.expectedUserPdaFunding();
-            assert.equal(result, 14_969_440n);
+            assert.equal(result, 29_969_440n);
         });
     });
 


### PR DESCRIPTION
## Summary
- Adds `CCTP_BURN_RESERVE = 15_000_000` lamports constant to `SimpleActivator`
- Bumps `USER_PDA_FUNDING` from 14_969_440 → 29_969_440 lamports (≈ 0.015 SOL → ≈ 0.030 SOL)
- Closes part of #83 (Option A — operational floor adjustment)

## Why this matters

A freshly-activated user (`USER_PDA_FUNDING` = 14_969_440 lamports = 0.015 SOL) reverts on their first outbound CCTP burn with System Program `ResultWithNegativeLamports` (`Custom(1)`) because `CCTP.deposit_for_burn` creates a ~1.6KB `MessageSent` event account (~12M lamports rent) whose `rent_payer` is the user's PDA. Pre-fix, every fresh user trying outbound CCTP saw an opaque revert.

The hook comment in [`rome-ui/src/features/bridge/hooks/useOutboundCctpSend.ts:16-23`](https://github.com/rome-protocol/rome-ui/blob/main/src/features/bridge/hooks/useOutboundCctpSend.ts) flagged this as a "TODO follow-up" pre-fix.

## Sizing

```
CCTP_BURN_RESERVE = 15_000_000 lamports
  = 12M (MessageSent rent: (128 + 1600) × 3480 × 2)
  + 5K (Solana tx fee margin)
  + ~3M (Solana rent-rate drift margin)
```

After Circle attestation (~30 min), `reclaim_event_account` returns the rent to the user PDA, so typical paced usage refills naturally. **Burst capacity > 1 burn still requires a `topUpUserPda` call** — that's the use case for Option B follow-up (fold-in via Solidity helper using existing `HelperProgram.swap_gas_to_lamports` primitive).

## Files changed

| File | What |
|---|---|
| `contracts/activation/SimpleActivator.sol` | Add `CCTP_BURN_RESERVE` constant + update `USER_PDA_FUNDING` formula + comments |
| `contracts/activation/test/SimpleActivatorHelper.sol` | Mirror the constant for hardhat tests |
| `tests/activation/simple-activator.test.ts` | Lock in new value (20 passing — 19 prior + 1 new CCTP_BURN_RESERVE assertion) |
| `scripts/activation/deploy-simple-activator.ts` | Refresh comment + post-deploy verification message |

## TDD evidence

```
RED:
  AssertionError: Expected 29969440n, Received 14969440n
  (test file modified first; ran hardhat to confirm failure
   came from constant mismatch, then implemented the constant)

GREEN:
  20 passing (20 nodejs)
  - constants: 4 (incl new CCTP_BURN_RESERVE)
  - expectedUserPdaFunding: 2 (formula + absolute)
  - validatePayment: 5
  - isActivatedFromLamports: 6
  - validateTopUpPayment: 3
```

## Deployment plan

1. Merge this PR
2. Operator runs `activation-deploy.yml` (contract-deploys repo) targeting `testnet-hadrian` to deploy new SimpleActivator
3. Operator opens registry PR with new SimpleActivator address in `chains/200010-hadrian/contracts.json` (replaces the live entry)
4. Bump rome-ui's `DEFAULT_REGISTRY_REF` env / `REGISTRY_REF` to pick up the new address (or wait for next pod restart)
5. New activations automatically get the higher floor; **existing Hadrian-activated users stay at 0.015 SOL** and need to either `topUpUserPda` manually or wait for Option B

## Forward-only on dev chains
Per `project_hadrian_forward_only_policy.md` — Hadrian is a dev chain, no backfill of existing users. They can call `topUpUserPda{value: ...}()` themselves to refill.

## Test plan
- [x] Hardhat unit tests 20/20 pass
- [ ] (post-deploy) Verify new SimpleActivator address on Hadrian by activating a fresh EVM address + reading PDA lamports = 29_969_440
- [ ] (post-deploy) Attempt outbound CCTP burn from fresh user — should succeed where pre-fix reverted