### PR TITLE
revert: SSTORE-coalesce optimization (#191) — was net-negative on Solana CU

### DIFF
--- a/contracts/oracle/PythLazerCache.sol
+++ b/contracts/oracle/PythLazerCache.sol
@@ -95,41 +95,20 @@ contract PythLazerCache is IPythLazerCache {
     /// @notice Internal: write the parsed feeds to storage. Extracted from
     ///         refresh() so unit tests can exercise it via a harness without
     ///         going through the IHelperProgram precompile path.
-    /// @dev CU-conscious for Rome's storage model. Two optimizations vs the
-    ///      naive form (field-by-field `c.X = Y`):
-    ///        1. Single struct-level assignment of `_prices[feed_id]`. The
-    ///           compiler coalesces writes into 2 SSTOREs (one per touched
-    ///           slot) instead of 4+ read-modify-write cycles on the packed
-    ///           slot (confidence + timestamp + roundId share slot 2).
-    ///        2. Cache the new values in memory and pass them to `emit` rather
-    ///           than re-reading from storage. Saves 4 SLOADs/feed.
-    ///      Measured on Hadrian 2026-05-20: pre-fix 5-feed cold cache.refresh
-    ///      was 556K CU; post-fix expected ~310K. Per-feed marginal drops
-    ///      from ~87K to an expected ~37K.
     function _writeFeeds(ILazerHelper.LazerFeedPrice[] memory feeds) internal {
         uint64 nowTs = uint64(block.timestamp);
-        uint256 len = feeds.length;
-        for (uint i = 0; i < len; ++i) {
+        for (uint i = 0; i < feeds.length; i++) {
             ILazerHelper.LazerFeedPrice memory f = feeds[i];
+            CachedPrice storage c = _prices[f.feed_id];
 
-            // Compute new values in memory.
-            int256 newAnswer = _normalize(f.price, f.expo);
+            c.answer = _normalize(f.price, f.expo);
             // Normalize conf at the same scale as answer. Cast uint64 → int64
             // is safe because Lazer's conf is bounded well below 2^63.
-            uint64 newConfidence = uint64(uint256(_normalize(int64(uint64(f.conf)), f.expo)));
-            // Read prior roundId once; increment in memory. Reads only slot 2.
-            uint80 newRoundId = _prices[f.feed_id].roundId + 1;
+            c.confidence = uint64(uint256(_normalize(int64(uint64(f.conf)), f.expo)));
+            c.timestamp = nowTs;
+            c.roundId = c.roundId + 1;
 
-            // Single struct-level assignment — see @dev note above.
-            _prices[f.feed_id] = CachedPrice({
-                answer:     newAnswer,
-                confidence: newConfidence,
-                timestamp:  nowTs,
-                roundId:    newRoundId
-            });
-
-            // Emit from memory vars; avoids 4 SLOADs back on the slot we just wrote.
-            emit PriceUpdated(f.feed_id, newAnswer, newConfidence, nowTs, newRoundId);
+            emit PriceUpdated(f.feed_id, c.answer, c.confidence, c.timestamp, c.roundId);
         }
     }
 


### PR DESCRIPTION
Reverts https://github.com/rome-protocol/rome-solidity/pull/191.

## Why

Measured on Hadrian against the redeployed optimized cache (\`0x6d9741e554a104ee00a0e2bdfde8a08771fe37cc\`):

| Test | Pre-fix baseline | Post-#191 | Delta |
|---|---:|---:|---:|
| 1-feed warm | 187,072 | 208,446 | **+21,374** |
| 1-feed cold | 207,631 | 221,515 | **+13,884** |
| 5-feed cold | 556,639 | 630,057 | **+73,418** |

Control measurement on the OLD pre-fix cache at \`0xa6f9ac4cca545bdfd3741d72be99891cef8588af\` taken minutes after the post-fix tests landed **187,072 CU** — exactly matches the pre-fix baseline, so this isn't time-of-day variance. The optimization genuinely increased CU.

## What went wrong with the diagnosis

PR #191's hypothesis was that Solidity's struct-literal mapping assignment \`_prices[k] = CachedPrice({...})\` would compile to 2 coalesced SSTOREs (one per touched slot) and that caching values in memory for the \`emit\` would avoid 4 SLOADs/feed. **Both were wrong in practice.** What actually happened:

1. The compiler did **not** treat the struct literal as a slot-level packed write. Best guess (without disassembly) — it allocated the struct in memory, then copied each field to storage individually with read-modify-write semantics on slot 2, plus memory-allocation overhead. **Field-by-field assignment was closer to optimal** because the optimizer could fold the consecutive same-slot writes.
2. SLOADs on the freshly-written packed slot are warm (~100 EVM gas) — eliminating 4 of them per feed saves negligible EVM gas, and Rome's CU charging for warm SLOAD is low enough that the memory-allocation overhead from caching new values in stack-vars probably cost more than the SLOADs saved.

The probe-baseline 75K (direct \`helper.lazer_price\`) vs cache-refresh 87K/feed gap therefore **isn't** the SSTORE pattern. The real CU sink is somewhere else — likely the per-slot System Program CPI (\`allocate\` + \`assign\`) during the Commit phase plus VM state-propagation overhead. Properly characterizing this requires step-by-step program-log decomposition, not theory.

## What's next

Revert restores the pre-#191 cache contract. Follow-up investigation (task #57) will do empirical CU accounting via program logs + subtractive probe variants before any further optimization is proposed.

## Test plan

- [x] \`git revert 73ae8062\` produces exact inverse diff (8 insertions, 29 deletions — restores the original \`_writeFeeds\` body)
- [ ] CI: all 57 Hardhat tests pass (same code that passed at PR #188)
- [ ] After merge: redeploy via \`Oracle Gateway V2 — Deploy\` workflow with \`force_redeploy=true + run_lazer_deploy=true\`
- [ ] Verify post-revert 1-feed warm probe measures ~187K, matching pre-fix baseline