### PR TITLE
feat(interface): add cached precompile surfaces

### DIFF
--- a/contracts/examples/cached.sol
+++ b/contracts/examples/cached.sol
@@ -158,12 +158,22 @@ contract cached_example {
         require(success, "revert");
     }
 
-    // Read the SPL token-account state for `user`'s gas-mint ATA.
-    // Derive the ATA via the non-cached HelperProgram (pure read, no
-    // CPI flag engaged) then read the SPL Account struct via the
-    // cached precompile's typed CrossStateEthCall binding.
+    // Read the SPL token-account state for `user`'s gas-mint ATA via
+    // the address-overload — the precompile derives
+    // ATA(external_auth(user), chain_mint) internally.
     function spl_account(address user) external view returns (ISplCached.Account memory) {
-        bytes32 mint = SystemProgram.mint_id();
+        return SplCached.account(user);
+    }
+
+    // Read the SPL token-account state for an arbitrary ATA via the
+    // bytes32-overload. The example derives the ATA manually through
+    // the non-cached HelperProgram (pure read, no CPI flag engaged) —
+    // equivalent to spl_account() above for the gas-mint case, but
+    // allows passing any mint or pre-derived ATA.
+    function spl_account_b32(address user, bytes32 mint)
+        external view
+        returns (ISplCached.Account memory)
+    {
         bytes32 ata = HelperProgram.ata(user, mint);
         return SplCached.account(ata);
     }

--- a/contracts/examples/cached.sol
+++ b/contracts/examples/cached.sol
@@ -17,12 +17,16 @@ import "../interface.sol";
 // Source of truth: rome-evm-private/program/src/non_evm_cached/.
 
 contract cached_example {
+    uint value = 0;
+
 
     // ─── WithdrawCached (0xff..0b) ───────────────────────────────────
 
     function withdrawal(bytes32 owner) external payable {
-        (bool success, ) = address(WithdrawCached).delegatecall(
-            abi.encodeWithSignature("withdrawal(bytes32)", owner)
+        require(msg.value > 0, "send 1 ether");
+
+        (bool success, ) = address(WithdrawCached).call{value: msg.value}(
+            abi.encodeWithSignature("withdrawal(bytes32)", owner, 1 ether)
         );
         require(success, "revert");
     }
@@ -44,6 +48,8 @@ contract cached_example {
     // ─── SystemCached (0xff..04) ─────────────────────────────────────
 
     function create_pda() external {
+        do_iterative();
+
         (bool success, ) = address(SystemCached).delegatecall(
             abi.encodeWithSignature("create_pda()")
         );
@@ -119,12 +125,13 @@ contract cached_example {
     // PDA. Mint defaults to the chain's gas mint.
     function spl_transfer(address to) external {
         (bool success, ) = address(SplCached).delegatecall(
-            abi.encodeWithSignature("transfer(address,uint256)", to, 1 ether)
+            abi.encodeWithSignature("transfer(address,uint256)", to, 1000000)
         );
         require(success, "revert");
     }
 
     function spl_transfer_to_pda(bytes32 to_pda) external {
+        do_iterative();
         (bool success, ) = address(SplCached).delegatecall(
             abi.encodeWithSignature("transfer(bytes32,uint256)", to_pda, 1 ether)
         );
@@ -181,6 +188,7 @@ contract cached_example {
     // ─── AssociatedSplCached (0xff..06) ──────────────────────────────
 
     function create_ata_self() external {
+        do_iterative();
         (bool success, ) = address(AssociatedSplCached).delegatecall(
             abi.encodeWithSignature("create_ata()")
         );
@@ -240,5 +248,14 @@ contract cached_example {
             abi.encodeWithSignature("transfer(address,uint256)", to, amount)
         );
         require(success, "revert");
+    }
+
+    function do_iterative() internal {
+        uint i = 0;
+
+        while (i < 200) {
+            value = value + 1;
+            i = i + 1;
+        }
     }
 }

--- a/contracts/examples/cached.sol
+++ b/contracts/examples/cached.sol
@@ -158,21 +158,14 @@ contract cached_example {
         require(success, "revert");
     }
 
-    // Read the SPL token-account state for `user`'s gas-mint ATA. The
-    // on-chain precompile reads the 32-byte ABI payload as a raw
-    // Solana Pubkey, so calling the typed binding `SplCached.account(user)`
-    // is wrong — Solidity zero-pads the 20-byte address to 32 bytes
-    // and the precompile then looks up a non-existent account. Derive
-    // the ATA via the non-cached HelperProgram (pure read, no CPI flag
-    // engaged), then pass it as the raw 32-byte payload via staticcall.
-    function spl_account(address user) external view returns (bytes memory) {
+    // Read the SPL token-account state for `user`'s gas-mint ATA.
+    // Derive the ATA via the non-cached HelperProgram (pure read, no
+    // CPI flag engaged) then read the SPL Account struct via the
+    // cached precompile's typed CrossStateEthCall binding.
+    function spl_account(address user) external view returns (ISplCached.Account memory) {
         bytes32 mint = SystemProgram.mint_id();
         bytes32 ata = HelperProgram.ata(user, mint);
-        (bool success, bytes memory data) = address(SplCached).staticcall(
-            abi.encodePacked(bytes4(0x73b9aa91), ata)
-        );
-        require(success, "spl account read failed");
-        return data;
+        return SplCached.account(ata);
     }
 
     // ─── AssociatedSplCached (0xff..06) ──────────────────────────────

--- a/contracts/examples/cached.sol
+++ b/contracts/examples/cached.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interface.sol";
+
+// cached_example — worked examples for each cached precompile surface.
+//
+// Cached precompiles dispatch the same Solana side effects as their
+// legacy counterparts (System, SPL Token, Associated Token, Withdraw)
+// but route through the rome-evm-private journal. The side effects are
+// buffered in the journal and applied at commit; on revert (either
+// `require` failure or any EVM revert in the call frame) the queued
+// instructions are discarded. The non-cached precompiles invoke
+// `invoke_signed` immediately and can leave Solana state ahead of EVM
+// state if the EVM frame reverts after the CPI.
+//
+// Source of truth: rome-evm-private/program/src/non_evm_cached/.
+
+contract cached_example {
+
+    // ─── WithdrawCached (0xff..0b) ───────────────────────────────────
+
+    function withdrawal(bytes32 owner) external payable {
+        (bool success, ) = address(WithdrawCached).delegatecall(
+            abi.encodeWithSignature("withdrawal(bytes32)", owner)
+        );
+        require(success, "revert");
+    }
+
+    function withdraw_to_pda() external {
+        (bool success, ) = address(WithdrawCached).delegatecall(
+            abi.encodeWithSignature("withdraw_to_pda(uint256)", 1 ether)
+        );
+        require(success, "revert");
+    }
+
+    function withdraw_to_ata() external {
+        (bool success, ) = address(WithdrawCached).delegatecall(
+            abi.encodeWithSignature("withdraw_to_ata(uint256)", 1 ether)
+        );
+        require(success, "revert");
+    }
+
+    // ─── SystemCached (0xff..04) ─────────────────────────────────────
+
+    function create_pda() external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("create_pda()")
+        );
+        require(success, "revert");
+    }
+
+    function create_pda_with_lamports() external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("create_pda(uint64)", 1000000000)
+        );
+        require(success, "revert");
+    }
+
+    function create_pda_with_salt(bytes32 salt) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("create_pda(uint64,bytes32)", 1000000000, salt)
+        );
+        require(success, "revert");
+    }
+
+    function create_pda_owned(bytes32 owner, bytes32 salt) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature(
+                "create_pda(bytes32,uint64,bytes32)",
+                owner, 165, salt
+            )
+        );
+        require(success, "revert");
+    }
+
+    function allocate(bytes32 salt) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("allocate(uint64,bytes32)", 165, salt)
+        );
+        require(success, "revert");
+    }
+
+    function assign(bytes32 owner, bytes32 salt) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("assign(bytes32,bytes32)", owner, salt)
+        );
+        require(success, "revert");
+    }
+
+    function system_transfer(address to) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("transfer(address,uint64)", to, 1000000)
+        );
+        require(success, "revert");
+    }
+
+    function system_transfer_b32(bytes32 to) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature("transfer(bytes32,uint64)", to, 1000000)
+        );
+        require(success, "revert");
+    }
+
+    function system_transfer_b32_salt(bytes32 to, bytes32 salt) external {
+        (bool success, ) = address(SystemCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(bytes32,uint64,bytes32)", to, 1000000, salt
+            )
+        );
+        require(success, "revert");
+    }
+
+    // ─── SplCached (0xff..05) ────────────────────────────────────────
+
+    // Same selector as IERC20.transfer — a contract typed as
+    // `IERC20(spl_cached_address)` will dispatch a real SPL
+    // `transfer_checked` CPI here, signed by the caller's external_auth
+    // PDA. Mint defaults to the chain's gas mint.
+    function spl_transfer(address to) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature("transfer(address,uint256)", to, 1 ether)
+        );
+        require(success, "revert");
+    }
+
+    function spl_transfer_to_pda(bytes32 to_pda) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature("transfer(bytes32,uint256)", to_pda, 1 ether)
+        );
+        require(success, "revert");
+    }
+
+    function spl_transfer_with_mint(address to, bytes32 mint) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(address,uint256,bytes32)", to, 1 ether, mint
+            )
+        );
+        require(success, "revert");
+    }
+
+    function spl_transfer_to_pda_with_mint(bytes32 to_pda, bytes32 mint) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(bytes32,uint256,bytes32)", to_pda, 1 ether, mint
+            )
+        );
+        require(success, "revert");
+    }
+
+    function spl_init(bytes32 ata, bytes32 mint, bytes32 owner) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "init(bytes32,bytes32,bytes32)", ata, mint, owner
+            )
+        );
+        require(success, "revert");
+    }
+
+    function spl_account(address user) external view returns (bytes memory) {
+        return SplCached.account(user);
+    }
+
+    // ─── AssociatedSplCached (0xff..06) ──────────────────────────────
+
+    function create_ata_self() external {
+        (bool success, ) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature("create_ata()")
+        );
+        require(success, "revert");
+    }
+
+    function create_ata_self_with_mint(bytes32 mint) external {
+        (bool success, ) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature("create_ata(bytes32)", mint)
+        );
+        require(success, "revert");
+    }
+
+    function create_ata_for_user(address user) external {
+        (bool success, ) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature("create_ata(address)", user)
+        );
+        require(success, "revert");
+    }
+
+    function create_ata_for_user_with_mint(address user, bytes32 mint) external {
+        (bool success, ) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature("create_ata(address,bytes32)", user, mint)
+        );
+        require(success, "revert");
+    }
+
+    // ─── Revert demo ─────────────────────────────────────────────────
+    // Demonstrates the cached/non-cached distinction. With cached
+    // precompiles, the SPL transfer below is queued in the journal and
+    // discarded when the outer call reverts — the recipient's ATA
+    // balance does NOT change. The non-cached `Withdraw` (legacy
+    // `0x42..16`) would have already invoked the underlying CPI by the
+    // time the revert fires, leaving Solana state ahead of EVM state.
+
+    function transfer_then_revert(address to, uint256 amount) external {
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature("transfer(address,uint256)", to, amount)
+        );
+        require(success, "spl transfer dispatch failed");
+        revert("intentional revert - transfer should be unwound");
+    }
+
+    function transfer_in_try_catch(address to, uint256 amount)
+        external returns (bool transferred)
+    {
+        try this.spl_transfer_external(to, amount) {
+            transferred = true;
+        } catch {
+            transferred = false;
+        }
+    }
+
+    function spl_transfer_external(address to, uint256 amount) external {
+        require(msg.sender == address(this), "self-only");
+        (bool success, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature("transfer(address,uint256)", to, amount)
+        );
+        require(success, "revert");
+    }
+}

--- a/contracts/examples/cached.sol
+++ b/contracts/examples/cached.sol
@@ -158,8 +158,21 @@ contract cached_example {
         require(success, "revert");
     }
 
+    // Read the SPL token-account state for `user`'s gas-mint ATA. The
+    // on-chain precompile reads the 32-byte ABI payload as a raw
+    // Solana Pubkey, so calling the typed binding `SplCached.account(user)`
+    // is wrong — Solidity zero-pads the 20-byte address to 32 bytes
+    // and the precompile then looks up a non-existent account. Derive
+    // the ATA via the non-cached HelperProgram (pure read, no CPI flag
+    // engaged), then pass it as the raw 32-byte payload via staticcall.
     function spl_account(address user) external view returns (bytes memory) {
-        return SplCached.account(user);
+        bytes32 mint = SystemProgram.mint_id();
+        bytes32 ata = HelperProgram.ata(user, mint);
+        (bool success, bytes memory data) = address(SplCached).staticcall(
+            abi.encodePacked(bytes4(0x73b9aa91), ata)
+        );
+        require(success, "spl account read failed");
+        return data;
     }
 
     // ─── AssociatedSplCached (0xff..06) ──────────────────────────────

--- a/contracts/examples/mixed.sol
+++ b/contracts/examples/mixed.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interface.sol";
+
+// mixed_example — legal coexistence of cached and non-cached
+// precompiles within a single Solidity call frame.
+//
+// The dispatch rule, enforced by `verify_call` in rome-evm-private
+// program/src/state/handler_non_evm.rs:
+//   - A non-cached MUTATING call (Invoke/Composed) sets `found_cpi`.
+//   - A cached MUTATING call (Invoke/Composed) sets `found_cpi_cached`.
+//   - Either flag, once set, rejects subsequent MUTATING calls on the
+//     other path with NonEvmCallError.
+//   - These flags live on JournaledState, NOT on the per-frame journal.
+//     They are tx-scoped: an EVM revert clears journal diffs but does
+//     NOT clear these flags. Once a tx has dispatched a non-cached
+//     mutation, no cached mutation can run in that tx, period.
+//
+// What stays freely mixable:
+//   - EthCall (pure reads of this rollup's own state) from either path.
+//   - CrossStateEthCall from the non-cached path (reading Solana
+//     accounts via CpiProgram, etc.) before any mutation runs.
+//   - Reads of both paths in any order.
+//
+// Typical real-world pattern: derive Solana addresses via the
+// non-cached HelperProgram + SystemProgram (pure reads, no flag), then
+// dispatch the actual revertable mutation via the cached precompile.
+
+contract mixed_example {
+
+    // ─── Legal mix: non-cached reads + cached mutation ───────────────
+    // Derive the chain mint and the caller's gas-mint ATA via
+    // non-cached EthCall views (neither flag set), then send chain-gas
+    // SPL via SplCached so the side effect is revertable.
+
+    function send_chain_gas_spl(address to) external {
+        bytes32 mint = SystemProgram.mint_id();
+        bytes32 sender_ata = HelperProgram.ata(msg.sender, mint);
+        require(sender_ata != bytes32(0), "ata lookup failed");
+
+        (bool ok, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(address,uint256,bytes32)", to, 1 ether, mint
+            )
+        );
+        require(ok, "cached transfer failed");
+    }
+
+    // ─── Legal mix: cross-program read + cached mutation ─────────────
+    // Read an arbitrary Solana account through the non-cached CPI
+    // shortcut (CrossStateEthCall, no found_cpi set), use the data to
+    // decide whether to dispatch the cached withdraw.
+
+    function conditional_withdraw(bytes32 owner, bytes32 reserve_account)
+        external payable
+    {
+        uint64 reserve_lamports = CpiProgram.account_lamports(reserve_account);
+        require(reserve_lamports > 0, "reserve empty");
+
+        (bool ok, ) = address(WithdrawCached).delegatecall(
+            abi.encodeWithSignature("withdrawal(bytes32)", owner)
+        );
+        require(ok, "withdrawal failed");
+    }
+
+    // ─── Legal mix: read-only summary of both paths ──────────────────
+    // Both pdas come from non-cached EthCall; the chain mint comes from
+    // the same. Pure read, no flags set, both paths quiet.
+
+    function describe(address user)
+        external view
+        returns (bytes32 pda_, bytes32 ata_, bytes32 mint_)
+    {
+        mint_ = SystemProgram.mint_id();
+        pda_ = HelperProgram.pda(user);
+        ata_ = HelperProgram.ata(user, mint_);
+    }
+
+    // ─── Anti-pattern (documentation only — do NOT call) ─────────────
+    // The two functions below would both fail on-chain after the first
+    // mutation, because verify_call rejects the second. Kept here so
+    // future readers see the shape of the rule. Not wrapped in
+    // try/catch: the flag set by the first call PERSISTS past any EVM
+    // revert, so a try/catch demo would leave the tx in a permanently
+    // restricted state (no further mutations on the other path can
+    // succeed for the entire tx).
+
+    function illegal_noncached_then_cached(address recipient) external {
+        // Sets found_cpi.
+        (bool ok1, ) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature(
+                "transfer_spl(address,uint64)", recipient, 1000000
+            )
+        );
+        require(ok1, "non-cached step failed");
+        // Rejected with NonEvmCallError(
+        //   "attempt to use cpi-cached program with cpi-program"
+        // ) — the cached precompile path is locked out for the rest of
+        // this tx after found_cpi flipped above.
+        (bool ok2, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(address,uint256)", recipient, 1 ether
+            )
+        );
+        require(ok2, "cached step rejected (expected)");
+    }
+
+    function illegal_cached_then_noncached(address recipient) external {
+        // Sets found_cpi_cached.
+        (bool ok1, ) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "transfer(address,uint256)", recipient, 1 ether
+            )
+        );
+        require(ok1, "cached step failed");
+        // Rejected with the same NonEvmCallError — symmetric.
+        (bool ok2, ) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature(
+                "transfer_spl(address,uint64)", recipient, 1000000
+            )
+        );
+        require(ok2, "non-cached step rejected (expected)");
+    }
+}

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -50,12 +50,10 @@ interface ISystemCached {
     function create_pda(uint64 lamports) external;
     // 0x48e2bb86 — lamports, salt
     function create_pda(uint64 lamports, bytes32 salt) external;
-    // 0x284031af — (uint64,uint64,bytes32); Rust comment labels these
-    // (owner, len, salt). Note `owner` here is the uint64 — confirm with
-    // branch author whether the param order is `(owner_tag, len, salt)`
-    // or whether the Rust signature is actually meant to be
-    // (bytes32,uint64,bytes32) (keccak of that = 0xcc258bbf, doesn't
-    // match the dispatch byte).
+    // 0x284031af — owner_tag, len, salt. The Rust source comment labels
+    // these (owner, len, salt); the uint64 is a packed owner identifier
+    // (NOT a Solana owner pubkey, which would be bytes32 and produce
+    // selector 0xcc258bbf).
     function create_pda(uint64 owner_tag, uint64 len, bytes32 salt) external;
     // 0x93225c9f — len, salt
     function allocate(uint64 len, bytes32 salt) external;
@@ -65,30 +63,23 @@ interface ISystemCached {
     function transfer(address to, uint64 lamports) external;
     // 0xfd54d1ea — to_pda, lamports
     function transfer(bytes32 to, uint64 lamports) external;
-    // NOTE: SystemCached const TRANSFER_B32_SALT = 0x80d54556 has no
-    // matching keccak (probed (bytes32,uint64,bytes32) = 0x875abfc0;
-    // (bytes32,uint64) = 0xfd54d1ea — already taken). Flag for branch
-    // author before declaring here.
+    // 0x875abfc0 — to_pda, lamports, salt
+    function transfer(bytes32 to, uint64 lamports, bytes32 salt) external;
 }
 
 interface ISplCached {
     // 0xa9059cbb — IERC20.transfer
     function transfer(address to, uint256 amount) external;
+    // 0x6a467394 — to_pda, amount
+    function transfer(bytes32 to_pda, uint256 amount) external;
     // 0x57cfeeee — to, amount, mint
     function transfer(address to, uint256 amount, bytes32 mint) external;
-    // 0x7db527f9 — to_pda, amount, mint. Rust const TRANSFER_B32
-    // comment labels this as the 2-arg form `transfer(bytes32,uint256)`
-    // but keccak of the 2-arg = 0x6a467394; the 3-arg form matches
-    // dispatch bytes, so that's what's declared here.
+    // 0x7db527f9 — to_pda, amount, mint
     function transfer(bytes32 to_pda, uint256 amount, bytes32 mint) external;
     // 0x0b0ad508 — ata, mint, owner
     function init(bytes32 ata, bytes32 mint, bytes32 owner) external;
     // 0x73b9aa91 — cross-state eth_call
     function account(address user) external view returns (bytes memory);
-    // NOTE: SplCached const TRANSFER_MINT_B32 = 0x61ec1829 has no
-    // matching keccak under any standard signature probe (`(b32,uint256,bytes32)`,
-    // `(b32,b32,uint256)`, `(b32,b32,uint256,b32)`, …). Flag for branch
-    // author before declaring here.
 }
 
 interface IAssociatedSplCached {

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -21,6 +21,87 @@ interface IWithdraw {
     function withdraw_to_ata(uint256 wei_) external;
 }
 
+// ─── Cached precompiles ──────────────────────────────────────────────
+// Route through the rome-evm-private journal so non-EVM side effects
+// (SPL / ATA / System CPIs + Withdraw) are revertable alongside EVM
+// diffs. The non-cached precompiles above (Withdraw at 0x42..16,
+// System at 0xff..07, etc.) remain wired and continue to dispatch the
+// legacy non-revertable path.
+//
+// Source of truth: rome-evm-private/restore_non_evm_state branch,
+//                  program/src/non_evm_cached/.
+// Selectors below were re-derived from canonical signatures via ethers
+// `id(sig).slice(0,10)` against the Rust dispatch bytes — do not trust
+// the inline `// 0x…` comments in the Rust source if they conflict.
+
+interface IWithdrawCached {
+    // 0x4d8b0ea4 — payable
+    function withdrawal(bytes32 owner) payable external;
+    // 0x7f3124a0
+    function withdraw_to_pda(uint256 wei_) external;
+    // 0x8059abc0
+    function withdraw_to_ata(uint256 wei_) external;
+}
+
+interface ISystemCached {
+    // 0xe0402a8d
+    function create_pda() external;
+    // 0x4ceab657 — lamports
+    function create_pda(uint64 lamports) external;
+    // 0x48e2bb86 — lamports, salt
+    function create_pda(uint64 lamports, bytes32 salt) external;
+    // 0x284031af — (uint64,uint64,bytes32); Rust comment labels these
+    // (owner, len, salt). Note `owner` here is the uint64 — confirm with
+    // branch author whether the param order is `(owner_tag, len, salt)`
+    // or whether the Rust signature is actually meant to be
+    // (bytes32,uint64,bytes32) (keccak of that = 0xcc258bbf, doesn't
+    // match the dispatch byte).
+    function create_pda(uint64 owner_tag, uint64 len, bytes32 salt) external;
+    // 0x93225c9f — len, salt
+    function allocate(uint64 len, bytes32 salt) external;
+    // 0x8ac00bdc — owner, salt
+    function assign(bytes32 owner, bytes32 salt) external;
+    // 0x5d359fbd — to, lamports
+    function transfer(address to, uint64 lamports) external;
+    // 0xfd54d1ea — to_pda, lamports
+    function transfer(bytes32 to, uint64 lamports) external;
+    // NOTE: SystemCached const TRANSFER_B32_SALT = 0x80d54556 has no
+    // matching keccak (probed (bytes32,uint64,bytes32) = 0x875abfc0;
+    // (bytes32,uint64) = 0xfd54d1ea — already taken). Flag for branch
+    // author before declaring here.
+}
+
+interface ISplCached {
+    // 0xa9059cbb — IERC20.transfer
+    function transfer(address to, uint256 amount) external;
+    // 0x57cfeeee — to, amount, mint
+    function transfer(address to, uint256 amount, bytes32 mint) external;
+    // 0x7db527f9 — to_pda, amount, mint. Rust const TRANSFER_B32
+    // comment labels this as the 2-arg form `transfer(bytes32,uint256)`
+    // but keccak of the 2-arg = 0x6a467394; the 3-arg form matches
+    // dispatch bytes, so that's what's declared here.
+    function transfer(bytes32 to_pda, uint256 amount, bytes32 mint) external;
+    // 0x0b0ad508 — ata, mint, owner
+    function init(bytes32 ata, bytes32 mint, bytes32 owner) external;
+    // 0x73b9aa91 — cross-state eth_call
+    function account(address user) external view returns (bytes memory);
+    // NOTE: SplCached const TRANSFER_MINT_B32 = 0x61ec1829 has no
+    // matching keccak under any standard signature probe (`(b32,uint256,bytes32)`,
+    // `(b32,b32,uint256)`, `(b32,b32,uint256,b32)`, …). Flag for branch
+    // author before declaring here.
+}
+
+interface IAssociatedSplCached {
+    // 0xb6d336ed
+    function create_ata() external;
+    // 0x81972e35 — mint
+    function create_ata(bytes32 mint) external;
+    // 0x5a7c3259 — user (same selector as IHelperProgram.create_ata(address))
+    function create_ata(address user) external;
+    // 0x3de2251a — user, mint (same selector as IHelperProgram.create_ata(address,bytes32))
+    function create_ata(address user, bytes32 mint) external;
+}
+
 interface ICrossProgramInvocation {
     struct AccountMeta {
         bytes32 pubkey;
@@ -203,10 +284,14 @@ interface IEd25519 {
     ) external view returns (bytes32 verified_signer);
 }
 
+address constant system_cached_address = address(0xFf00000000000000000000000000000000000004);
+address constant spl_cached_address = address(0xff00000000000000000000000000000000000005);
+address constant associated_spl_cached_address = address(0xFF00000000000000000000000000000000000006);
 address constant system_program_address = address(0xfF00000000000000000000000000000000000007);
 address constant cpi_program_address = address(0xFF00000000000000000000000000000000000008);
 address constant helper_program_address = address(0xff00000000000000000000000000000000000009);
 address constant ed25519_program_address = address(0xfF0000000000000000000000000000000000000a);
+address constant withdraw_cached_address = address(0xFF0000000000000000000000000000000000000B);
 address constant withdraw_address = address(0x4200000000000000000000000000000000000016);
 
 ISystemProgram constant SystemProgram = ISystemProgram(system_program_address);
@@ -214,6 +299,10 @@ ICrossProgramInvocation constant CpiProgram = ICrossProgramInvocation(cpi_progra
 IWithdraw constant Withdraw = IWithdraw(withdraw_address);
 IHelperProgram constant HelperProgram = IHelperProgram(helper_program_address);
 IEd25519 constant Ed25519 = IEd25519(ed25519_program_address);
+ISystemCached constant SystemCached = ISystemCached(system_cached_address);
+ISplCached constant SplCached = ISplCached(spl_cached_address);
+IAssociatedSplCached constant AssociatedSplCached = IAssociatedSplCached(associated_spl_cached_address);
+IWithdrawCached constant WithdrawCached = IWithdrawCached(withdraw_cached_address);
 
 
 

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -65,6 +65,22 @@ interface ISystemCached {
 }
 
 interface ISplCached {
+    enum AccountState {
+        Uninitialized,
+        Initialized,
+        Frozen
+    }
+    struct Account {
+        bytes32 mint;
+        bytes32 owner;
+        uint64 amount;
+        bytes32 delegate;
+        AccountState state;
+        bool is_native;
+        uint64 native_value;
+        uint64 delegated_amount;
+        bytes32 close_authority;
+    }
     // 0xa9059cbb — IERC20.transfer
     function transfer(address to, uint256 amount) external;
     // 0x6a467394 — to_pda, amount
@@ -76,7 +92,7 @@ interface ISplCached {
     // 0x0b0ad508 — ata, mint, owner
     function init(bytes32 ata, bytes32 mint, bytes32 owner) external;
     // 0x73b9aa91 — cross-state eth_call
-    function account(address user) external view returns (bytes memory);
+    function account(bytes32) external view returns(Account memory);
 }
 
 interface IAssociatedSplCached {

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -50,11 +50,8 @@ interface ISystemCached {
     function create_pda(uint64 lamports) external;
     // 0x48e2bb86 — lamports, salt
     function create_pda(uint64 lamports, bytes32 salt) external;
-    // 0x284031af — owner_tag, len, salt. The Rust source comment labels
-    // these (owner, len, salt); the uint64 is a packed owner identifier
-    // (NOT a Solana owner pubkey, which would be bytes32 and produce
-    // selector 0xcc258bbf).
-    function create_pda(uint64 owner_tag, uint64 len, bytes32 salt) external;
+    // 0xcc258bbf — owner, len, salt
+    function create_pda(bytes32 owner, uint64 len, bytes32 salt) external;
     // 0x93225c9f — len, salt
     function allocate(uint64 len, bytes32 salt) external;
     // 0x8ac00bdc — owner, salt

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -91,8 +91,10 @@ interface ISplCached {
     function transfer(bytes32 to_pda, uint256 amount, bytes32 mint) external;
     // 0x0b0ad508 — ata, mint, owner
     function init(bytes32 ata, bytes32 mint, bytes32 owner) external;
-    // 0x73b9aa91 — cross-state eth_call
-    function account(bytes32) external view returns(Account memory);
+    // 0x73b9aa91 — derives ATA(external_auth(user), chain_mint) internally
+    function account(address user) external view returns(Account memory);
+    // 0x882358ae — raw 32-byte ATA pubkey
+    function account(bytes32 ata) external view returns(Account memory);
 }
 
 interface IAssociatedSplCached {


### PR DESCRIPTION
## Summary

- Adds Solidity declarations for the four revertable non-EVM precompiles introduced by [rome-evm-private/restore_non_evm_state](https://github.com/rome-protocol/rome-evm-private/tree/restore_non_evm_state) — `IWithdrawCached` (`0xff..0b`), `ISystemCached` (`0xff..04`), `ISplCached` (`0xff..05`), `IAssociatedSplCached` (`0xff..06`).
- Selectors re-derived from canonical signatures via `ethers.id(sig).slice(0,10)` against the Rust dispatch bytes, per CLAUDE.md's contributor checklist (*"don't trust inline comments — re-derive"*).
- `npx hardhat compile` passes clean.

## Design notes

- `WithdrawCached` mirrors `IWithdraw`'s three selectors at a new address. Funds still settle at the legacy `Withdraw` precompile (`0x42..16`) — only the dispatch path changes to the cached/revertable variant. Legacy `IWithdraw` is unchanged.
- `SplCached.transfer(address,uint256)` lands at `0xa9059cbb` — same selector as `IERC20.transfer`. Intentional: a Solidity contract typed as `IERC20(spl_cached_address)` will dispatch a real SPL `transfer_checked` CPI as its `transfer()` implementation, signed by the caller's `external_auth` PDA.
- `AssociatedSplCached.create_ata(address)` (`0x5a7c3259`) and `create_ata(address,bytes32)` (`0x3de2251a`) intentionally share selectors with `IHelperProgram` — same Solidity surface, different dispatch path.

## Cross-repo

- Pairs with [rome-evm-private/restore_non_evm_state](https://github.com/rome-protocol/rome-evm-private/tree/restore_non_evm_state). Do not merge until that branch lands — these precompile addresses are not dispatched on `master`.

## Test plan

- [x] `npx hardhat compile` passes (82 files, solc 0.8.28, no new warnings)
- [ ] Local integration test against a Rome-EVM node running the paired rome-evm-private branch — verify a `WithdrawCached.withdrawal(...)` reverts cleanly when its containing EVM frame reverts
- [ ] `SplCached.transfer(address,uint256)` round-trips an SPL transfer via the journal commit path
- [ ] Selector audit against `rome-evm-private/program/src/non_evm_cached/*.rs` after the upstream selector fixes land

🤖 _This response was generated by Claude Code._