### PR TITLE
feat(lazer): L7 — IHelperProgram.lazer_price + worked consumer

### DIFF
--- a/contracts/examples/lazer_consumer.sol
+++ b/contracts/examples/lazer_consumer.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interface.sol";
+
+/// Reference consumer for Pyth Lazer prices on Rome.
+///
+/// Spec: rome-specs/main/active/technical/2026-05-19-pyth-lazer-integration.md §5.2
+///
+/// Demonstrates the two responsibilities the IHelperProgram.lazer_price
+/// wrapper does NOT enforce (per spec §3.4 — explicit consumer
+/// responsibility for per-policy flexibility):
+///
+///   1. **Per-feed monotonic replay protection.** A single envelope can
+///      carry N feeds at independent cadences. Per-feed
+///      `lastAcceptedPublishTimeUs[feed_id]` is MANDATORY — a single
+///      envelope-level timestamp is INSUFFICIENT (feed F1 can have a
+///      newer publish_time than feed F2 within the same envelope).
+///
+///   2. **Staleness enforcement.** The wrapper returns whatever Pyth
+///      signed, including stale payloads. The consumer enforces its own
+///      max staleness window appropriate to its use case (Compound
+///      liquidation tolerates 30s; bridge value verification needs
+///      seconds; UI display tolerates minutes).
+///
+/// Real consumers (Compound on Rome, Cardo's Drift/Mango adapters) inline
+/// this pattern. Multi-source aggregation (median of Lazer + Stork +
+/// Switchboard On-Demand) is consumer-side composition; the wrapper is
+/// designed as a primitive, not a policy.
+contract lazer_consumer {
+    uint32  public constant ETH_FEED = 2;
+    uint64  public constant MAX_STALENESS_US = 60_000_000; // 60s in microseconds
+
+    /// Per-feed monotonicity tracking — REQUIRED to prevent replay.
+    /// Maps Pyth's u32 feed_id to the last publish_time_us we accepted.
+    mapping(uint32 => uint64) public lastAcceptedPublishTimeUs;
+
+    /// Pull a fresh ETH price from a Lazer envelope + record it.
+    ///
+    /// NOT `view` because it mutates `lastAcceptedPublishTimeUs`. A pure-
+    /// view alternative (no monotonicity check) is acceptable only for
+    /// low-stakes UI display; high-stakes use cases (lending liquidations,
+    /// bridge value verification) MUST track monotonicity in storage to
+    /// reject replays of older signed payloads.
+    function getEthPrice(
+        bytes calldata envelope,
+        uint8 ed25519_ix_idx,
+        uint8 sig_idx
+    ) external returns (int64 price, int32 expo) {
+        // 1. Verify + parse via the wrapper.
+        (IHelperProgram.LazerFeedPrice[] memory feeds, uint64 publish_time_us)
+            = HelperProgram.lazer_price(envelope, ed25519_ix_idx, sig_idx);
+
+        // 2. Staleness check. block.timestamp is seconds; publish_time is microseconds.
+        //    Solidity 0.8+ checked arithmetic catches the (block.timestamp * 1_000_000)
+        //    multiplication overflow automatically — but only on the uint64 result, not
+        //    on the input cast. Explicit upper-bound guard so the cast itself never
+        //    silently wraps if block.timestamp exceeds uint64 microsecond range
+        //    (year 586,524+ — practically unreachable, but the check is cheap).
+        require(
+            block.timestamp < type(uint64).max / 1_000_000,
+            "block timestamp out of uint64 microsecond range"
+        );
+        uint64 now_us = uint64(block.timestamp) * 1_000_000;
+        require(now_us >= publish_time_us, "future-dated payload");
+        require(now_us - publish_time_us <= MAX_STALENESS_US, "stale payload");
+
+        // 3. Find ETH feed and enforce monotonicity.
+        for (uint256 i = 0; i < feeds.length; i++) {
+            if (feeds[i].feed_id == ETH_FEED) {
+                require(
+                    publish_time_us > lastAcceptedPublishTimeUs[ETH_FEED],
+                    "replay: publish_time not strictly increasing"
+                );
+                lastAcceptedPublishTimeUs[ETH_FEED] = publish_time_us;
+                return (feeds[i].price, feeds[i].expo);
+            }
+        }
+        revert("ETH feed not in payload");
+    }
+}

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -169,6 +169,72 @@ interface IHelperProgram {
     function allowance_of(address owner, address spender, bytes32 mint) external view returns (uint64);
     // deposit gas-token from ata
     function deposit_from_ata(uint256 wei_) external;
+
+    // ─── Pyth Lazer wrapper (signed-price oracle) ─────────────────────────
+    //
+    // Spec: rome-specs/main/active/technical/2026-05-19-pyth-lazer-integration.md
+    // Selector: 0xa5f15a86 = keccak256("lazer_price(bytes,uint8,uint8)")[..4]
+    // Body: rome-evm-private/program/src/non_evm/lazer_ix.rs::lazer_price
+    //
+    // Verifies a Pyth Lazer signed payload via the IEd25519 primitive +
+    // returns per-feed prices + the envelope-level publish timestamp.
+    // Pure-read CrossStateEthCall; single-state Rome chains only.
+    //
+    // Wire-format invariants the wrapper enforces:
+    //   - envelope: SOLANA_FORMAT_MAGIC (0x821A01B9 in u32 LE), 102-byte
+    //     header + payload_size (u16 LE, max 8192 bytes)
+    //   - PayloadData: PAYLOAD_FORMAT_MAGIC (0x93C7D375), 13 property tag
+    //     dispatch arms across three wire-encoding strategies (0-sentinel
+    //     Option<Price>, explicit-flag Option<T>, bare scalars)
+    //
+    // Allowlist is hardcoded to Pyth's mainnet Lazer signer pubkey
+    // (9gKEEcFzSd1PDYBKWAKZi4Sq4ZCUaVX5oTr8kEjdwsfR, expires 2035-01-15).
+    // Rotation = rome-evm-private program upgrade.
+
+    /// Per-feed price returned by the Lazer wrapper.
+    ///
+    /// `price` is an int64 mantissa scaled by `expo` (Pyth wire format —
+    /// real price = price * 10^expo; e.g. BTC at $76,815 with expo=-8 →
+    /// price = 7_681_500_000_000).
+    ///
+    /// `conf` follows the same scaling. `conf == 0` signals "no confidence
+    /// published" — this matches Pyth's own 0-sentinel wire convention for
+    /// the `Option<Price>` tag (the wire i64 mantissa is 0 ⇒ None).
+    ///
+    /// Feeds where the publisher posted no price for this batch are
+    /// silently dropped before encoding — consumers iterate this array
+    /// and detect "no value" by the absence of the expected feed_id, not
+    /// by a sentinel value on `price`.
+    struct LazerFeedPrice {
+        uint32 feed_id;
+        int64  price;
+        uint64 conf;
+        int32  expo;
+    }
+
+    /// Verify and parse a Pyth Lazer signed price payload.
+    ///
+    /// Returns the parsed prices for all feeds in the payload, plus the
+    /// payload's publish timestamp in **microseconds** (uint64). Consumers
+    /// that want seconds divide by 1_000_000.
+    ///
+    /// The caller MUST enforce replay protection and freshness per their
+    /// use case (see examples/lazer_consumer.sol). The wrapper does not
+    /// store any state.
+    ///
+    /// @param envelope The on-wire SolanaMessage envelope from a Pyth
+    ///        Lazer subscription. Byte-equal to the data embedded in the
+    ///        prefix Ed25519SigVerify ix of the current Solana tx.
+    /// @param ed25519_ix_idx Index of the Ed25519SigVerify ix in the
+    ///        current Solana tx.
+    /// @param sig_idx Which signature within that ix to check.
+    /// @return feeds Array of LazerFeedPrice (one per publishing feed).
+    /// @return publish_time_us Envelope-level publish timestamp in microseconds.
+    function lazer_price(
+        bytes calldata envelope,
+        uint8 ed25519_ix_idx,
+        uint8 sig_idx
+    ) external view returns (LazerFeedPrice[] memory feeds, uint64 publish_time_us);
 }
 
 // IEd25519 — generic ed25519 signature verification primitive at `0xff..0a`.


### PR DESCRIPTION
## Summary

Solidity side of the Pyth Lazer integration. Companion to rome-protocol/rome-evm-private#373 (which adds the on-chain wrapper at selector `0xa5f15a86`).

Single commit, single PR (rome-solidity scope of the feature is minimal — interface + worked consumer).

## Changes

| File | LOC | Purpose |
|---|---:|---|
| `contracts/interface.sol` | +65 | `LazerFeedPrice` struct + `lazer_price(bytes,uint8,uint8)` function inside `IHelperProgram` |
| `contracts/examples/lazer_consumer.sol` | +80 (new) | Reference consumer demonstrating per-feed monotonic replay protection + staleness |

## Spec

[`rome-specs/active/technical/2026-05-19-pyth-lazer-integration.md`](https://github.com/rome-protocol/rome-specs/blob/main/active/technical/2026-05-19-pyth-lazer-integration.md) §5 (Solidity interface + worked consumer).

## The interface

```solidity
struct LazerFeedPrice {
    uint32 feed_id;
    int64  price;
    uint64 conf;
    int32  expo;
}

function lazer_price(
    bytes calldata envelope,
    uint8 ed25519_ix_idx,
    uint8 sig_idx
) external view returns (LazerFeedPrice[] memory feeds, uint64 publish_time_us);
```

Selector pinned `0xa5f15a86` = `keccak256("lazer_price(bytes,uint8,uint8)")[..4]`, verified against the matching Rust const in [`rome-evm-private/program/src/non_evm/helper.rs:lazer_price_selector_locked`](https://github.com/rome-protocol/rome-evm-private/blob/master/program/src/non_evm/helper.rs).

## Consumer pattern (per spec §5.2)

The wrapper does NOT enforce replay protection or staleness — those are consumer-side per spec §3.4. The worked example demonstrates:

```solidity
mapping(uint32 => uint64) public lastAcceptedPublishTimeUs;

function getEthPrice(bytes calldata envelope, uint8 ix_idx, uint8 sig_idx)
    external returns (int64 price, int32 expo)
{
    (IHelperProgram.LazerFeedPrice[] memory feeds, uint64 publish_time_us)
        = HelperProgram.lazer_price(envelope, ix_idx, sig_idx);

    // 1. Staleness check (consumer-chosen MAX_STALENESS_US)
    require(now_us - publish_time_us <= MAX_STALENESS_US, "stale payload");

    // 2. Per-feed monotonicity (MANDATORY for multi-feed envelopes)
    for (uint i = 0; i < feeds.length; i++) {
        if (feeds[i].feed_id == ETH_FEED) {
            require(publish_time_us > lastAcceptedPublishTimeUs[ETH_FEED], "replay");
            lastAcceptedPublishTimeUs[ETH_FEED] = publish_time_us;
            return (feeds[i].price, feeds[i].expo);
        }
    }
    revert("ETH feed not in payload");
}
```

Per-feed (not envelope-level) monotonicity tracking is mandatory because a single envelope can carry N feeds at independent cadences — collapsing to one timestamp either rejects valid feeds or accepts replayed ones.

## Merge order

This PR MUST merge AFTER rome-protocol/rome-evm-private#373:

1. rome-evm-private#373 merges → master has the `lazer_price` selector at `0xa5f15a86`
2. Hadrian (or any test chain) rebuilds with new program — `IHelperProgram.lazer_price` is now callable
3. This PR merges
4. (optional) Contracts deploy the worked consumer for end-to-end smoke

If rome-solidity master ships ahead of rome-evm-private, consumer contracts calling `lazer_price` get a clear `Unimplemented(method is not supported by HelperProgram 0xa5f15a86)` — clear surface, no silent data corruption, but a deploy-time gotcha. The order matters.

## Verification

- `npx hardhat compile` → 46 files compiled clean (existing meteora factory size warning is unrelated)
- `npx hardhat test tests/oracle/PythPullParser.test.ts tests/oracle/SwitchboardParser.test.ts` → 22/22 pass (no regressions on adjacent parser tests)

## Test plan

- [x] Compile clean
- [x] No regressions on adjacent parser test suites
- [ ] CI runs on push (build-and-test, slither, CodeQL, etc.)
- [ ] Post-deploy: worked consumer at `contracts/examples/lazer_consumer.sol` deploys + can be called with a captured envelope