### PR TITLE
docs(cpi+oracle): correct AccountReader NatSpec — read shortcuts are not CPIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,16 @@ The core abstraction layer. Rome-EVM exposes Solana programs as EVM precompiles 
 
 Global constants pre-bound by `interface.sol`: `SystemProgram`, `CpiProgram`, `HelperProgram`, `Withdraw`.
 
+**Validation note (2026-05-22).** "CPI in docs" ≠ "Solana CPI on chain". When a precompile method's NatSpec says "via Rome's CPI precompile", check the dispatch variant in the source-of-truth table at [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "Precompile Interfaces — Canonical Surface". Only selectors marked `Invoke` (or `Composed` arms that nest an `Invoke`) actually issue a Solana CPI signed by the caller's `EXTERNAL_AUTHORITY` PDA. Selectors marked `EthCall` / `CrossStateEthCall` are pure reads — no signing, no PDA seeds, no on-chain side effect. AccountReader (this repo's `contracts/cpi/AccountReader.sol`) and the oracle adapters (`contracts/oracle/PythPullAdapter.sol`, `contracts/oracle/SwitchboardV3Adapter.sol`) only exercise the `CrossStateEthCall` path. Foundation PR: [`rome-protocol/rome-evm-private#377`](https://github.com/rome-protocol/rome-evm-private/pull/377).
+
 **Removed precompiles** (kept here so agents recognize stale code):
 
 - `0xff..05` (SPL Token) and `0xff..06` (Associated Token) — dedicated handlers were removed in the rome-evm-private Mollusk refactor; SPL operations now route through Mollusk SVM in the emulator and CPI on-chain. The `ISplToken` / `IAssociatedSplToken` interfaces and `SplToken` / `AssociatedSplToken` constants are no longer in `interface.sol`.
 - `0x42..17` (`unwrap_spl_to_gas(uint256)`) and `0x42..18` (`wrap_gas_to_spl(uint256)`) — replaced 2026-05-12 by `Withdraw.withdraw_to_ata(uint256)` (wrap leg: gas → wrapper ATA) and `HelperProgram.deposit_from_ata(uint256)` (unwrap leg: wrapper ATA → gas). The `IUnwrapSplToGas` / `IWrapGasToSpl` interfaces and their pre-bound constants are no longer in `interface.sol`. Migration sequence: rome-solidity PR #137 → #138 → #141 → #143 paired with rome-evm-private #348 / #349 / #351 / #352 / #353 / #354.
 
 #### `CpiProgram` shortcut selectors (`0xff..08`)
+
+> **"CpiProgram" is a historical name — most of these selectors are NOT CPIs.** The precompile carries two dispatch families: actual Solana CPI (`invoke` / `invoke_signed`, which sign as the caller's `EXTERNAL_AUTHORITY` PDA) AND a set of read-side shortcuts (`account_info`, `account_data_at`, `account_u64_at`, `account_lamports`, `pdas_batch_derive`) that the on-chain dispatcher routes through `NonEvmCall::CrossStateEthCall` — no inner Solana invocation, no signing, no PDA seeds, no on-chain side effect. The read shortcuts are pure cross-state queries. **Authoritative per-selector dispatch table (column "Dispatch"):** [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "CpiProgram". Read it before assuming a selector that lives at `0xff..08` issues a CPI — most don't.
 
 (rome-evm-private PRs #318 / #319 / #320, shipped 2026-05-06; trimmed 2026-05-12 — `spl_transfer_checked_v1` + `derive_user_ata` migrated into `HelperProgram` under cleaner names):
 

--- a/contracts/cpi/AccountReader.sol
+++ b/contracts/cpi/AccountReader.sol
@@ -30,13 +30,52 @@ import {CpiProgram} from "../interface.sol";
 ///   `expectOwner`, `expectDataLen` are NOT included — no current consumer
 ///   needs them. Add them when a consumer does, not before.
 ///
-/// ## Live behavior
+/// ## Live behavior — these are reads, not CPIs
 ///
 ///   Every function dispatches through the `CpiProgram` pre-bound constant
-///   (precompile at `0xff00…0008`). The precompile signs the read as the
-///   EVM caller via Rome's `external_auth` derivation; for read-only
-///   account inspection this is irrelevant but worth knowing when reading
-///   the source.
+///   (precompile at `0xff00…0008`). The name "CpiProgram" is historical:
+///   the precompile carries both arbitrary Solana CPI dispatch (`invoke` /
+///   `invoke_signed`, selectors `0x7480cb86` / `0xb94f3733`) AND a family
+///   of read-side shortcut selectors. The three selectors used here —
+///   `account_data_at` (`0x593762e8`), `account_u64_at` (`0xb317d4c1`),
+///   `account_lamports` (`0xde79ed54`) — dispatch as
+///   `NonEvmCall::CrossStateEthCall`, not `NonEvmCall::Invoke`.
+///
+///   Concretely, this means:
+///
+///   - **No Solana CPI is issued.** The on-chain dispatcher routes these
+///     selectors through `cross_state_call`, which reads the target
+///     `AccountInfo` and returns the bytes. There is no inner Solana
+///     program invocation.
+///   - **No signing.** No `invoke_signed`, no PDA seeds, no
+///     `external_auth(caller)` derivation participates in the read.
+///     `AccountReader` never calls a signed path; the signing semantics
+///     of `invoke_signed` apply only to the two `Invoke` selectors and
+///     are not on the code path of any function in this library.
+///   - **No on-chain side effect.** These are pure cross-state queries —
+///     equivalent to an `eth_call` against a Solana account.
+///
+///   Source of truth for the dispatch routing: `rome-evm-private/program/
+///   src/non_evm/cpi.rs:65` (the `ACCOUNT_DATA_AT => CrossStateEthCall`
+///   match arm; the three v2 selectors `ACCOUNT_U64_AT`, `ACCOUNT_LAMPORTS`,
+///   `PDAS_BATCH_DERIVE` join the same arm on lines 71-73). The full per-
+///   selector dispatch table is in
+///   [`rome-evm-private/CLAUDE.md`](../../../rome-evm-private/CLAUDE.md) §
+///   "CpiProgram" — column "Dispatch" labels each selector with its
+///   `NonEvmCall` variant.
+///
+///   The signing path (`invoke_signed` → `EXTERNAL_AUTHORITY(caller)` PDA)
+///   only runs for `ICrossProgramInvocation.invoke_signed`. Reaching for
+///   `AccountReader` does not exercise it.
+///
+/// ## Validation
+///
+///   - Selector hex re-verified via `cast keccak <signature>` against
+///     `rome-evm-private/program/src/non_evm/cpi.rs` const block on
+///     2026-05-13 and 2026-05-22 — matches `ACCOUNT_DATA_AT`,
+///     `ACCOUNT_U64_AT`, `ACCOUNT_LAMPORTS`.
+///   - Dispatch-variant claim verified against `cpi.rs:65,71-73` —
+///     all three selectors route to `NonEvmCall::CrossStateEthCall`.
 library AccountReader {
     /// Lamports balance of `account`. Cheapest read — no data buffer
     /// fetch. Common pattern: gate-check whether an account exists at all

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -10,8 +10,11 @@ import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title PythPullAdapter
 /// @notice Per-feed adapter that reads PriceUpdateV2 from Pyth Solana Receiver
-///         via Rome's CPI precompile. Implements both IAggregatorV3Interface and
-///         IExtendedOracleAdapter. Deployed as EIP-1167 clone by OracleAdapterFactory.
+///         via Rome's `CpiProgram` precompile (read-shortcut path —
+///         `account_data_at` dispatches as `NonEvmCall::CrossStateEthCall`,
+///         not a Solana CPI; no signing, no PDA seeds involved). Implements
+///         both IAggregatorV3Interface and IExtendedOracleAdapter. Deployed
+///         as EIP-1167 clone by OracleAdapterFactory.
 contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     bytes32 public pythAccount;
     string private _description;

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -10,9 +10,12 @@ import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title SwitchboardV3Adapter
 /// @notice Per-feed adapter that reads AggregatorAccountData from Switchboard V2
-///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f) via Rome's CPI
-///         precompile. Same interface as PythPullAdapter. Deployed as EIP-1167
-///         clone by OracleAdapterFactory.
+///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f) via Rome's
+///         `CpiProgram` precompile (read-shortcut path — `account_data_at`
+///         dispatches as `NonEvmCall::CrossStateEthCall`, not a Solana CPI;
+///         no signing, no PDA seeds involved). Same interface as
+///         PythPullAdapter. Deployed as EIP-1167 clone by
+///         OracleAdapterFactory.
 /// @dev The contract name keeps "V3" for backwards compatibility with the
 ///      deploy scripts and cached ABIs, but both the program ID passed by
 ///      the factory and the byte layout consumed by SwitchboardParser target


### PR DESCRIPTION
## Summary

The `AccountReader` library's NatSpec made a false claim about its dispatch semantics. The "Live behavior" section said every function "signs the read as the EVM caller via Rome's `external_auth` derivation." That is wrong. AccountReader's three selectors — `account_data_at`, `account_u64_at`, `account_lamports` — dispatch as `NonEvmCall::CrossStateEthCall` in [`rome-evm-private/program/src/non_evm/cpi.rs:65,71-73`](https://github.com/rome-protocol/rome-evm-private/blob/master/program/src/non_evm/cpi.rs#L65-L73). They are pure cross-state reads — no Solana CPI, no `invoke_signed`, no PDA seeds, no on-chain side effect. The signing path only runs for `invoke_signed` (the `Invoke` dispatch), which AccountReader never calls.

The same conflation appeared in three other surfaces in this repo, all fixed in this PR (NatSpec + CLAUDE.md only; no contract logic changes).

## Why

The `0xff..08` precompile is named `CpiProgram` for historical reasons — it was originally a CPI dispatcher and grew read-shortcut selectors later. Today the precompile carries two distinct dispatch families:

- **Invoke family** (`invoke` `0x7480cb86`, `invoke_signed` `0xb94f3733`) — these are real Solana CPIs. `invoke_signed` derives `EXTERNAL_AUTHORITY(caller)` and signs as the caller's PDA.
- **Read-shortcut family** (`account_info`, `account_data_at`, `account_u64_at`, `account_lamports`, `pdas_batch_derive`) — these are pure cross-state queries, equivalent to an `eth_call` against a Solana account. The on-chain dispatcher routes them through `cross_state_call`. No inner Solana invocation, no signing, no PDA seeds involved.

Agents reading AccountReader and inferring "this signs as `external_auth(caller)`" will reason incorrectly about authorization, gas, billing, error surfaces, and CU. The current AccountReader docstring was the most actively misleading instance: it asserted the signing happens "but is irrelevant for read-only inspection" — which framed a false claim as merely a minor implementation detail. Fixing this here prevents future agents from carrying the misunderstanding into adapter authoring.

This PR is part of a coordinated cross-monorepo docs cleanup driven by the foundation PR at rome-protocol/rome-evm-private#377.

## Changes

- **`contracts/cpi/AccountReader.sol`** — rewrote the "Live behavior" paragraph (lines 33-69 of the new file). New text:
  - Acknowledges "CpiProgram" is a historical name covering two dispatch families.
  - States explicitly that AccountReader's three selectors dispatch as `NonEvmCall::CrossStateEthCall`, not `NonEvmCall::Invoke`.
  - Lists the three concrete consequences (no Solana CPI, no signing, no PDA seeds; no on-chain side effect).
  - Cites `rome-evm-private/program/src/non_evm/cpi.rs:65` and the upstream `CLAUDE.md` dispatch table as sources of truth.
  - Adds a Validation footer with re-verification dates against `cast keccak` + the dispatch arm.
- **`contracts/oracle/PythPullAdapter.sol`** — NatSpec "via Rome's CPI precompile" → "via Rome's `CpiProgram` precompile (read-shortcut path — `account_data_at` dispatches as `NonEvmCall::CrossStateEthCall`, not a Solana CPI; no signing, no PDA seeds involved)".
- **`contracts/oracle/SwitchboardV3Adapter.sol`** — same wording adjustment.
- **`CLAUDE.md`** — added two notes:
  - A small banner above the "CpiProgram shortcut selectors" table flagging the historical name and pointing to the upstream per-selector dispatch table (column "Dispatch") for the actual on-chain side-effect model of each selector.
  - A Validation note in the "Rome-EVM Precompile Interfaces" section cross-referencing rome-evm-private#377 and pointing future agents to check the dispatch variant before assuming a `0xff..08` selector issues a CPI.

## Validation

- `npx hardhat compile` passes — 82 Solidity files compiled with solc 0.8.28 (cancun). No new warnings; the pre-existing Meteora factory size + orra.sol view/pure suggestions are unchanged.
- Selector hex re-verified via `cast keccak <signature>` against `rome-evm-private/program/src/non_evm/cpi.rs` const block on 2026-05-22 — `ACCOUNT_DATA_AT` = `0x593762e8`, `ACCOUNT_U64_AT` = `0xb317d4c1`, `ACCOUNT_LAMPORTS` = `0xde79ed54`.
- Dispatch-variant claim verified against `cpi.rs:65,71-73` — all three selectors route to `NonEvmCall::CrossStateEthCall`. The upstream `rome-evm-private/CLAUDE.md` § "CpiProgram" table also lists them as `CrossStateEthCall` in the "Dispatch" column.

## Cross-reference

- Foundation PR: rome-protocol/rome-evm-private#377 (explains the disambiguation and seeds the per-selector "Dispatch" column in the canonical surface table).
- Source of truth for dispatch routing: [`rome-evm-private/program/src/non_evm/cpi.rs:65`](https://github.com/rome-protocol/rome-evm-private/blob/master/program/src/non_evm/cpi.rs#L65) (the `ACCOUNT_DATA_AT => NonEvmCall::CrossStateEthCall(a, b)` arm, with the v2 selectors joining the same arm on lines 71-73).

## Out of scope

- No contract logic changes anywhere. NatSpec + markdown only.
- Other consumer repos (rome-ui, cardo, rome-sdk, etc.) are handled in their own parallel PRs under the same cleanup arc.