### PR TITLE
fix(meteora): drop trailing prog_dynamic_amm meta workaround (post-#368 redundant + actively harmful)

### DIFF
--- a/contracts/meteora/damm_v1_pool.sol
+++ b/contracts/meteora/damm_v1_pool.sol
@@ -910,25 +910,31 @@ library DAMMv1Lib {
         return bytes32(0);
     }
 
-    /// @dev The 16th account (`prog_dynamic_amm`) is a Rome-EVM emulator
-    ///      workaround required by `rome-evm-private/emulator/src/state.rs`'s
-    ///      `ix_store` filter — see `contracts/bridge/ICCTP.sol:27-59` for the
-    ///      same pattern applied to CCTP outbound. The Meteora Anchor IDL
-    ///      stops at 15 accounts; trailing entries are ignored by the on-chain
-    ///      Anchor account-validation (per Solana's standard CPI ABI) but are
-    ///      required so Mollusk's `load_elf` can find the AMM program in the
-    ///      per-ix store during `eth_estimateGas`. Without it, gas-estimate
-    ///      reverts with `program account not found: <amm-id>` before
-    ///      reaching the actual swap dispatcher.
+    /// @notice Build the 15-account swap instruction meta list per the
+    ///         Meteora dynamic-amm Anchor IDL.
+    ///
+    /// Historical note: a trailing 16th meta (`prog_dynamic_amm`) used to be
+    /// appended here as a Rome-EVM emulator workaround for the pre-#368
+    /// `ix_store` filter in `rome-evm-private/emulator/src/state.rs`, which
+    /// dropped `ix.program_id` from the per-CPI store and prevented
+    /// `mollusk.rs::load_elf` from finding the AMM program. rome-evm-private
+    /// PR #368 (the tightened allowlist that explicitly includes
+    /// `ix.program_id`) made the workaround redundant.
+    ///
+    /// Verified empirically on 2026-05-18 via `simulateTransaction` against
+    /// Solana devnet: with the trailing entry, both real Solana and Mollusk
+    /// fire `<amm>'s writable privilege escalated` during the inner CPI to
+    /// dynamic-vault (the swap aborts at ~32.7K CU before tokens move).
+    /// Without the trailing entry, the same swap completes Deposit (vault A)
+    /// + Withdraw (vault B) cleanly at ~99.5K CU.
     function build_swap_account_metas(
-        SwapAccountsInput memory a,
-        bytes32 prog_dynamic_amm
+        SwapAccountsInput memory a
     )
     internal
     pure
     returns (ICrossProgramInvocation.AccountMeta[] memory metas)
     {
-        metas = new ICrossProgramInvocation.AccountMeta[](16);
+        metas = new ICrossProgramInvocation.AccountMeta[](15);
 
         metas[0] = ICrossProgramInvocation.AccountMeta(a.pool, false, true);
         metas[1] = ICrossProgramInvocation.AccountMeta(
@@ -981,11 +987,6 @@ library DAMMv1Lib {
             false,
             false
         );
-        metas[15] = ICrossProgramInvocation.AccountMeta(
-            prog_dynamic_amm,
-            false,
-            false
-        );
     }
 
     function build_swap_ix_data(uint64 in_amount, uint64 minimum_out_amount)
@@ -996,18 +997,22 @@ library DAMMv1Lib {
         return abi.encodePacked(SWAP_PREFIX, Convert.u64le(in_amount), Convert.u64le(minimum_out_amount));
     }
 
-    /// @dev The 17th account (`prog_dynamic_amm`) is the same Rome-EVM
-    ///      emulator workaround applied in `build_swap_account_metas` —
-    ///      see comment there for the full rationale.
+    /// @notice Build the 16-account balance-liquidity (add/remove) meta list
+    ///         per the Meteora dynamic-amm Anchor IDL.
+    ///
+    /// Historical note: same trailing-meta workaround as
+    /// `build_swap_account_metas` (drop it for the same reasons — see comment
+    /// above). Both swap and balance-liquidity paths go through dynamic-amm
+    /// → dynamic-vault inner CPIs that trigger the same writable privilege
+    /// escalation when the trailing entry is present.
     function build_balance_liquidity_account_metas(
-        BalanceLiquidityAccountsInput memory a,
-        bytes32 prog_dynamic_amm
+        BalanceLiquidityAccountsInput memory a
     )
     internal
     pure
     returns (ICrossProgramInvocation.AccountMeta[] memory metas)
     {
-        metas = new ICrossProgramInvocation.AccountMeta[](17);
+        metas = new ICrossProgramInvocation.AccountMeta[](16);
 
         metas[0] = ICrossProgramInvocation.AccountMeta(a.pool, false, true);
         metas[1] = ICrossProgramInvocation.AccountMeta(a.lp_mint, false, true);
@@ -1025,7 +1030,6 @@ library DAMMv1Lib {
         metas[13] = ICrossProgramInvocation.AccountMeta(a.user, true, false);
         metas[14] = ICrossProgramInvocation.AccountMeta(a.vault_program, false, false);
         metas[15] = ICrossProgramInvocation.AccountMeta(a.token_program, false, false);
-        metas[16] = ICrossProgramInvocation.AccountMeta(prog_dynamic_amm, false, false);
     }
 
     function build_add_balance_liquidity_ix_data(
@@ -1591,8 +1595,7 @@ contract ERC20DAMMv1Pool {
             internal_pool.make_swap_accounts_from_pool(
                 msg.sender,
                 in_token
-            ),
-            internal_pool.prog_dynamic_amm()
+            )
         );
 
         bytes memory data = DAMMv1Lib.build_swap_ix_data(uint64(amount_in), uint64(min_amount_out));
@@ -1626,8 +1629,7 @@ contract ERC20DAMMv1Pool {
 
         ICrossProgramInvocation.AccountMeta[] memory accounts =
             DAMMv1Lib.build_balance_liquidity_account_metas(
-                internal_pool.make_balance_liquidity_accounts_from_pool(msg.sender),
-                internal_pool.prog_dynamic_amm()
+                internal_pool.make_balance_liquidity_accounts_from_pool(msg.sender)
             );
 
         bytes memory data = DAMMv1Lib.build_remove_balance_liquidity_ix_data(
@@ -1669,8 +1671,7 @@ contract ERC20DAMMv1Pool {
                 internal_pool.make_balance_liquidity_accounts_from_pool_and_user_accounts(
                     msg.sender,
                     user_accounts
-                ),
-                internal_pool.prog_dynamic_amm()
+                )
             );
 
         bytes memory data = DAMMv1Lib.build_add_balance_liquidity_ix_data(


### PR DESCRIPTION
## TL;DR

The trailing-meta workaround in `damm_v1_pool.sol::build_swap_account_metas` (and `build_balance_liquidity_account_metas`) was originally added to dodge the Rome-EVM emulator's pre-#368 `ix_store` filter. rome-evm-private PR #368 fixed `ix_store` to explicitly include `ix.program_id`; the workaround became redundant — and **actively harmful**: with the trailing entry, both real Solana and Mollusk fire `<amm>'s writable privilege escalated` and abort the swap before tokens move.

**Empirical proof** via `simulateTransaction` against Solana devnet, byte-identical accounts + calldata:

| Variant | Real Solana | CU |
|---|---|---|
| 15-meta (IDL strict, this PR) | **SUCCESS** | 99,579 |
| 16-meta (with trailing prog_dynamic_amm) | **PrivilegeEscalation** | 32,650 |

The 15-meta variant cleanly executes Swap → Deposit (vault A) → Withdraw (vault B).

## Failure trace (16-meta, pre-fix)

```
Program Eo7WjKq67rj... invoke [1]           <-- dynamic-amm swap
Program log: Instruction: Swap
Program TokenkegQ invoke [2]                <-- first SPL Token transfer (user → vault A)
Program TokenkegQ consumed 78 CU
Program TokenkegQ success
Eo7WjKq67rj's writable privilege escalated  <-- ERROR fires on next inner CPI
failed: Cross-program invocation with unauthorized signer or writable account
```

The escalation fires on the would-be inner CPI to dynamic-vault (`24Uqj9JC...`) — before the body executes. With the 15-meta IDL-strict variant, that same dynamic-vault CPI runs cleanly with Deposit + Withdraw.

## Why this surfaced now

Pre-#367 (`rome-evm-private`), the `mollusk-svm-programs-token` bundled-binary fast path special-cased SPL Token / Token-2022 / ATA and never ran the SBF programs through Mollusk's real Solana runtime. That path was tolerant of the trailing meta because it never reached the runtime's privilege checker. PR #367 removed the fast path → swap CPI started running through real Solana runtime semantics → trailing meta started failing → but the failure got masked behind #368 (`ix_store` filter dropped `ix.program_id`) and #369 (`update_accs` poisoned cache for BPFLoader2 programs).

With those three out of the way, the trailing meta is the surface bug.

## What's in this PR

- `build_swap_account_metas`: drop `prog_dynamic_amm` parameter, array size 16 → 15
- `build_balance_liquidity_account_metas`: drop `prog_dynamic_amm` parameter, array size 17 → 16
- Three callers updated to drop the now-removed arg
- Doc comments rewritten to explain the historical workaround + why we drop it

Net diff: +32 / -31. Pure mechanical change at the meta-list level; the swap CPI's semantics, accounts, and calldata are unchanged for metas[0..14].

## What's NOT in this PR

`ICCTP.sol::buildDepositForBurnAccounts` has a similar trailing-meta pattern but the rationale is **different**: it's for Anchor's `event_cpi` pattern (the inner CPI to MessageTransmitter::send_message_with_caller needs MessageTransmitter's own `__event_authority` PDA in the OUTER metas list so mollusk's per-CPI account fetch can resolve it). PR #368 doesn't help with arbitrary inner-CPI accounts; the rationale survives at first glance.

Need a separate empirical test (same `simulateTransaction` approach) before deciding whether CCTP can drop its trailing meta too. Tracking as a follow-up.

## Test plan

- [x] `npx hardhat compile` — clean, no warnings on touched code
- [x] Empirical sim on Solana devnet with both variants (this PR's rationale)
- [ ] Deploy updated MeteoraDAMMv1Factory + dependents to Hadrian via `contract-deploys`
- [ ] Re-run end-to-end Meteora wUSDC → wSOL swap probe — expected to succeed cleanly
- [ ] CU measure: real on-chain CU should track the simulateTransaction baseline (~100K CU per swap)

## Deploy plan

This is a Solidity-level fix — no rome-evm-private rebuild needed. The proxy/hercules at master (post-#369) are correct.

After merge:
1. Trigger `contract-deploys` Meteora workflow for Hadrian to redeploy `MeteoraDAMMv1Factory` from this commit
2. Re-register the wUSDC×wSOL pool on the new factory
3. Update `registry/chains/200010-hadrian/contracts.json` with new factory address
4. rome-ui consumes registry; no client redeploy needed
5. Smoke test: Meteora swap end-to-end on Hadrian