### PR TITLE
chore(deps): add missing peer deps for hardhat-toolbox-viem v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,10 @@
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-ignition": "^3.1.6",
+        "@nomicfoundation/hardhat-ignition-viem": "^3.0.7",
         "@nomicfoundation/hardhat-toolbox-viem": "^5.0.6",
+        "@nomicfoundation/hardhat-verify": "^3.0.0",
+        "@nomicfoundation/ignition-core": "^3.0.7",
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.1",
@@ -552,7 +555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -581,7 +583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -608,7 +609,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -633,7 +633,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -658,7 +657,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0"
       }
@@ -721,7 +719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0"
       }
@@ -742,7 +739,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -809,7 +805,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -830,7 +825,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -872,7 +866,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
@@ -898,7 +891,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -921,7 +913,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -950,7 +941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1214,7 +1204,6 @@
       "integrity": "sha512-/od8ZsYAdYDLLJwwSzwh6O+9ds0HjJWXj09MeYzK29jHgwrmwmjUhTEL5pwCS87Mn5vEIqWpGFgiIcfnePKpeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.11"
       },
@@ -1342,7 +1331,6 @@
       "integrity": "sha512-6DO8Z0MzyU4p89lPJVhsCX0CsOopkYhptatdt0uSfsqHdNz6JOtZ/KTTRuNXDI4QpR+KPq2GDkD4KqfAMX9WfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.8.0",
         "@nomicfoundation/hardhat-errors": "^3.0.11",
@@ -2431,8 +2419,7 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -2757,7 +2744,6 @@
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2773,8 +2759,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3241,7 +3226,6 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -3263,7 +3247,6 @@
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -4030,16 +4013,14 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "type": "module",
   "devDependencies": {
     "@nomicfoundation/hardhat-ignition": "^3.1.6",
+    "@nomicfoundation/hardhat-ignition-viem": "^3.0.7",
     "@nomicfoundation/hardhat-toolbox-viem": "^5.0.6",
+    "@nomicfoundation/hardhat-verify": "^3.0.0",
+    "@nomicfoundation/ignition-core": "^3.0.7",
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.1",


### PR DESCRIPTION
## Summary

- `@nomicfoundation/hardhat-toolbox-viem@5.0.6` declares peer dependencies that were not listed in `package.json` — every dev workflow on a fresh clone fails with `HHE201` because `@nomicfoundation/hardhat-ignition-viem` is not installed.
- Adds three missing peer deps to `devDependencies`:
  - `@nomicfoundation/hardhat-ignition-viem` (`^3.0.7`) — **hard blocker**, was the source of `HHE201`
  - `@nomicfoundation/hardhat-verify` (`^3.0.0`) — yarn-warning only, but listed as peer
  - `@nomicfoundation/ignition-core` (`^3.0.7`) — yarn-warning only, but listed as peer

## Verification

- ` npm install ` succeeds without `HHE201` errors
- ` npx hardhat compile ` compiles 86 Solidity files cleanly
- ` npx hardhat test tests/oracle/PythPullParser.test.ts ` passes 14/14

## Test plan

- [ ] CI green (`npm ci && npx hardhat compile && npx hardhat test`)
- [ ] Manual: `npm install` on a fresh clone produces no `HHE201`
- [ ] Manual: at least one existing test file runs (PythPullParser is the smallest)