### PR TITLE
fix(oracle/lazer): deploy script handles flat-string factory address

### DIFF
--- a/scripts/oracle/deploy-lazer.ts
+++ b/scripts/oracle/deploy-lazer.ts
@@ -69,8 +69,13 @@ async function main() {
         );
     }
     const content = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    // deploy-v2-polish.ts writes the factory address as a flat string
+    // (`OracleAdapterFactory: "0xabc..."`); earlier ad-hoc deploys nested it
+    // (`OracleAdapterFactory: { address: "0xabc..." }`). Handle both so this
+    // script doesn't break against either schema.
+    const factoryRaw = content.OracleGatewayV2?.OracleAdapterFactory;
     const factoryAddr: string | undefined =
-        content.OracleGatewayV2?.OracleAdapterFactory?.address;
+        typeof factoryRaw === "string" ? factoryRaw : factoryRaw?.address;
     if (!factoryAddr) {
         throw new Error(
             `OracleAdapterFactory address not found in ${filePath}. Run scripts/oracle/deploy.ts first.`,


### PR DESCRIPTION
## Summary

- `scripts/oracle/deploy-lazer.ts` (shipped in https://github.com/rome-protocol/rome-solidity/pull/188) crashes against any chain deployed via `scripts/oracle/deploy-v2-polish.ts` because the polished script writes `OracleAdapterFactory: \"0xabc...\"` (flat string) while `deploy-lazer.ts` looked up the address as `OracleAdapterFactory.address` (nested object).
- 6-line patch accepts both schemas; no `deployments/<network>.json` rewrite needed.

## Background

Discovered during validation of the merged Lazer extension on Hadrian. PR #188 added `deploy-lazer.ts` but the script was never run end-to-end against any chain in CI/CD or manually, so the schema mismatch went unnoticed. The pending `contract-deploys` GHA workflow that wires the Lazer extension on Hadrian (and any future chain) would hit the same error the first time it tries to run this script.

## Test plan

- [x] Locally patched the same change against `deployments/hadrian.json` (flat-string form) → `npx hardhat run scripts/oracle/deploy-lazer.ts --network hadrian` reads the factory address correctly and proceeds to deploy
- [x] No-op against any future deployments file that uses the nested form (back-compat preserved)
- [ ] Trigger `contract-deploys` Oracle Gateway V2 workflow on testnet-hadrian after this lands — independent task