### PR TITLE
perf(oracle/lazer): coalesce SSTOREs + cache emit values in PythLazerCache._writeFeeds

### DIFF
--- a/contracts/oracle/PythLazerCache.sol
+++ b/contracts/oracle/PythLazerCache.sol
@@ -95,20 +95,41 @@ contract PythLazerCache is IPythLazerCache {
     /// @notice Internal: write the parsed feeds to storage. Extracted from
     ///         refresh() so unit tests can exercise it via a harness without
     ///         going through the IHelperProgram precompile path.
+    /// @dev CU-conscious for Rome's storage model. Two optimizations vs the
+    ///      naive form (field-by-field `c.X = Y`):
+    ///        1. Single struct-level assignment of `_prices[feed_id]`. The
+    ///           compiler coalesces writes into 2 SSTOREs (one per touched
+    ///           slot) instead of 4+ read-modify-write cycles on the packed
+    ///           slot (confidence + timestamp + roundId share slot 2).
+    ///        2. Cache the new values in memory and pass them to `emit` rather
+    ///           than re-reading from storage. Saves 4 SLOADs/feed.
+    ///      Measured on Hadrian 2026-05-20: pre-fix 5-feed cold cache.refresh
+    ///      was 556K CU; post-fix expected ~310K. Per-feed marginal drops
+    ///      from ~87K to an expected ~37K.
     function _writeFeeds(ILazerHelper.LazerFeedPrice[] memory feeds) internal {
         uint64 nowTs = uint64(block.timestamp);
-        for (uint i = 0; i < feeds.length; i++) {
+        uint256 len = feeds.length;
+        for (uint i = 0; i < len; ++i) {
             ILazerHelper.LazerFeedPrice memory f = feeds[i];
-            CachedPrice storage c = _prices[f.feed_id];
 
-            c.answer = _normalize(f.price, f.expo);
+            // Compute new values in memory.
+            int256 newAnswer = _normalize(f.price, f.expo);
             // Normalize conf at the same scale as answer. Cast uint64 → int64
             // is safe because Lazer's conf is bounded well below 2^63.
-            c.confidence = uint64(uint256(_normalize(int64(uint64(f.conf)), f.expo)));
-            c.timestamp = nowTs;
-            c.roundId = c.roundId + 1;
+            uint64 newConfidence = uint64(uint256(_normalize(int64(uint64(f.conf)), f.expo)));
+            // Read prior roundId once; increment in memory. Reads only slot 2.
+            uint80 newRoundId = _prices[f.feed_id].roundId + 1;
 
-            emit PriceUpdated(f.feed_id, c.answer, c.confidence, c.timestamp, c.roundId);
+            // Single struct-level assignment — see @dev note above.
+            _prices[f.feed_id] = CachedPrice({
+                answer:     newAnswer,
+                confidence: newConfidence,
+                timestamp:  nowTs,
+                roundId:    newRoundId
+            });
+
+            // Emit from memory vars; avoids 4 SLOADs back on the slot we just wrote.
+            emit PriceUpdated(f.feed_id, newAnswer, newConfidence, nowTs, newRoundId);
         }
     }
 


### PR DESCRIPTION
## Summary

On-chain validation of OG-V2 PythLazerCache (rome-solidity#188) surfaced that cache.refresh was consuming **way more CU than the probe baseline predicts**:

| Test | CU measured |
|---|---:|
| Direct \`helper.lazer_price\` 1-feed (probe baseline) | 75,613 |
| \`cache.refresh\` 1-feed cold (first refresh ever) | **207,631** |
| \`cache.refresh\` 1-feed warm | **186,866** |
| \`cache.refresh\` 5-feed cold | **556,639** |

Direct \`lazer_price\` adds ~975 CU per added feed (per the probe baseline doc). Cache.refresh adds **~87K CU per added feed cold** — ~89× higher.

## Diagnosis (from Solana program logs of the 5-feed cold tx)

```
Program log: Commit
Program 11111111... invoke [2]   ← System Program CPI #1
... (8 total invocations) ...
Program log: NonceChange
```

The Commit phase issues per-slot System Program CPIs (allocate/commit) for every storage slot touched. Direct \`lazer_price\` has ZERO SSTOREs and ZERO such CPIs; cache.refresh's heavy storage writes pay this overhead.

Combined with two contract-level inefficiencies:

1. **Field-by-field SSTOREs** to the packed slot 2 (\`confidence\`+\`timestamp\`+\`roundId\` share slot 2 in the \`CachedPrice\` struct). \`c.X = Y\` for each compiles to a separate read-modify-write of the slot, not a coalesced single SSTORE.
2. **SLOADs back from storage** in the \`emit PriceUpdated\` call — reading the four \`c.*\` field values after the SSTOREs that just wrote them.

## Fix (this PR)

Rewrite \`_writeFeeds\` body:

\`\`\`solidity
// Compute new values in memory
int256 newAnswer     = _normalize(f.price, f.expo);
uint64 newConfidence = uint64(uint256(_normalize(int64(uint64(f.conf)), f.expo)));
uint80 newRoundId    = _prices[f.feed_id].roundId + 1;

// Single struct-level assignment → 2 SSTOREs (1 per touched slot)
_prices[f.feed_id] = CachedPrice({
    answer:     newAnswer,
    confidence: newConfidence,
    timestamp:  nowTs,
    roundId:    newRoundId
});

// Emit from memory vars; no SLOADs back
emit PriceUpdated(f.feed_id, newAnswer, newConfidence, nowTs, newRoundId);
\`\`\`

Plus \`++i\` for the loop counter (small) and caching \`feeds.length\`.

## Expected impact

Based on the 5-feed CU breakdown analysis (3 inefficiencies × ~50K total savings per feed):

| Mode | Pre-fix | Post-fix (expected) |
|---|---:|---:|
| 1-feed cold | 207,631 | ~155K |
| 1-feed warm | 186,866 | ~135K |
| 5-feed cold | 556,639 | ~310K |
| 20-feed cold | ~1.7M (over budget) | ~850K (within 1.4M cap) |

Empirical verification will happen when this lands and the GHA workflow redeploys with \`force_redeploy=true + run_lazer_deploy=true\`.

## Test plan

- [x] All 57 Hardhat tests pass against the optimized contract (no behavior change)
- [ ] After merge: redeploy via \`Oracle Gateway V2 — Deploy\` workflow on \`testnet-hadrian\`
- [ ] Re-run cache.refresh probe (1-feed, 5-feed) on Hadrian; confirm CU drops
- [ ] If 20-feed now fits: validate 20-feed cache.refresh end-to-end