### PR TITLE
docs(claude+cpi+oracle): CPI vs CrossStateEthCall disambiguation + cached precompile family + one-track rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,20 +126,48 @@ npx hardhat keystore set <CHAIN>_PRIVATE_KEY --dev
 
 The core abstraction layer. Rome-EVM exposes Solana programs as EVM precompiles at fixed addresses. **Authoritative inventory of upstream Rust dispatch + selector hex lives in [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md)** — when adding a method, treat the Rust side as canonical and mirror here.
 
-| Precompile | Address | Interface | Source of truth |
-|---|---|---|---|
-| System Program | `0xff..07` | `ISystemProgram` — PDA derivation, base58, mint/operator/program-id getters | `program/src/non_evm/system.rs` |
-| CPI | `0xff..08` | `ICrossProgramInvocation` — arbitrary Solana CPI + 4 CU-shortcut selectors | `program/src/non_evm/cpi.rs` |
-| Helper Program | `0xff..09` | `IHelperProgram` — 14 selectors for SPL / PDA / ATA / lamports / gas-token plumbing | `program/src/non_evm/helper.rs` |
-| Withdraw | `0x42..16` | `IWithdraw` — SOL `withdrawal` + the two gas-token bridge legs (`withdraw_to_pda` / `withdraw_to_ata`) | `program/src/non_evm/withdraw.rs` |
+| Precompile | Address | Interface | Track | Source of truth |
+|---|---|---|---|---|
+| **SystemCached** | `0xff..04` | `ISystemCached` — PDA create + system-program ops (allocate, assign, lamport transfer), revertable | **cached** | `program/src/non_evm_cached/system_cached.rs` |
+| **SplCached** | `0xff..05` | `ISplCached` — SPL Token / Token-2022 transfers + ATA init + cross-state account reads, revertable | **cached** | `program/src/non_evm_cached/spl_cached.rs` |
+| **AssociatedSplCached** | `0xff..06` | `IAssociatedSplCached` — idempotent ATA-create variants, revertable | **cached** | `program/src/non_evm_cached/aspl_cached.rs` |
+| System Program | `0xff..07` | `ISystemProgram` — PDA derivation, base58, mint/operator/program-id getters | legacy | `program/src/non_evm/system.rs` |
+| CPI | `0xff..08` | `ICrossProgramInvocation` — arbitrary Solana CPI + 4 CU-shortcut selectors | legacy | `program/src/non_evm/cpi.rs` |
+| Helper Program | `0xff..09` | `IHelperProgram` — 14 selectors for SPL / PDA / ATA / lamports / gas-token plumbing | legacy | `program/src/non_evm/helper.rs` |
+| Ed25519 | `0xff..0a` | `IEd25519` — Ed25519 sysvar-verify allowlist (Pyth Lazer support) | neutral (read-only) | `program/src/non_evm/ed25519.rs` |
+| **WithdrawCached** | `0xff..0b` | `IWithdrawCached` — gas-token withdrawal legs, revertable. Cached counterpart to `Withdraw @ 0x42..16` | **cached** | `program/src/non_evm_cached/withdraw_cached.rs` |
+| Withdraw | `0x42..16` | `IWithdraw` — SOL `withdrawal` + the two gas-token bridge legs (`withdraw_to_pda` / `withdraw_to_ata`) | legacy | `program/src/non_evm/withdraw.rs` |
 
-Global constants pre-bound by `interface.sol`: `SystemProgram`, `CpiProgram`, `HelperProgram`, `Withdraw`.
+Global constants pre-bound by `interface.sol`: `SystemProgram`, `CpiProgram`, `HelperProgram`, `Withdraw`, plus the new cached-track addresses `system_cached_address`, `spl_cached_address`, `associated_spl_cached_address`, `withdraw_cached_address`, `ed25519_program_address` (per rome-solidity #204, merged 2026-05-23).
 
-**Validation note (2026-05-22).** "CPI in docs" ≠ "Solana CPI on chain". When a precompile method's NatSpec says "via Rome's CPI precompile", check the dispatch variant in the source-of-truth table at [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "Precompile Interfaces — Canonical Surface". Only selectors marked `Invoke` (or `Composed` arms that nest an `Invoke`) actually issue a Solana CPI signed by the caller's `EXTERNAL_AUTHORITY` PDA. Selectors marked `EthCall` / `CrossStateEthCall` are pure reads — no signing, no PDA seeds, no on-chain side effect. AccountReader (this repo's `contracts/cpi/AccountReader.sol`) and the oracle adapters (`contracts/oracle/PythPullAdapter.sol`, `contracts/oracle/SwitchboardV3Adapter.sol`) only exercise the `CrossStateEthCall` path. Foundation PR: [`rome-protocol/rome-evm-private#377`](https://github.com/rome-protocol/rome-evm-private/pull/377).
+### Track selection — one track per contract (HARD RULE)
+
+**A Solidity contract picks one precompile track — cached or legacy — and commits to it.** Mixing cached-track and legacy-track precompile *mutating* calls within the same contract, or transitively across contracts in the same tx, is unsupported and runtime-blocked by `verify_call` in rome-evm-private. Track decision is **per-tx, sticky after revert** — once a track fires (even in a frame that later reverts), the tx is locked into it.
+
+Author statement (rome-evm-private PR #376, Valentin Konyakhin, 2026-05-22): *"Contract must use either a Cpi-based Solidity program or Cached-based Solidity program."*
+
+**What this means in practice:**
+- A contract that calls `ISplCached.transfer(...)` MUST NOT also call `IHelperProgram.transfer_spl(...)` in any reachable code path
+- A contract using `IAssociatedSplCached.create_ata(...)` cannot fall back to `IHelperProgram.create_ata(...)` in `try/catch` — gate fires regardless of revert
+- Migration from legacy → cached is a **contract-redeploy event**: deploy a new contract (e.g., `SPL_ERC20_cached`), point consumers at the new address, do not hybrid-modify an existing contract
+- CrossStateEthCall reads (`account_data_at`, `account_info`, `user_balance`, `lazer_price`, `ISplCached.account`, etc.) are track-neutral — pure reads, never lock a track
+
+**Why this rule:**
+- Auditability — one question per contract ("which track?"), not a code-path map
+- No subtle state-vs-overlay divergence at runtime
+- Static analysis can flag mixed-track contracts as policy violations
+
+**Authoritative dispatch + track-gate spec:** [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "Track selection — one track per contract (HARD RULE)". Foundation PR: [`rome-protocol/rome-evm-private#382`](https://github.com/rome-protocol/rome-evm-private/pull/382).
+
+**Worked examples for cached-track contracts:** `contracts/examples/cached.sol` (canonical patterns) and `contracts/examples/mixed.sol` (intentional anti-pattern showing the gate firing) — shipped in rome-solidity #204.
+
+**Validation note (2026-05-22).** "CPI in docs" ≠ "Solana CPI on chain". When a precompile method's NatSpec says "via Rome's CPI precompile", check the dispatch variant in the source-of-truth table at [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "Precompile Interfaces — Canonical Surface". Only selectors marked `Invoke` (or `Composed` arms that nest an `Invoke`) actually issue a Solana CPI signed by the caller's `EXTERNAL_AUTHORITY` PDA. Selectors marked `EthCall` / `CrossStateEthCall` are pure reads — no signing, no PDA seeds, no on-chain side effect. AccountReader (this repo's `contracts/cpi/AccountReader.sol`) and the oracle adapters (`contracts/oracle/PythPullAdapter.sol`, `contracts/oracle/SwitchboardV3Adapter.sol`) only exercise the `CrossStateEthCall` path. Foundation PRs: [`rome-protocol/rome-evm-private#382`](https://github.com/rome-protocol/rome-evm-private/pull/382) (disambiguation + one-track rule + cached family), [`rome-protocol/rome-evm-private#376`](https://github.com/rome-protocol/rome-evm-private/pull/376) (cached infrastructure — merged).
+
+**Known cached-track gaps** (tracked in [`rome-specs#122`](https://github.com/rome-protocol/rome-specs/pull/122)): SplCached missing `transferFrom` / `approve` / `mint` selectors; ASplCached missing raw-pubkey-owner `create_ata_for_key`; WithdrawCached missing unwrap leg (cached counterpart to `HelperProgram.deposit_from_ata`). Until these land, router-driven Romeswap / Compound supply-borrow / Cardo intent adapters / Wormhole outbound flows cannot fully migrate from legacy to cached track — they require the missing selectors.
 
 **Removed precompiles** (kept here so agents recognize stale code):
 
-- `0xff..05` (SPL Token) and `0xff..06` (Associated Token) — dedicated handlers were removed in the rome-evm-private Mollusk refactor; SPL operations now route through Mollusk SVM in the emulator and CPI on-chain. The `ISplToken` / `IAssociatedSplToken` interfaces and `SplToken` / `AssociatedSplToken` constants are no longer in `interface.sol`.
+- `0xff..05` (legacy SPL Token) and `0xff..06` (legacy Associated Token) — original dedicated handlers were removed in the rome-evm-private Mollusk refactor. **The slots have been REUSED post-#376 (2026-05-23) for cached precompiles**: `0xff..05` is now `SplCached` and `0xff..06` is now `AssociatedSplCached`. The old `ISplToken` / `IAssociatedSplToken` interface declarations are gone; the new `ISplCached` / `IAssociatedSplCached` interfaces live at these addresses with cached-track semantics.
 - `0x42..17` (`unwrap_spl_to_gas(uint256)`) and `0x42..18` (`wrap_gas_to_spl(uint256)`) — replaced 2026-05-12 by `Withdraw.withdraw_to_ata(uint256)` (wrap leg: gas → wrapper ATA) and `HelperProgram.deposit_from_ata(uint256)` (unwrap leg: wrapper ATA → gas). The `IUnwrapSplToGas` / `IWrapGasToSpl` interfaces and their pre-bound constants are no longer in `interface.sol`. Migration sequence: rome-solidity PR #137 → #138 → #141 → #143 paired with rome-evm-private #348 / #349 / #351 / #352 / #353 / #354.
 
 #### `CpiProgram` shortcut selectors (`0xff..08`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,16 @@ The core abstraction layer. Rome-EVM exposes Solana programs as EVM precompiles 
 
 Global constants pre-bound by `interface.sol`: `SystemProgram`, `CpiProgram`, `HelperProgram`, `Withdraw`.
 
+**Validation note (2026-05-22).** "CPI in docs" ≠ "Solana CPI on chain". When a precompile method's NatSpec says "via Rome's CPI precompile", check the dispatch variant in the source-of-truth table at [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "Precompile Interfaces — Canonical Surface". Only selectors marked `Invoke` (or `Composed` arms that nest an `Invoke`) actually issue a Solana CPI signed by the caller's `EXTERNAL_AUTHORITY` PDA. Selectors marked `EthCall` / `CrossStateEthCall` are pure reads — no signing, no PDA seeds, no on-chain side effect. AccountReader (this repo's `contracts/cpi/AccountReader.sol`) and the oracle adapters (`contracts/oracle/PythPullAdapter.sol`, `contracts/oracle/SwitchboardV3Adapter.sol`) only exercise the `CrossStateEthCall` path. Foundation PR: [`rome-protocol/rome-evm-private#377`](https://github.com/rome-protocol/rome-evm-private/pull/377).
+
 **Removed precompiles** (kept here so agents recognize stale code):
 
 - `0xff..05` (SPL Token) and `0xff..06` (Associated Token) — dedicated handlers were removed in the rome-evm-private Mollusk refactor; SPL operations now route through Mollusk SVM in the emulator and CPI on-chain. The `ISplToken` / `IAssociatedSplToken` interfaces and `SplToken` / `AssociatedSplToken` constants are no longer in `interface.sol`.
 - `0x42..17` (`unwrap_spl_to_gas(uint256)`) and `0x42..18` (`wrap_gas_to_spl(uint256)`) — replaced 2026-05-12 by `Withdraw.withdraw_to_ata(uint256)` (wrap leg: gas → wrapper ATA) and `HelperProgram.deposit_from_ata(uint256)` (unwrap leg: wrapper ATA → gas). The `IUnwrapSplToGas` / `IWrapGasToSpl` interfaces and their pre-bound constants are no longer in `interface.sol`. Migration sequence: rome-solidity PR #137 → #138 → #141 → #143 paired with rome-evm-private #348 / #349 / #351 / #352 / #353 / #354.
 
 #### `CpiProgram` shortcut selectors (`0xff..08`)
+
+> **"CpiProgram" is a historical name — most of these selectors are NOT CPIs.** The precompile carries two dispatch families: actual Solana CPI (`invoke` / `invoke_signed`, which sign as the caller's `EXTERNAL_AUTHORITY` PDA) AND a set of read-side shortcuts (`account_info`, `account_data_at`, `account_u64_at`, `account_lamports`, `pdas_batch_derive`) that the on-chain dispatcher routes through `NonEvmCall::CrossStateEthCall` — no inner Solana invocation, no signing, no PDA seeds, no on-chain side effect. The read shortcuts are pure cross-state queries. **Authoritative per-selector dispatch table (column "Dispatch"):** [`rome-evm-private/CLAUDE.md`](../rome-evm-private/CLAUDE.md) § "CpiProgram". Read it before assuming a selector that lives at `0xff..08` issues a CPI — most don't.
 
 (rome-evm-private PRs #318 / #319 / #320, shipped 2026-05-06; trimmed 2026-05-12 — `spl_transfer_checked_v1` + `derive_user_ata` migrated into `HelperProgram` under cleaner names):
 

--- a/contracts/cpi/AccountReader.sol
+++ b/contracts/cpi/AccountReader.sol
@@ -30,13 +30,52 @@ import {CpiProgram} from "../interface.sol";
 ///   `expectOwner`, `expectDataLen` are NOT included — no current consumer
 ///   needs them. Add them when a consumer does, not before.
 ///
-/// ## Live behavior
+/// ## Live behavior — these are reads, not CPIs
 ///
 ///   Every function dispatches through the `CpiProgram` pre-bound constant
-///   (precompile at `0xff00…0008`). The precompile signs the read as the
-///   EVM caller via Rome's `external_auth` derivation; for read-only
-///   account inspection this is irrelevant but worth knowing when reading
-///   the source.
+///   (precompile at `0xff00…0008`). The name "CpiProgram" is historical:
+///   the precompile carries both arbitrary Solana CPI dispatch (`invoke` /
+///   `invoke_signed`, selectors `0x7480cb86` / `0xb94f3733`) AND a family
+///   of read-side shortcut selectors. The three selectors used here —
+///   `account_data_at` (`0x593762e8`), `account_u64_at` (`0xb317d4c1`),
+///   `account_lamports` (`0xde79ed54`) — dispatch as
+///   `NonEvmCall::CrossStateEthCall`, not `NonEvmCall::Invoke`.
+///
+///   Concretely, this means:
+///
+///   - **No Solana CPI is issued.** The on-chain dispatcher routes these
+///     selectors through `cross_state_call`, which reads the target
+///     `AccountInfo` and returns the bytes. There is no inner Solana
+///     program invocation.
+///   - **No signing.** No `invoke_signed`, no PDA seeds, no
+///     `external_auth(caller)` derivation participates in the read.
+///     `AccountReader` never calls a signed path; the signing semantics
+///     of `invoke_signed` apply only to the two `Invoke` selectors and
+///     are not on the code path of any function in this library.
+///   - **No on-chain side effect.** These are pure cross-state queries —
+///     equivalent to an `eth_call` against a Solana account.
+///
+///   Source of truth for the dispatch routing: `rome-evm-private/program/
+///   src/non_evm/cpi.rs:65` (the `ACCOUNT_DATA_AT => CrossStateEthCall`
+///   match arm; the three v2 selectors `ACCOUNT_U64_AT`, `ACCOUNT_LAMPORTS`,
+///   `PDAS_BATCH_DERIVE` join the same arm on lines 71-73). The full per-
+///   selector dispatch table is in
+///   [`rome-evm-private/CLAUDE.md`](../../../rome-evm-private/CLAUDE.md) §
+///   "CpiProgram" — column "Dispatch" labels each selector with its
+///   `NonEvmCall` variant.
+///
+///   The signing path (`invoke_signed` → `EXTERNAL_AUTHORITY(caller)` PDA)
+///   only runs for `ICrossProgramInvocation.invoke_signed`. Reaching for
+///   `AccountReader` does not exercise it.
+///
+/// ## Validation
+///
+///   - Selector hex re-verified via `cast keccak <signature>` against
+///     `rome-evm-private/program/src/non_evm/cpi.rs` const block on
+///     2026-05-13 and 2026-05-22 — matches `ACCOUNT_DATA_AT`,
+///     `ACCOUNT_U64_AT`, `ACCOUNT_LAMPORTS`.
+///   - Dispatch-variant claim verified against `cpi.rs:65,71-73` —
+///     all three selectors route to `NonEvmCall::CrossStateEthCall`.
 library AccountReader {
     /// Lamports balance of `account`. Cheapest read — no data buffer
     /// fetch. Common pattern: gate-check whether an account exists at all

--- a/contracts/oracle/PythPullAdapter.sol
+++ b/contracts/oracle/PythPullAdapter.sol
@@ -10,8 +10,11 @@ import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title PythPullAdapter
 /// @notice Per-feed adapter that reads PriceUpdateV2 from Pyth Solana Receiver
-///         via Rome's CPI precompile. Implements both IAggregatorV3Interface and
-///         IExtendedOracleAdapter. Deployed as EIP-1167 clone by OracleAdapterFactory.
+///         via Rome's `CpiProgram` precompile (read-shortcut path —
+///         `account_data_at` dispatches as `NonEvmCall::CrossStateEthCall`,
+///         not a Solana CPI; no signing, no PDA seeds involved). Implements
+///         both IAggregatorV3Interface and IExtendedOracleAdapter. Deployed
+///         as EIP-1167 clone by OracleAdapterFactory.
 contract PythPullAdapter is IExtendedOracleAdapter, IAdapterMetadata {
     bytes32 public pythAccount;
     string private _description;

--- a/contracts/oracle/SwitchboardV3Adapter.sol
+++ b/contracts/oracle/SwitchboardV3Adapter.sol
@@ -10,9 +10,12 @@ import {AccountReader} from "../cpi/AccountReader.sol";
 
 /// @title SwitchboardV3Adapter
 /// @notice Per-feed adapter that reads AggregatorAccountData from Switchboard V2
-///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f) via Rome's CPI
-///         precompile. Same interface as PythPullAdapter. Deployed as EIP-1167
-///         clone by OracleAdapterFactory.
+///         (program SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f) via Rome's
+///         `CpiProgram` precompile (read-shortcut path — `account_data_at`
+///         dispatches as `NonEvmCall::CrossStateEthCall`, not a Solana CPI;
+///         no signing, no PDA seeds involved). Same interface as
+///         PythPullAdapter. Deployed as EIP-1167 clone by
+///         OracleAdapterFactory.
 /// @dev The contract name keeps "V3" for backwards compatibility with the
 ///      deploy scripts and cached ABIs, but both the program ID passed by
 ///      the factory and the byte layout consumed by SwitchboardParser target


### PR DESCRIPTION
## Summary

Two commits, docs + NatSpec, sitting cleanly on top of post-#204 master (`eb2cea0`):

1. **AccountReader NatSpec correction + oracle adapter wording fix** (commit `0599e28`)
   - `contracts/cpi/AccountReader.sol` — rewrites the misleading "signs the read as the EVM caller via Rome's `external_auth` derivation" NatSpec (the read shortcuts dispatch as `CrossStateEthCall`; no signing happens). Names the dispatch variant explicitly and cites `rome-evm-private/program/src/non_evm/cpi.rs:65,71-73`.
   - `contracts/oracle/PythPullAdapter.sol` + `SwitchboardV3Adapter.sol` — clarifies "via Rome's CPI precompile" to "via Rome's CpiProgram precompile (read-shortcut path; dispatches as CrossStateEthCall, not a Solana CPI)".
   - CLAUDE.md — adds a validation note distinguishing CPI from CrossStateEthCall.

2. **Cached precompile family + "one track per contract" hard rule** (commit `da87d94`)
   - CLAUDE.md precompile inventory table — adds the 4 cached precompiles + Ed25519 with a "Track" column:
     - SystemCached @ `0xff..04`
     - SplCached @ `0xff..05` (reuses old retired-SPL-Token slot)
     - AssociatedSplCached @ `0xff..06` (reuses old retired-ATA slot)
     - Ed25519Program @ `0xff..0a`
     - WithdrawCached @ `0xff..0b`
   - New section: "Track selection — one track per contract (HARD RULE)" — captures Valentin's design intent (rome-evm-private #376, 2026-05-22): contracts MUST commit to either cached or legacy precompiles; mixing is runtime-blocked by `verify_call`. Track decision is per-tx, sticky after revert. Cross-references rome-evm-private #382 (foundation doc) and points at `contracts/examples/cached.sol` + `mixed.sol` (shipped in #204).
   - "Removed precompiles" section — updates to note that `0xff..05` and `0xff..06` slots have been REUSED for cached precompiles post-#376.
   - Known gaps cross-referenced to `rome-specs#122`.

## Why this PR replaces #203

Original #203 was branched from a base that's now well behind master (rome-solidity #204 merged in between adding the cached interfaces). Rather than force-push to rewrite the original branch, this new PR rebases cleanly onto post-#204 master with both commits. Same content as #203 plus the cached-track expansion.

#203 will be closed with a pointer here.

## Validation

- `npx hardhat compile` passes (82 files, solc 0.8.28, no new warnings).
- Selector hex re-verified against `rome-evm-private/program/src/non_evm_cached/*.rs` on `cf19c64`.
- Cached precompile addresses cross-checked against `interface.sol` post-#204 (`system_cached_address = 0xff..04`, `spl_cached_address = 0xff..05`, `associated_spl_cached_address = 0xff..06`, `withdraw_cached_address = 0xff..0b`) — all match.

## Test plan

- [x] `npx hardhat compile` — clean
- [x] Selector + address cross-validated against rome-evm-private + rome-solidity master
- [x] AccountReader.sol NatSpec re-read — no false claim about signing remains
- [x] Oracle adapter NatSpec — read-shortcut framing clear
- [ ] Reviewer pass on the "one track per contract" wording (most policy-laden new content)

## Cross-references

- Depends on (now landed): rome-evm-private #376 (cached track infrastructure) — merged at `cf19c64`
- Companion (now landed): rome-solidity #204 (cached precompile Solidity interfaces) — merged at `eb2cea0`
- Foundation doc: rome-evm-private #382 (CLAUDE.md disambiguation + one-track rule + cached family)
- Spec: rome-specs #122 (cached precompile selector roadmap — Phase A-E)
- Supersedes: rome-solidity #203 (to be closed)