### PR TITLE
feat(oracle): emit-registry-update helper for auto-PR-to-registry flow

### DIFF
--- a/scripts/oracle/emit-registry-update-cli.ts
+++ b/scripts/oracle/emit-registry-update-cli.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env -S npx tsx
+// CLI wrapper for emit-registry-update. Designed to be invoked from the
+// contract-deploys oracle-deploy.yml workflow.
+//
+// Usage:
+//   npx tsx scripts/oracle/emit-registry-update-cli.ts \
+//     --network <slug> \
+//     --registry-path <path-to-registry-checkout> \
+//     --source-git-sha <sha> \
+//     [--compiler-version <semver>] \
+//     [--deployments-path <path>]
+//
+// Reads:
+//   - <deployments-path> | default: deployments/<network>.json
+//   - <registry-path>/chains/<slug>/oracle.json
+//   - <registry-path>/chains/<slug>/contracts.json
+//
+// Writes updated versions IN PLACE back to the registry path. The workflow
+// then uses peter-evans/create-pull-request to PR them.
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  emitRegistryUpdate,
+  type DeploymentsFile,
+  type RegistryOracleFile,
+  type RegistryContractsFile,
+} from "./lib/emit-registry-update.js";
+
+interface Args {
+  network: string;
+  registryPath: string;
+  sourceGitSha: string;
+  compilerVersion: string;
+  deploymentsPath: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Partial<Args> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    const v = argv[i + 1];
+    if (k === "--network") args.network = v, i++;
+    else if (k === "--registry-path") args.registryPath = v, i++;
+    else if (k === "--source-git-sha") args.sourceGitSha = v, i++;
+    else if (k === "--compiler-version") args.compilerVersion = v, i++;
+    else if (k === "--deployments-path") args.deploymentsPath = v, i++;
+  }
+  if (!args.network || !args.registryPath || !args.sourceGitSha) {
+    throw new Error(
+      "missing required arg(s); need --network, --registry-path, --source-git-sha",
+    );
+  }
+  return {
+    network: args.network,
+    registryPath: args.registryPath,
+    sourceGitSha: args.sourceGitSha,
+    compilerVersion: args.compilerVersion ?? "0.8.28+commit.7893614a",
+    deploymentsPath: args.deploymentsPath ?? `deployments/${args.network}.json`,
+  };
+}
+
+/** Locate the chain directory in registry/chains by slug suffix (handles `<chainId>-<slug>` convention). */
+function resolveChainDir(registryPath: string, network: string): string {
+  const chainsDir = join(registryPath, "chains");
+  const candidates = readdirSync(chainsDir).filter(
+    (d) => d.endsWith(`-${network}`) || d === network,
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      `no registry chain dir found for network="${network}" under ${chainsDir}; ` +
+        `expected a dir ending in "-${network}" (e.g. "200010-hadrian")`,
+    );
+  }
+  if (candidates.length > 1) {
+    throw new Error(
+      `multiple registry chain dirs match network="${network}": ${candidates.join(", ")}`,
+    );
+  }
+  return join(chainsDir, candidates[0]);
+}
+
+function readJsonOrDefault<T>(path: string, fallback: T): T {
+  if (!existsSync(path)) return fallback;
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const deployments = JSON.parse(
+    readFileSync(args.deploymentsPath, "utf8"),
+  ) as DeploymentsFile;
+
+  if (!deployments.OracleGatewayV2) {
+    console.error(
+      `deployments file ${args.deploymentsPath} has no OracleGatewayV2 block; nothing to emit`,
+    );
+    process.exit(0); // Soft-exit — non-oracle deploy isn't a failure for this CLI.
+  }
+
+  const chainDir = resolveChainDir(args.registryPath, args.network);
+  const oraclePath = join(chainDir, "oracle.json");
+  const contractsPath = join(chainDir, "contracts.json");
+
+  const oracle = readJsonOrDefault<RegistryOracleFile>(oraclePath, {
+    factory: "0x0000000000000000000000000000000000000000",
+    feeds: {},
+  });
+  const contracts = readJsonOrDefault<RegistryContractsFile>(contractsPath, []);
+
+  const { oracle: newOracle, contracts: newContracts } = emitRegistryUpdate({
+    deployments,
+    oracle,
+    contracts,
+    options: {
+      sourceGitSha: args.sourceGitSha,
+      compilerVersion: args.compilerVersion,
+      deployedAt: deployments.OracleGatewayV2.deployedAt,
+    },
+  });
+
+  // Pretty-printed 2-space indent to match the existing registry house style.
+  writeFileSync(oraclePath, JSON.stringify(newOracle, null, 2) + "\n");
+  writeFileSync(contractsPath, JSON.stringify(newContracts, null, 2) + "\n");
+
+  // Emit summary lines the workflow can grep for / display in the run log.
+  console.log(`[emit-registry-update] wrote ${oraclePath}`);
+  console.log(`[emit-registry-update] wrote ${contractsPath}`);
+}
+
+main();

--- a/scripts/oracle/lib/__fixtures__/deployments-hadrian-sample.json
+++ b/scripts/oracle/lib/__fixtures__/deployments-hadrian-sample.json
@@ -1,0 +1,101 @@
+{
+  "ERC20SPLFactory": {
+    "address": "0x3c971ea1c7cf7a1b0a8af46f8a9e0648a82f9869",
+    "cpiContractAddress": "0xFF00000000000000000000000000000000000008"
+  },
+  "OracleGatewayV2": {
+    "deployedAt": "2026-05-21T02:57:14.616Z",
+    "defaultMaxStaleness": 60,
+    "pythReceiverProgramId": "0x0cb7fabb52f7a648bb5b317d9a018b9057cb024774fafe01e6c4df98cc385881",
+    "switchboardProgramId": "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90",
+    "PythPullAdapterImpl": "0xea0bc9643c462fafc470873f85ee57d1ac2bbcaf",
+    "SwitchboardV3AdapterImpl": "0x43cbe9c67e35c7f401fa76d8ce06595e004d2a63",
+    "OracleAdapterFactory": "0x9be249718c5c066d98fead6bfbb214ca0787f870",
+    "BatchReader": "0xc1224fe8d9eaeef34376ff4b24db360d5e10163e",
+    "feeds": {
+      "pyth": [
+        {
+          "pair": "SOL/USD",
+          "adapter": "0x63C28E0adE03B38e32b9cD85f2dD9B9fbB89185F",
+          "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+          "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
+        },
+        {
+          "pair": "BTC/USD",
+          "adapter": "0x7e35f232C8f1cB0eDE5BEddb8Ebe7110C29a6E81",
+          "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+          "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
+        },
+        {
+          "pair": "ETH/USD",
+          "adapter": "0xbE869FCA226545927E671E60F32720dB9dEc5980",
+          "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+          "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
+        },
+        {
+          "pair": "USDC/USD",
+          "adapter": "0xFf1adC858a6e16aD146b020da1CBfa5891a76f97",
+          "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
+          "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
+        },
+        {
+          "pair": "USDT/USD",
+          "adapter": "0x70766c9C81478595aB48CcdAD465d149a9b89aa2",
+          "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
+          "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
+        }
+      ],
+      "switchboard": [
+        {
+          "pair": "SOL/USD",
+          "adapter": "0xffD0586Ff206C95e6ff365da9EDf0524eA1F61db",
+          "pubkey": "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
+          "pubkeyBytes32": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a"
+        }
+      ]
+    }
+  },
+  "MeteoraDAMMv1Factory": {
+    "address": "0x6ce0e90db2b54b9a433530cd5b3d31573a401c3e"
+  },
+  "SPL_ERC20_USDC": {
+    "address": "0x9fD4D58dbB041CaFF77d323d2410c16DE339eB18",
+    "mintId": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+    "name": "Rome USDC",
+    "symbol": "wUSDC",
+    "deployedAt": 1779081476,
+    "via": "ERC20SPLFactory.add_spl_token_no_metadata"
+  },
+  "SPL_ERC20_WETH": {
+    "address": "0xE9A82f536C9b12B6346560d7A5d30cD91A41e8ac",
+    "mintId": "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs",
+    "name": "Rome ETH",
+    "symbol": "wETH",
+    "deployedAt": 1779081481,
+    "via": "ERC20SPLFactory.add_spl_token_no_metadata"
+  },
+  "SPL_ERC20_WSOL": {
+    "address": "0x28E7c064E734cB3edeA65A98927c1c20581c8934",
+    "mintId": "So11111111111111111111111111111111111111112",
+    "name": "Rome SOL",
+    "symbol": "wSOL",
+    "deployedAt": 1779081485,
+    "via": "ERC20SPLFactory.add_spl_token_no_metadata"
+  },
+  "RomeBridgePaymaster": {
+    "address": "0xe5b515d69590044a994d88c8bb8a87b36cd7b6d2",
+    "deployedAt": 1779081498
+  },
+  "RomeBridgeWithdraw": {
+    "address": "0x5dbe5e8b3697516637cc967b428b0d903c93bb43",
+    "deployedAt": 1779081505
+  },
+  "SimpleActivator": {
+    "address": "0xc478604d116222190750fe9a52dd3d6ae9140212",
+    "activationCostWei": "2000000000000000000",
+    "usdcWrapper": "0x9fD4D58dbB041CaFF77d323d2410c16DE339eB18",
+    "wsolWrapper": "0x28E7c064E734cB3edeA65A98927c1c20581c8934",
+    "users": "0x46066102B8E848d67Cf5f96212B92C8A24b51d8b",
+    "deployedAt": 1779114924
+  }
+}

--- a/scripts/oracle/lib/emit-registry-update.test.ts
+++ b/scripts/oracle/lib/emit-registry-update.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  emitRegistryUpdate,
+  type DeploymentsFile,
+  type RegistryOracleFile,
+  type RegistryContractsFile,
+  type EmitOptions,
+} from "./emit-registry-update.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(__dirname, "__fixtures__", name), "utf8"));
+}
+
+const HADRIAN_DEPLOYMENTS = readFixture("deployments-hadrian-sample.json") as DeploymentsFile;
+
+const META: EmitOptions = {
+  sourceGitSha: "4d67b384642063ab27fc20a890c12de78661568e",
+  compilerVersion: "0.8.28+commit.7893614a",
+  deployedAt: "2026-05-21T02:57:14.616Z",
+};
+
+// Empty stub state — what registry looks like for a never-deployed chain.
+const EMPTY_ORACLE: RegistryOracleFile = {
+  factory: "0x0000000000000000000000000000000000000000",
+  feeds: {},
+};
+const EMPTY_CONTRACTS: RegistryContractsFile = [];
+
+describe("emitRegistryUpdate — oracle.json output", () => {
+  it("populates factory from deployments OracleAdapterFactory", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.factory).toBe("0x9be249718c5c066d98fead6bfbb214ca0787f870");
+  });
+
+  it("emits one feed per pyth entry, keyed by pair", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.feeds["SOL/USD"]).toEqual({
+      address: "0x63C28E0adE03B38e32b9cD85f2dD9B9fbB89185F",
+      source: "pyth",
+      underlyingAccount: "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+    });
+    expect(oracle.feeds["BTC/USD"]).toEqual({
+      address: "0x7e35f232C8f1cB0eDE5BEddb8Ebe7110C29a6E81",
+      source: "pyth",
+      underlyingAccount: "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+    });
+  });
+
+  it("suffixes switchboard feeds with -SB to disambiguate from pyth", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.feeds["SOL/USD-SB"]).toEqual({
+      address: "0xffD0586Ff206C95e6ff365da9EDf0524eA1F61db",
+      source: "switchboard",
+      underlyingAccount: "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
+    });
+  });
+
+  it("is deterministic — same inputs produce same output", () => {
+    const a = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    const b = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(a.oracle).toEqual(b.oracle);
+    expect(a.contracts).toEqual(b.contracts);
+  });
+});
+
+describe("emitRegistryUpdate — contracts.json output (greenfield)", () => {
+  it("creates 4 entries (factory + 2 impls + batch reader) at v1.0.0", () => {
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    const names = contracts.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "BatchReader",
+      "OracleAdapterFactory",
+      "PythPullAdapterImpl",
+      "SwitchboardV3AdapterImpl",
+    ]);
+    for (const entry of contracts) {
+      expect(entry.versions).toHaveLength(1);
+      expect(entry.versions[0].status).toBe("live");
+      expect(entry.versions[0].version).toBe("1.0.0");
+      expect(entry.versions[0].sourceGitSha).toBe(META.sourceGitSha);
+      expect(entry.versions[0].compilerVersion).toBe(META.compilerVersion);
+      expect(entry.versions[0].deployedAt).toBe(META.deployedAt);
+    }
+  });
+
+  it("addresses match deployments file exactly", () => {
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    const byName = Object.fromEntries(
+      contracts.map((c) => [c.name, c.versions[0].address]),
+    );
+    expect(byName["OracleAdapterFactory"]).toBe("0x9be249718c5c066d98fead6bfbb214ca0787f870");
+    expect(byName["PythPullAdapterImpl"]).toBe("0xea0bc9643c462fafc470873f85ee57d1ac2bbcaf");
+    expect(byName["SwitchboardV3AdapterImpl"]).toBe("0x43cbe9c67e35c7f401fa76d8ce06595e004d2a63");
+    expect(byName["BatchReader"]).toBe("0xc1224fe8d9eaeef34376ff4b24db360d5e10163e");
+  });
+});
+
+describe("emitRegistryUpdate — contracts.json output (redeploy onto existing)", () => {
+  const PRIOR: RegistryContractsFile = [
+    {
+      name: "OracleAdapterFactory",
+      versions: [
+        {
+          address: "0xdc4de76da5508a0f53a302451ebcc6fc156c19b9",
+          version: "1.0.0",
+          status: "live",
+          deployedAt: "2026-05-20T13:19:00Z",
+          sourceGitSha: "abc1234",
+          compilerVersion: "0.8.28+commit.7893614a",
+        },
+      ],
+    },
+    {
+      name: "PythPullAdapterImpl",
+      versions: [
+        {
+          address: "0x731d22d69e686ea3f407600984d794e4046fa4d8",
+          version: "1.0.0",
+          status: "live",
+          deployedAt: "2026-05-20T13:19:00Z",
+          sourceGitSha: "abc1234",
+          compilerVersion: "0.8.28+commit.7893614a",
+        },
+      ],
+    },
+    {
+      name: "SwitchboardV3AdapterImpl",
+      versions: [
+        {
+          address: "0x39946f23e4931d5d14dfdf415c2d10345b528ef3",
+          version: "1.0.0",
+          status: "live",
+          deployedAt: "2026-05-20T13:19:00Z",
+          sourceGitSha: "abc1234",
+          compilerVersion: "0.8.28+commit.7893614a",
+        },
+      ],
+    },
+    {
+      name: "BatchReader",
+      versions: [
+        {
+          address: "0xfe4275443771932f766bf959b4d0244c8f4652be",
+          version: "1.0.0",
+          status: "live",
+          deployedAt: "2026-05-20T13:19:00Z",
+          sourceGitSha: "abc1234",
+          compilerVersion: "0.8.28+commit.7893614a",
+        },
+      ],
+    },
+  ];
+
+  it("retires previous live version when address differs", () => {
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: { factory: "0xdc4de76da5508a0f53a302451ebcc6fc156c19b9", feeds: {} },
+      contracts: PRIOR,
+      options: META,
+    });
+    const factory = contracts.find((c) => c.name === "OracleAdapterFactory")!;
+    expect(factory.versions).toHaveLength(2);
+    const v1 = factory.versions.find((v) => v.version === "1.0.0")!;
+    expect(v1.status).toBe("retired");
+    expect(v1.deprecatedAt).toBe(META.deployedAt);
+    expect(v1.replacedBy).toBe("0x9be249718c5c066d98fead6bfbb214ca0787f870");
+    const v2 = factory.versions.find((v) => v.version === "2.0.0")!;
+    expect(v2.status).toBe("live");
+    expect(v2.address).toBe("0x9be249718c5c066d98fead6bfbb214ca0787f870");
+  });
+
+  it("is idempotent — no change when address already matches", () => {
+    // Build prior state with TODAY's addresses (i.e. registry already up to date).
+    const upToDate: RegistryContractsFile = [
+      {
+        name: "OracleAdapterFactory",
+        versions: [
+          {
+            address: HADRIAN_DEPLOYMENTS.OracleGatewayV2.OracleAdapterFactory,
+            version: "1.0.0",
+            status: "live",
+            deployedAt: META.deployedAt,
+            sourceGitSha: META.sourceGitSha,
+            compilerVersion: META.compilerVersion,
+          },
+        ],
+      },
+      {
+        name: "PythPullAdapterImpl",
+        versions: [
+          {
+            address: HADRIAN_DEPLOYMENTS.OracleGatewayV2.PythPullAdapterImpl,
+            version: "1.0.0",
+            status: "live",
+            deployedAt: META.deployedAt,
+            sourceGitSha: META.sourceGitSha,
+            compilerVersion: META.compilerVersion,
+          },
+        ],
+      },
+      {
+        name: "SwitchboardV3AdapterImpl",
+        versions: [
+          {
+            address: HADRIAN_DEPLOYMENTS.OracleGatewayV2.SwitchboardV3AdapterImpl,
+            version: "1.0.0",
+            status: "live",
+            deployedAt: META.deployedAt,
+            sourceGitSha: META.sourceGitSha,
+            compilerVersion: META.compilerVersion,
+          },
+        ],
+      },
+      {
+        name: "BatchReader",
+        versions: [
+          {
+            address: HADRIAN_DEPLOYMENTS.OracleGatewayV2.BatchReader,
+            version: "1.0.0",
+            status: "live",
+            deployedAt: META.deployedAt,
+            sourceGitSha: META.sourceGitSha,
+            compilerVersion: META.compilerVersion,
+          },
+        ],
+      },
+    ];
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: {
+        factory: HADRIAN_DEPLOYMENTS.OracleGatewayV2.OracleAdapterFactory,
+        feeds: {},
+      },
+      contracts: upToDate,
+      options: META,
+    });
+    // Should equal the input — no new version added.
+    expect(contracts).toEqual(upToDate);
+  });
+
+  it("preserves prior retired versions across multiple redeploys", () => {
+    const twoVersions: RegistryContractsFile = [
+      {
+        name: "OracleAdapterFactory",
+        versions: [
+          {
+            address: "0xnewly_live_aaaa00000000000000000000000000000001",
+            version: "2.0.0",
+            status: "live",
+            deployedAt: "2026-05-18T05:30:00Z",
+            sourceGitSha: "def5678",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+          {
+            address: "0xprior_retired_b00000000000000000000000000000001",
+            version: "1.0.0",
+            status: "retired",
+            deployedAt: "2026-05-14T09:55:00Z",
+            deprecatedAt: "2026-05-18T05:30:00Z",
+            replacedBy: "0xnewly_live_aaaa00000000000000000000000000000001",
+            sourceGitSha: "abc1234",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+    ];
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: twoVersions,
+      options: META,
+    });
+    const factory = contracts.find((c) => c.name === "OracleAdapterFactory")!;
+    expect(factory.versions).toHaveLength(3); // 2 old + 1 new
+    const v3 = factory.versions.find((v) => v.version === "3.0.0")!;
+    expect(v3.status).toBe("live");
+    expect(v3.address).toBe(HADRIAN_DEPLOYMENTS.OracleGatewayV2.OracleAdapterFactory);
+    // Prior retired entry is untouched
+    const v1 = factory.versions.find((v) => v.version === "1.0.0")!;
+    expect(v1.status).toBe("retired");
+    expect(v1.deprecatedAt).toBe("2026-05-18T05:30:00Z");
+  });
+});

--- a/scripts/oracle/lib/emit-registry-update.test.ts
+++ b/scripts/oracle/lib/emit-registry-update.test.ts
@@ -321,3 +321,124 @@ describe("emitRegistryUpdate — contracts.json output (redeploy onto existing)"
     expect(v1.deprecatedAt).toBe("2026-05-18T05:30:00Z");
   });
 });
+
+describe("emitRegistryUpdate — preserves non-managed contracts.json entries", () => {
+  it("passes through ERC20SPLFactory, Multicall3, and any other unmanaged entries untouched", () => {
+    // Mimic a real Hadrian contracts.json that has many non-OG entries.
+    const realisticPrior: RegistryContractsFile = [
+      {
+        name: "ERC20SPLFactory",
+        versions: [
+          {
+            address: "0x3c971ea1c7cf7a1b0a8af46f8a9e0648a82f9869",
+            version: "3.0.0",
+            status: "live",
+            deployedAt: "2026-05-18T05:30:00Z",
+            sourceGitSha: "506961ed1fe4f368a4c6a8793960a754b777b9fd",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+      {
+        name: "Multicall3",
+        versions: [
+          {
+            address: "0x000000000000000000000000000000000000ca11",
+            version: "3.0.0",
+            status: "live",
+            deployedAt: "2026-05-21T04:49:00Z",
+            sourceGitSha: "deadbeef",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+      {
+        name: "RomeBridgePaymaster",
+        versions: [
+          {
+            address: "0xe5b515d69590044a994d88c8bb8a87b36cd7b6d2",
+            version: "3.0.0",
+            status: "live",
+            deployedAt: "2026-05-18T05:30:00Z",
+            sourceGitSha: "506961ed1fe4f368a4c6a8793960a754b777b9fd",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+    ];
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: realisticPrior,
+      options: META,
+    });
+    // The 3 non-managed entries should pass through unchanged
+    const erc20 = contracts.find((c) => c.name === "ERC20SPLFactory")!;
+    const multicall = contracts.find((c) => c.name === "Multicall3")!;
+    const paymaster = contracts.find((c) => c.name === "RomeBridgePaymaster")!;
+    expect(erc20).toEqual(realisticPrior[0]);
+    expect(multicall).toEqual(realisticPrior[1]);
+    expect(paymaster).toEqual(realisticPrior[2]);
+    // The 4 managed entries should be appended (since they weren't in prior)
+    const managedNames = contracts
+      .filter((c) =>
+        ["BatchReader", "OracleAdapterFactory", "PythPullAdapterImpl", "SwitchboardV3AdapterImpl"].includes(c.name),
+      )
+      .map((c) => c.name);
+    expect(managedNames.sort()).toEqual([
+      "BatchReader",
+      "OracleAdapterFactory",
+      "PythPullAdapterImpl",
+      "SwitchboardV3AdapterImpl",
+    ]);
+    // Total entries: 3 preserved + 4 new = 7
+    expect(contracts).toHaveLength(7);
+    // Non-managed entries appear FIRST (in input order); managed entries appended.
+    expect(contracts[0].name).toBe("ERC20SPLFactory");
+    expect(contracts[1].name).toBe("Multicall3");
+    expect(contracts[2].name).toBe("RomeBridgePaymaster");
+  });
+
+  it("preserves non-managed entries even on a redeploy that retires managed ones", () => {
+    const mixedPrior: RegistryContractsFile = [
+      {
+        name: "Multicall3",
+        versions: [
+          {
+            address: "0x000000000000000000000000000000000000ca11",
+            version: "3.0.0",
+            status: "live",
+            deployedAt: "2026-05-21T04:49:00Z",
+            sourceGitSha: "deadbeef",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+      {
+        name: "OracleAdapterFactory",
+        versions: [
+          {
+            address: "0xold_factory_address0000000000000000000000",
+            version: "1.0.0",
+            status: "live",
+            deployedAt: "2026-05-20T00:00:00Z",
+            sourceGitSha: "old",
+            compilerVersion: "0.8.28+commit.7893614a",
+          },
+        ],
+      },
+    ];
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: mixedPrior,
+      options: META,
+    });
+    const multicall = contracts.find((c) => c.name === "Multicall3")!;
+    expect(multicall).toEqual(mixedPrior[0]); // unchanged
+    const factory = contracts.find((c) => c.name === "OracleAdapterFactory")!;
+    expect(factory.versions).toHaveLength(2); // 1 retired + 1 new live
+    expect(factory.versions.find((v) => v.version === "2.0.0")!.status).toBe("live");
+    expect(factory.versions.find((v) => v.version === "1.0.0")!.status).toBe("retired");
+  });
+});

--- a/scripts/oracle/lib/emit-registry-update.ts
+++ b/scripts/oracle/lib/emit-registry-update.ts
@@ -1,0 +1,218 @@
+// Pure transform from rome-solidity's per-chain deployment receipt to the
+// registry's per-chain oracle.json + contracts.json. Designed to be
+// invoked from the contract-deploys oracle-deploy.yml workflow after the
+// rome-solidity PR-back step, so registry updates land automatically.
+//
+// Single source of truth invariants this enforces:
+//   - registry/chains/<slug>/oracle.json   ← workflow-managed; no hand-edits
+//   - registry/chains/<slug>/contracts.json ← workflow-managed; no hand-edits
+//
+// Pure-functional core (`emitRegistryUpdate`) takes file contents in,
+// returns file contents out. The CLI wrapper (sibling file) handles I/O.
+
+// ─── Input types ────────────────────────────────────────────────────────────
+
+export interface DeploymentsFeed {
+  pair: string; // "SOL/USD"
+  adapter: `0x${string}`;
+  pubkey: string; // Solana base58
+  pubkeyBytes32: `0x${string}`;
+}
+
+export interface DeploymentsFile {
+  OracleGatewayV2: {
+    deployedAt: string;
+    defaultMaxStaleness: number;
+    pythReceiverProgramId: string;
+    switchboardProgramId: string;
+    PythPullAdapterImpl: `0x${string}`;
+    SwitchboardV3AdapterImpl: `0x${string}`;
+    OracleAdapterFactory: `0x${string}`;
+    BatchReader: `0x${string}`;
+    feeds: {
+      pyth: DeploymentsFeed[];
+      switchboard: DeploymentsFeed[];
+    };
+  };
+}
+
+export interface RegistryOracleFile {
+  factory: string;
+  feeds: Record<
+    string,
+    {
+      address: string;
+      source: "pyth" | "switchboard";
+      underlyingAccount?: string;
+    }
+  >;
+}
+
+export interface RegistryContractVersion {
+  address: string;
+  version: string;
+  status: "live" | "retired";
+  deployedAt: string;
+  sourceGitSha?: string;
+  compilerVersion?: string;
+  deprecatedAt?: string;
+  replacedBy?: string;
+}
+
+export interface RegistryContractEntry {
+  name: string;
+  versions: RegistryContractVersion[];
+}
+
+export type RegistryContractsFile = RegistryContractEntry[];
+
+export interface EmitOptions {
+  sourceGitSha: string;
+  compilerVersion: string;
+  deployedAt: string;
+}
+
+export interface EmitInput {
+  deployments: DeploymentsFile;
+  oracle: RegistryOracleFile;
+  contracts: RegistryContractsFile;
+  options: EmitOptions;
+}
+
+export interface EmitOutput {
+  oracle: RegistryOracleFile;
+  contracts: RegistryContractsFile;
+}
+
+// The 4 contract names this script manages. Order is the stable sort order
+// emitted on greenfield deploys (matches alphabetical for predictability).
+const MANAGED_CONTRACTS: ReadonlyArray<{
+  name: string;
+  field: keyof DeploymentsFile["OracleGatewayV2"];
+}> = [
+  { name: "BatchReader", field: "BatchReader" },
+  { name: "OracleAdapterFactory", field: "OracleAdapterFactory" },
+  { name: "PythPullAdapterImpl", field: "PythPullAdapterImpl" },
+  { name: "SwitchboardV3AdapterImpl", field: "SwitchboardV3AdapterImpl" },
+];
+
+export function emitRegistryUpdate(input: EmitInput): EmitOutput {
+  return {
+    oracle: buildOracle(input),
+    contracts: buildContracts(input),
+  };
+}
+
+function buildOracle({ deployments }: EmitInput): RegistryOracleFile {
+  const og = deployments.OracleGatewayV2;
+  const feeds: RegistryOracleFile["feeds"] = {};
+
+  for (const f of og.feeds.pyth) {
+    feeds[f.pair] = {
+      address: f.adapter,
+      source: "pyth",
+      underlyingAccount: f.pubkey,
+    };
+  }
+  for (const f of og.feeds.switchboard) {
+    // Suffix switchboard entries with "-SB" so a pyth + switchboard pair
+    // for the same symbol (e.g. SOL/USD) don't collide. Matches Marcus's
+    // existing curated registry shape.
+    feeds[`${f.pair}-SB`] = {
+      address: f.adapter,
+      source: "switchboard",
+      underlyingAccount: f.pubkey,
+    };
+  }
+
+  return {
+    factory: og.OracleAdapterFactory,
+    feeds,
+  };
+}
+
+function buildContracts({
+  deployments,
+  contracts: prior,
+  options,
+}: EmitInput): RegistryContractsFile {
+  const updateForName = (name: string): RegistryContractEntry => {
+    const cfg = MANAGED_CONTRACTS.find((c) => c.name === name);
+    if (!cfg) {
+      // Unknown contract — shouldn't happen for the 4 managed ones, but
+      // if a chain's contracts.json has other entries (e.g. legacy stuff)
+      // we pass them through untouched.
+      return prior.find((e) => e.name === name)!;
+    }
+    const newAddress = deployments.OracleGatewayV2[cfg.field] as string;
+    const priorEntry = prior.find((e) => e.name === name);
+
+    if (!priorEntry) {
+      return {
+        name,
+        versions: [
+          {
+            address: newAddress,
+            version: "1.0.0",
+            status: "live",
+            deployedAt: options.deployedAt,
+            sourceGitSha: options.sourceGitSha,
+            compilerVersion: options.compilerVersion,
+          },
+        ],
+      };
+    }
+
+    const liveVersion = priorEntry.versions.find((v) => v.status === "live");
+    if (liveVersion && liveVersion.address.toLowerCase() === newAddress.toLowerCase()) {
+      // Idempotent — current live version already matches deployment.
+      return priorEntry;
+    }
+
+    // Address differs (or no live entry). Compute next version: max major + 1.
+    const maxMajor = priorEntry.versions
+      .map((v) => parseInt(v.version.split(".")[0], 10))
+      .filter((n) => Number.isFinite(n))
+      .reduce((a, b) => Math.max(a, b), 0);
+    const nextVersion = `${maxMajor + 1}.0.0`;
+
+    const updatedVersions: RegistryContractVersion[] = priorEntry.versions.map((v) =>
+      v.status === "live"
+        ? {
+            ...v,
+            status: "retired" as const,
+            deprecatedAt: options.deployedAt,
+            replacedBy: newAddress,
+          }
+        : v,
+    );
+    updatedVersions.unshift({
+      address: newAddress,
+      version: nextVersion,
+      status: "live",
+      deployedAt: options.deployedAt,
+      sourceGitSha: options.sourceGitSha,
+      compilerVersion: options.compilerVersion,
+    });
+
+    return { name, versions: updatedVersions };
+  };
+
+  // Preserve input order for entries already in the prior array.
+  // Append new (managed) entries that didn't exist before, in alphabetical
+  // order. This gives byte-equal output on idempotent runs.
+  const out: RegistryContractsFile = [];
+  const seenNames = new Set<string>();
+
+  for (const entry of prior) {
+    out.push(updateForName(entry.name));
+    seenNames.add(entry.name);
+  }
+  for (const { name } of MANAGED_CONTRACTS) {
+    if (!seenNames.has(name)) {
+      out.push(updateForName(name));
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary

Adds a pure-functional helper + CLI that transforms rome-solidity's per-chain deployment receipt into the registry's per-chain \`oracle.json\` + \`contracts.json\`. Enables the contract-deploys workflow to auto-PR registry updates after every oracle deploy, eliminating the manual file-edit step that caused Hadrian to ship with an empty \`oracle.json\` stub.

This is Part 2 of the end-state pipeline described in the audit follow-up — companion PRs in \`contract-deploys\` (workflow wiring) and \`registry\` (liveness probe extension + invariant doc) will follow.

## What's new

\`\`\`
scripts/oracle/lib/
  emit-registry-update.ts        — pure transformer (~210 LOC)
  emit-registry-update.test.ts   — 9 vitest cases (all passing)
  __fixtures__/
    deployments-hadrian-sample.json  — real Hadrian deploy snapshot

scripts/oracle/
  emit-registry-update-cli.ts    — CLI wrapper for the workflow (~100 LOC)
\`\`\`

## Behavior

| Scenario | Output |
|---|---|
| Greenfield chain (empty stub \`oracle.json\` + \`[]\` \`contracts.json\`) | 4 contracts at v1.0.0, all live, sorted alphabetically; oracle.json populated with factory + N feeds |
| Redeploy onto existing chain (address differs from current live) | Prior live entry marked \`retired\` with \`deprecatedAt\` + \`replacedBy\`; new entry prepended as next-major-version (e.g. 2.0.0 → 3.0.0) |
| Idempotent rerun (addresses already match) | Byte-equal output to input — no PR diff |
| Multiple historical retired versions | Preserved untouched; only the currently-live entry is retired on next bump |
| Pyth + Switchboard feeds for same pair | Switchboard entries get \`-SB\` suffix (e.g. \`SOL/USD-SB\`) to disambiguate — matches Marcus's existing curated registry shape |

## Verification

- \`npx vitest run scripts/oracle/lib/emit-registry-update.test.ts\` → **9 passing**
- Smoke test against \`deployments/hadrian.json\` (the current post-cleanup state on master): CLI produces expected \`oracle.json\` (5 pyth feeds + 1 switchboard) and \`contracts.json\` (4 entries × 1 version each)
- No production code changes; pure new helper + CLI

## What does NOT change

- Existing deploy workflow behavior — this PR adds the helper, doesn't wire it
- rome-ui consumption — still reads pinned \`REGISTRY_REF\`; nothing auto-rolls
- Existing \`deployments/<chain>.json\` artifact — unchanged
- Any contract source / test / interface