### PR TITLE
feat(interface): IEd25519 precompile interface + worked example

### DIFF
--- a/contracts/examples/ed25519_example.sol
+++ b/contracts/examples/ed25519_example.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interface.sol";
+
+/// Worked example: verifying a single ed25519 signature via the IEd25519 precompile.
+///
+/// The caller provides:
+///   - `allowed_signers`: bytes32[] of trusted ed25519 public keys
+///   - `expected_message`: bytes the caller asserts the runtime verified
+///   - `ed25519_ix_idx`: top-level Solana ix index of the Ed25519SigVerify ix
+///   - `sig_idx`: which signature within that ix (multi-sig batching support)
+///
+/// On success, returns the verified signer pubkey (∈ allowed_signers).
+/// Reverts otherwise. See rome-evm-private's `non_evm/ed25519_ix.rs` for the
+/// 15 error variants and what triggers each.
+///
+/// Real consumers (e.g. the Pyth Lazer wrapper) inline this pattern but pin
+/// `allowed_signers` to a hardcoded allowlist (e.g. just the Lazer signer
+/// pubkey) and supply the on-wire envelope as `expected_message`.
+contract ed25519_example {
+    function verify_one(
+        bytes32[] calldata allowed_signers,
+        bytes calldata expected_message,
+        uint8 ed25519_ix_idx,
+        uint8 sig_idx
+    ) external view returns (bytes32 verified_signer) {
+        return Ed25519.verify_from_allowlist(
+            allowed_signers,
+            expected_message,
+            ed25519_ix_idx,
+            sig_idx
+        );
+    }
+}

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -171,15 +171,50 @@ interface IHelperProgram {
     function deposit_from_ata(uint256 wei_) external;
 }
 
+// IEd25519 — generic ed25519 signature verification primitive at `0xff..0a`.
+// Confirms the Solana runtime cryptographically verified a signature in the
+// current transaction against `allowed_signers` and `expected_message`.
+// Pure-read CrossStateEthCall; single-state Rome chains only.
+//
+// Spec: rome-specs/main/active/technical/2026-05-19-rome-ed25519-precompile.md
+// Source of truth: rome-evm-private/program/src/non_evm/ed25519.rs +
+// rome-evm-private/program/src/non_evm/ed25519_ix.rs.
+//
+// First consumer: the Pyth Lazer wrapper (separate spec at
+// 2026-05-19-pyth-lazer-integration.md). Future consumers (signed-payload
+// bridges, additional oracle providers, capability tokens) reuse this
+// primitive without modification.
+interface IEd25519 {
+    /// @param allowed_signers MUST be non-empty (max 16 — DoS guard).
+    /// @param expected_message MUST be non-empty. The byte sequence the caller
+    ///        asserts was verified. Must byte-equal what the precompile
+    ///        actually verified, or this function reverts.
+    /// @param ed25519_ix_idx Index of the Ed25519SigVerify ix in the current
+    ///        Solana tx.
+    /// @param sig_idx Which signature within that ix to check (the ix
+    ///        supports multi-sig batching).
+    /// @return verified_signer The pubkey from the precompile ix data that the
+    ///        runtime confirmed signed `expected_message`. Guaranteed
+    ///        member of `allowed_signers`.
+    function verify_from_allowlist(
+        bytes32[] calldata allowed_signers,
+        bytes calldata expected_message,
+        uint8 ed25519_ix_idx,
+        uint8 sig_idx
+    ) external view returns (bytes32 verified_signer);
+}
+
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);
 address constant cpi_program_address = address(0xFF00000000000000000000000000000000000008);
 address constant helper_program_address = address(0xff00000000000000000000000000000000000009);
+address constant ed25519_program_address = address(0xfF0000000000000000000000000000000000000a);
 address constant withdraw_address = address(0x4200000000000000000000000000000000000016);
 
 ISystemProgram constant SystemProgram = ISystemProgram(system_program_address);
 ICrossProgramInvocation constant CpiProgram = ICrossProgramInvocation(cpi_program_address);
 IWithdraw constant Withdraw = IWithdraw(withdraw_address);
 IHelperProgram constant HelperProgram = IHelperProgram(helper_program_address);
+IEd25519 constant Ed25519 = IEd25519(ed25519_program_address);
 
 
 


### PR DESCRIPTION
## Summary

Solidity-side declaration for the IEd25519 verification precompile (rome-protocol/rome-evm-private https://github.com/rome-protocol/rome-evm-private/pull/370) — caller-facing surface for any future signed-payload consumer (Pyth Lazer is the first; ECDSA / Stork are siblings).

## Per-commit walk

- `5e68d70` — Add `IEd25519` interface + `Ed25519PrecompileAddress = 0xfF0000000000000000000000000000000000000a` constant (EIP-55 checksummed — `0xff..` lowercase form fails `solc 0.8.28`) + `examples/ed25519_example.sol` worked consumer.

## Status per Valentin's review

> rome-solidity has only precompile call, there is no use-case.

Correct — this PR just lands the interface + a single worked example. There's no production EVM consumer yet; the Pyth Lazer wrapper (the first real consumer) ships in a separate spec / branch and will land its own consumer Solidity contract. This PR is intentionally minimal so future signed-payload work has the primitive available.

## Test plan

- [ ] CI runs on push (Hardhat compile + ABI generation)