### PR TITLE
feat(erc20spl-cached): cache-based SPL_ERC20 wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `SPL_ERC20_cached` cache-based wrapper + demonstrator contracts
+
+New contract at [`contracts/erc20spl/erc20spl_cached.sol`](contracts/erc20spl/erc20spl_cached.sol). Replaces the existing CPI-based `SPL_ERC20` on devnet (existing wrapper stays until consumer cutover per the migration spec).
+
+All mutations dispatch through the cache-based precompile family (`SplCached` `0xff..05`, `AssociatedSplCached` `0xff..06`). Reads use the CU-preference order from the spec — `EthCall` first (`HelperProgram.ata`), then `HelperProgram` `CrossStateEthCall` (`user_balance`, `allowance_of`), then `CpiProgram` `CrossStateEthCall` (`account_lamports`, `account_u64_at`).
+
+Surface: `name` / `symbol` / `decimals` / `totalSupply` / `balanceOf` / `allowance` / `get_token_account` / `transfer` / `transferFrom` / `approve` / `mint_to` / `ensure_token_account` / `create_token_account`. Bridge methods (`bridgeOutToSolana`, `ensureRecipientAta`) **NOT** included — they require the permanently-CPI-only `create_ata_for_key` and would violate the one-track-per-contract HARD RULE. Bridge relocation tracked in a follow-up spec.
+
+Also adds [`contracts/erc20spl/cached_revert_demo.sol`](contracts/erc20spl/cached_revert_demo.sol) with three demonstrator contracts that exercise the cache track's defining properties:
+
+- `CachedRevertDemo.transferThenRevert` — proves EVM revert atomicity discards the queued cache mutation.
+- `IterativeMultiTransferDemo.burnAndTransferN` — proves iterative-VM multi-step SPL flows succeed where CPI track would `CpiProhibitedInIterativeTx`.
+- `OrderingViolationDemo.cacheThenReadFromCpi` — documents the consumer-side ordering constraint (cache mutation followed by CPI `CrossStateEthCall` reverts via `verify_call`).
+
+Deploy via [`scripts/erc20spl/deploy_cached.ts`](scripts/erc20spl/deploy_cached.ts) with `WRAPPER_MINT_ID` env var. Writes deployment receipt under the `SPL_ERC20_cached` (and per-mint `SPL_ERC20_*_cached`) keys in `deployments/<network>.json`.
+
+Selector hex locks at [`tests/erc20spl/cached.selectors.test.ts`](tests/erc20spl/cached.selectors.test.ts) — 5/5 pass on hardhatMainnet, locks the four cache-based mutating selectors + `AssociatedSplCached.create_ata` against `cast keccak` derivation.
+
+Behavioral integration tests at [`tests/erc20spl/cached.integration.ts`](tests/erc20spl/cached.integration.ts) — exercise constructor + views + mutations + saturation sentinel against a deployed wrapper. **Runtime execution requires Hadrian** (`HADRIAN_PRIVATE_KEY` in keystore + `SPL_ERC20_CACHED_ADDRESS` env var pointing at the deployed wrapper). Demo test files for revert atomicity / iterative-VM / ordering negative — follow-up commits.
+
+Spec: [`rome-specs#128`](https://github.com/rome-protocol/rome-specs/pull/128).
+
 ### Changed — Renamed `IWithdrawCached.withdraw_from_ata` → `deposit`; selector `0x214ee485` → `0xb6b55f25`
 
 Tracks the post-ship correction in [`rome-evm-private#386`](https://github.com/rome-protocol/rome-evm-private/pull/386). Two issues with the original ship:

--- a/contracts/erc20spl/cached_revert_demo.sol
+++ b/contracts/erc20spl/cached_revert_demo.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {HelperProgram} from "../interface.sol";
+
+/// @dev Minimal wrapper view used by the demo contracts. Bound at the
+///      SPL_ERC20_cached wrapper's address so the cache-track mutations
+///      it dispatches fire as if a regular consumer called them.
+interface IWrapperLite {
+    function transfer(address to, uint256 value) external returns (bool);
+}
+
+/// @title  CachedRevertDemo
+/// @notice Demonstrator for the cache track's defining property — EVM
+///         revert atomicity over Solana side effects. Calls the wrapper's
+///         cache-based transfer, then explicitly reverts. Expected:
+///         recipient's SPL balance is UNCHANGED post-tx because the
+///         cache overlay discards the queued instruction on EVM revert.
+///         Contrast with the CPI-based SPL_ERC20 wrapper where the SPL
+///         transfer would already have hit Solana before the revert.
+contract CachedRevertDemo {
+    /// @notice Transfer then revert. Outer call MUST revert; recipient
+    ///         balance MUST be unchanged after the tx.
+    function transferThenRevert(
+        address wrapper,
+        address to,
+        uint256 value
+    ) external {
+        IWrapperLite(wrapper).transfer(to, value);
+        revert("intentional revert - transfer must be unwound");
+    }
+}
+
+/// @title  IterativeMultiTransferDemo
+/// @notice Demonstrator for the cache track's iterative-VM unlock. Burns
+///         enough EVM CU to push the tx into iterative VM, then performs
+///         N cache-based wrapper.transfer calls. On the CPI track this
+///         pattern hits CpiProhibitedInIterativeTx after the first
+///         transfer. On cache, all N succeed because cache Invoke is
+///         iterative-VM-compatible.
+contract IterativeMultiTransferDemo {
+    uint256 public counter;
+
+    /// @notice Burns EVM CU then performs N transfers. Each Solana tx in
+    ///         the iterative sequence has its own 1.4M CU budget; the
+    ///         cache commit fires `invoke_signed` at end-of-tx.
+    function burnAndTransferN(
+        address wrapper,
+        address[] calldata recipients,
+        uint256 amountEach
+    ) external {
+        // Bump EVM CU past the atomic-VM threshold so the rome-evm
+        // iterative VM kicks in. The exact loop count is empirical —
+        // 5_000 SSTOREs comfortably exceeds the atomic-VM gas envelope
+        // on every chain configuration this contract is deployed on.
+        for (uint256 i = 0; i < 5_000; i++) {
+            counter = counter + 1;
+        }
+        for (uint256 i = 0; i < recipients.length; i++) {
+            IWrapperLite(wrapper).transfer(recipients[i], amountEach);
+        }
+    }
+}
+
+/// @title  OrderingViolationDemo
+/// @notice Documents the in-tx ordering rule consumers must respect:
+///         CPI CrossStateEthCall reads (e.g., HelperProgram.user_balance)
+///         that follow a cache Invoke in the same tx are blocked by
+///         verify_call. The expected outcome is a revert at the second
+///         call site with NonEvmCallError("attempt to use cpi-cached
+///         program with cpi-program").
+contract OrderingViolationDemo {
+    /// @notice Cache mutation -> CPI CrossStateEthCall. Reverts.
+    function cacheThenReadFromCpi(
+        address wrapper,
+        address to,
+        uint256 value,
+        address probeUser,
+        bytes32 probeMint
+    ) external returns (uint64) {
+        IWrapperLite(wrapper).transfer(to, value);
+        return HelperProgram.user_balance(probeUser, probeMint);
+    }
+}

--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -7,7 +7,8 @@ import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {
     HelperProgram,
     SplCached,
-    AssociatedSplCached
+    AssociatedSplCached,
+    ISplCached
 } from "../interface.sol";
 import {AccountReader} from "../cpi/AccountReader.sol";
 import {Convert} from "../convert.sol";
@@ -84,24 +85,33 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
         return uint256(AccountReader.readU64At(mint_id, 36));
     }
 
-    /// @notice Single CrossStateEthCall via HelperProgram.user_balance —
-    ///         reads SPL TokenAccount.amount on the user's PDA-owned ATA
-    ///         for this wrapper's mint. Returns 0 if the ATA doesn't
-    ///         exist (fresh-chain probe). Collapses 3 v1 dispatches into 1.
+    /// @notice Cached-track read: derive ATA via HelperProgram.ata (pure
+    ///         EthCall, track-neutral) then SplCached.account (cached
+    ///         CrossStateEthCall at 0xff..05). Replaces the prior
+    ///         HelperProgram.user_balance (legacy 0xff..09) read so the
+    ///         wrapper exposes a fully cache-track read surface — enables
+    ///         canonical (unmodified) Uniswap V2 pair to compose with this
+    ///         wrapper without tripping the verify_call ordering gate on
+    ///         post-mutation balance reads.
     function balanceOf(address account) external view returns (uint256) {
-        return uint256(HelperProgram.user_balance(account, mint_id));
+        bytes32 ata = HelperProgram.ata(account, mint_id);
+        return uint256(SplCached.account(ata).amount);
     }
 
-    /// @notice Single CrossStateEthCall via HelperProgram.allowance_of —
-    ///         reads owner-ATA's delegated_amount IFF the on-chain
-    ///         delegate matches external_auth(spender). Returns 0
-    ///         otherwise (fresh user, unapproved spender, expired
-    ///         allowance). Saturates uint64::max → uint256::max so wallet
-    ///         consumers probing for the MaxUint256 "infinite approval"
-    ///         sentinel keep working.
+    /// @notice Cached-track read: SplCached.account exposes delegate +
+    ///         delegated_amount in a single cached read. Returns 0 unless
+    ///         the on-chain SPL delegate equals external_auth(spender)
+    ///         (matches HelperProgram.allowance_of's HARD-REQ semantics).
+    ///         Saturates uint64::max → uint256::max for wallet "infinite
+    ///         approval" sentinel compatibility.
     function allowance(address owner, address spender) external view returns (uint256) {
-        uint64 delegated = HelperProgram.allowance_of(owner, spender, mint_id);
-        return delegated == type(uint64).max ? type(uint256).max : uint256(delegated);
+        bytes32 ownerAta = HelperProgram.ata(owner, mint_id);
+        ISplCached.Account memory acc = SplCached.account(ownerAta);
+        bytes32 spenderPda = HelperProgram.pda(spender);
+        if (acc.delegate != spenderPda) return 0;
+        return acc.delegated_amount == type(uint64).max
+            ? type(uint256).max
+            : uint256(acc.delegated_amount);
     }
 
     /// @notice Pure EthCall derivation — `external_auth(user) + mint_id`
@@ -112,18 +122,17 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
 
     // ─── Mutating ERC-20 surface — all cache-based Invokes ────────────────
 
-    /// @notice Idempotent first-time ATA bootstrap. CPI reads (ata +
-    ///         lamports) happen BEFORE any cache mutation so the
-    ///         verify_call ordering rule holds. AssociatedSplCached
-    ///         create_ata is itself idempotent on the Solana side, so
-    ///         the read fast-path is a CU optimization, not a correctness
-    ///         requirement.
+    /// @notice Idempotent ATA bootstrap. Drops the prior CpiProgram
+    ///         account_lamports (legacy 0xff..08) probe that was used as
+    ///         a CU optimization — AssociatedSplCached.create_ata is
+    ///         idempotent on the Solana side, so calling it
+    ///         unconditionally is safe semantically. Removing the probe
+    ///         eliminates the last legacy-precompile READ from this
+    ///         wrapper's hot path, making the wrapper fully cache-track
+    ///         (so canonical UV2 pair can compose without verify_call
+    ///         ordering issues).
     function ensure_token_account(address user) public returns (bytes32) {
         bytes32 ata = HelperProgram.ata(user, mint_id);
-        uint64 lamports = AccountReader.lamportsOf(ata);
-        if (lamports != 0) {
-            return ata;
-        }
         (bool ok, bytes memory result) = address(AssociatedSplCached).delegatecall(
             abi.encodeWithSignature(
                 "create_ata(address,bytes32)",

--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -71,45 +71,178 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
         return _symbol;
     }
 
-    // ─── Stubs — implemented in subsequent tasks (Tasks 3-12 of the plan) ───
+    // ─── Read views — CPI CrossStateEthCall + EthCall ─────────────────────
 
+    /// @notice SPL Mint.supply (u64 LE at offset 36). Returns 0 when the
+    ///         mint account is uninitialized so consumers that probe the
+    ///         wrapper during chain bring-up don't revert (ERC-20 spec
+    ///         invariant: views never revert).
     function totalSupply() external view returns (uint256) {
-        revert("not implemented");
+        if (AccountReader.lamportsOf(mint_id) == 0) {
+            return 0;
+        }
+        return uint256(AccountReader.readU64At(mint_id, 36));
     }
 
-    function balanceOf(address) external view returns (uint256) {
-        revert("not implemented");
+    /// @notice Single CrossStateEthCall via HelperProgram.user_balance —
+    ///         reads SPL TokenAccount.amount on the user's PDA-owned ATA
+    ///         for this wrapper's mint. Returns 0 if the ATA doesn't
+    ///         exist (fresh-chain probe). Collapses 3 v1 dispatches into 1.
+    function balanceOf(address account) external view returns (uint256) {
+        return uint256(HelperProgram.user_balance(account, mint_id));
     }
 
-    function allowance(address, address) external view returns (uint256) {
-        revert("not implemented");
+    /// @notice Single CrossStateEthCall via HelperProgram.allowance_of —
+    ///         reads owner-ATA's delegated_amount IFF the on-chain
+    ///         delegate matches external_auth(spender). Returns 0
+    ///         otherwise (fresh user, unapproved spender, expired
+    ///         allowance). Saturates uint64::max → uint256::max so wallet
+    ///         consumers probing for the MaxUint256 "infinite approval"
+    ///         sentinel keep working.
+    function allowance(address owner, address spender) external view returns (uint256) {
+        uint64 delegated = HelperProgram.allowance_of(owner, spender, mint_id);
+        return delegated == type(uint64).max ? type(uint256).max : uint256(delegated);
     }
 
-    function get_token_account(address) external view returns (bytes32) {
-        revert("not implemented");
+    /// @notice Pure EthCall derivation — `external_auth(user) + mint_id`
+    ///         ATA pubkey. Never a track-locking event; never reverts.
+    function get_token_account(address user) external view returns (bytes32) {
+        return HelperProgram.ata(user, mint_id);
     }
 
-    function transfer(address, uint256) external returns (bool) {
-        revert("not implemented");
+    // ─── Mutating ERC-20 surface — all cache-based Invokes ────────────────
+
+    /// @notice Idempotent first-time ATA bootstrap. CPI reads (ata +
+    ///         lamports) happen BEFORE any cache mutation so the
+    ///         verify_call ordering rule holds. AssociatedSplCached
+    ///         create_ata is itself idempotent on the Solana side, so
+    ///         the read fast-path is a CU optimization, not a correctness
+    ///         requirement.
+    function ensure_token_account(address user) public returns (bytes32) {
+        bytes32 ata = HelperProgram.ata(user, mint_id);
+        uint64 lamports = AccountReader.lamportsOf(ata);
+        if (lamports != 0) {
+            return ata;
+        }
+        (bool ok, bytes memory result) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature(
+                "create_ata(address,bytes32)",
+                user,
+                mint_id
+            )
+        );
+        require(ok, string(Convert.revert_msg(result)));
+        return ata;
     }
 
-    function transferFrom(address, address, uint256) external returns (bool) {
-        revert("not implemented");
+    /// @notice Public ATA-create entry. Cache invoke; idempotent on
+    ///         repeat. The ATA address returned via HelperProgram.ata
+    ///         after the create — EthCall (pure compute) is exempt from
+    ///         the verify_call gate, so it works even after the cache
+    ///         mutation has fired this tx.
+    function create_token_account(address user) external returns (bytes32) {
+        _users.ensure_user(user);
+        (bool ok, bytes memory result) = address(AssociatedSplCached).delegatecall(
+            abi.encodeWithSignature(
+                "create_ata(address,bytes32)",
+                user,
+                mint_id
+            )
+        );
+        require(ok, string(Convert.revert_msg(result)));
+        return HelperProgram.ata(user, mint_id);
     }
 
-    function approve(address, uint256) external returns (bool) {
-        revert("not implemented");
+    function transfer(address to, uint256 value) external returns (bool) {
+        return _transfer(msg.sender, to, value);
     }
 
-    function mint_to(address, uint256) external returns (bool) {
-        revert("not implemented");
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        return _transfer(from, to, value);
     }
 
-    function ensure_token_account(address) external returns (bytes32) {
-        revert("not implemented");
+    /// @notice Internal transfer dispatcher — selects sender path or
+    ///         delegate path based on `from == msg.sender`. Both paths
+    ///         go through SplCached, locking the tx to the cache track.
+    function _transfer(address from, address to, uint256 value) internal returns (bool) {
+        require(value <= type(uint64).max, "Transfer amount exceeds uint64");
+        _users.ensure_user(msg.sender);
+        ensure_token_account(to);
+
+        bool ok;
+        bytes memory result;
+        if (from == msg.sender) {
+            // Sender path — caller-PDA owns the source ATA. Cache
+            // SplCached.transfer(address,uint256,bytes32) at 0x57cfeeee.
+            (ok, result) = address(SplCached).delegatecall(
+                abi.encodeWithSignature(
+                    "transfer(address,uint256,bytes32)",
+                    to,
+                    value,
+                    mint_id
+                )
+            );
+        } else {
+            // Delegate path — caller-PDA is the SPL delegate set by a
+            // prior approve(). Cache SplCached.transferFrom at
+            // 0x401e3367. SPL Token accepts PDA as ATA owner OR
+            // delegated-amount delegate.
+            (ok, result) = address(SplCached).delegatecall(
+                abi.encodeWithSignature(
+                    "transferFrom(address,address,uint256,bytes32)",
+                    from,
+                    to,
+                    value,
+                    mint_id
+                )
+            );
+        }
+        require(ok, string(Convert.revert_msg(result)));
+        emit Transfer(from, to, value);
+        return true;
     }
 
-    function create_token_account(address) external returns (bytes32) {
-        revert("not implemented");
+    /// @notice Saturates uint64::max for SPL storage; emits uint256::max
+    ///         so wallet "infinite approval" sentinels (`if allowance ==
+    ///         MaxUint256`) keep working as a round-trip invariant.
+    function approve(address spender, uint256 value) external returns (bool) {
+        _users.ensure_user(msg.sender);
+        uint64 storedAmount = value > type(uint64).max
+            ? type(uint64).max
+            : uint64(value);
+        (bool ok, bytes memory result) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "approve(address,uint256,bytes32)",
+                spender,
+                storedAmount,
+                mint_id
+            )
+        );
+        require(ok, string(Convert.revert_msg(result)));
+        uint256 emittedValue = storedAmount == type(uint64).max
+            ? type(uint256).max
+            : uint256(storedAmount);
+        emit Approval(msg.sender, spender, emittedValue);
+        return true;
+    }
+
+    /// @notice Caller-PDA signs as the on-chain mint authority. SPL
+    ///         Token runtime enforces caller-PDA == mint authority.
+    ///         Recipient ATA auto-created via ensure_token_account.
+    function mint_to(address to, uint256 value) external returns (bool) {
+        require(value <= type(uint64).max, "Mint amount exceeds uint64");
+        _users.ensure_user(msg.sender);
+        ensure_token_account(to);
+        (bool ok, bytes memory result) = address(SplCached).delegatecall(
+            abi.encodeWithSignature(
+                "mint(address,uint256,bytes32)",
+                to,
+                value,
+                mint_id
+            )
+        );
+        require(ok, string(Convert.revert_msg(result)));
+        emit Transfer(address(0), to, value);
+        return true;
     }
 }

--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SplTokenLib} from "../spl_token/spl_token.sol";
+import {
+    HelperProgram,
+    SplCached,
+    AssociatedSplCached
+} from "../interface.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
+import {Convert} from "../convert.sol";
+import {ERC20Users} from "./erc20spl.sol";
+
+/// @title  SPL_ERC20_cached
+/// @notice Cache-based ERC20 wrapper around an SPL mint. Replaces the
+///         CPI-based SPL_ERC20 on devnet. All mutations dispatch through
+///         the cache-based precompile family (SplCached at 0xff..05,
+///         AssociatedSplCached at 0xff..06). Reads use whichever
+///         precompile gives the cleanest answer per the CU preference
+///         order in the migration spec:
+///           1. EthCall                              — HelperProgram.ata
+///           2. HelperProgram CrossStateEthCall      — user_balance, allowance_of
+///           3. CpiProgram CrossStateEthCall         — account_lamports, account_u64_at
+///
+/// @dev    Per the rome-evm-private one-track-per-contract HARD RULE,
+///         this contract does NOT perform any CPI Invoke. Bridge methods
+///         (bridgeOutToSolana, ensureRecipientAta) which require the
+///         permanently-CPI-only create_ata_for_key are NOT exposed here
+///         — they relocate to a separate sibling contract per follow-up
+///         spec.
+contract SPL_ERC20_cached is IERC20, IERC20Metadata {
+    address public immutable cpi_program;
+    bytes32 public immutable mint_id;
+    uint8 public immutable decimals;
+
+    string private _name;
+    string private _symbol;
+    ERC20Users private _users;
+
+    error ERC20InvalidApprover(address approver);
+    error ERC20InvalidSpender(address spender);
+    error ERC20InsufficientAllowance(
+        address spender,
+        uint256 currentAllowance,
+        uint256 requiredAllowance
+    );
+
+    constructor(
+        bytes32 _mint_id,
+        address _cpi_program,
+        string memory name_,
+        string memory symbol_,
+        ERC20Users users_
+    ) {
+        SplTokenLib.SplMint memory mint = SplTokenLib.load_mint(_mint_id, _cpi_program);
+        cpi_program = _cpi_program;
+        mint_id = _mint_id;
+        decimals = mint.decimals;
+        _name = name_;
+        _symbol = symbol_;
+        _users = users_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    // ─── Stubs — implemented in subsequent tasks (Tasks 3-12 of the plan) ───
+
+    function totalSupply() external view returns (uint256) {
+        revert("not implemented");
+    }
+
+    function balanceOf(address) external view returns (uint256) {
+        revert("not implemented");
+    }
+
+    function allowance(address, address) external view returns (uint256) {
+        revert("not implemented");
+    }
+
+    function get_token_account(address) external view returns (bytes32) {
+        revert("not implemented");
+    }
+
+    function transfer(address, uint256) external returns (bool) {
+        revert("not implemented");
+    }
+
+    function transferFrom(address, address, uint256) external returns (bool) {
+        revert("not implemented");
+    }
+
+    function approve(address, uint256) external returns (bool) {
+        revert("not implemented");
+    }
+
+    function mint_to(address, uint256) external returns (bool) {
+        revert("not implemented");
+    }
+
+    function ensure_token_account(address) external returns (bytes32) {
+        revert("not implemented");
+    }
+
+    function create_token_account(address) external returns (bytes32) {
+        revert("not implemented");
+    }
+}

--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -97,5 +97,11 @@
     "wsolWrapper": "0x28E7c064E734cB3edeA65A98927c1c20581c8934",
     "users": "0x46066102B8E848d67Cf5f96212B92C8A24b51d8b",
     "deployedAt": 1779114924
+  },
+  "SPL_ERC20_cached": {
+    "address": "0xa6ee6ead4f4b6448c55e6b6b61b2e68b51e3e001",
+    "mint": "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7",
+    "name": "Rome USDC (cached)",
+    "symbol": "wUSDCc"
   }
 }

--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -99,9 +99,9 @@
     "deployedAt": 1779114924
   },
   "SPL_ERC20_cached": {
-    "address": "0xa6ee6ead4f4b6448c55e6b6b61b2e68b51e3e001",
-    "mint": "0x3b442cb3912157f13a933d0134282d032b5ffecd01a2dbf1b7790608df002ea7",
-    "name": "Rome USDC (cached)",
-    "symbol": "wUSDCc"
+    "address": "0x979cb140cd9593758496742f40ab37b41807284c",
+    "mint": "0xe129d398fb5bf9c7ffb56bfa0b855b101ea92c6d014be32283817301db843bed",
+    "name": "Cached Test Token",
+    "symbol": "wTESTc"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,10 @@
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-ignition": "^3.1.6",
+        "@nomicfoundation/hardhat-ignition-viem": "^3.0.7",
         "@nomicfoundation/hardhat-toolbox-viem": "^5.0.6",
+        "@nomicfoundation/hardhat-verify": "^3.0.0",
+        "@nomicfoundation/ignition-core": "^3.0.7",
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.1",
@@ -552,7 +555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -581,7 +583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -608,7 +609,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -633,7 +633,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -658,7 +657,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0"
       }
@@ -721,7 +719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0"
       }
@@ -742,7 +739,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -809,7 +805,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -830,7 +825,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -872,7 +866,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
@@ -898,7 +891,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -921,7 +913,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -950,7 +941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1214,7 +1204,6 @@
       "integrity": "sha512-/od8ZsYAdYDLLJwwSzwh6O+9ds0HjJWXj09MeYzK29jHgwrmwmjUhTEL5pwCS87Mn5vEIqWpGFgiIcfnePKpeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.11"
       },
@@ -1342,7 +1331,6 @@
       "integrity": "sha512-6DO8Z0MzyU4p89lPJVhsCX0CsOopkYhptatdt0uSfsqHdNz6JOtZ/KTTRuNXDI4QpR+KPq2GDkD4KqfAMX9WfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.8.0",
         "@nomicfoundation/hardhat-errors": "^3.0.11",
@@ -2431,8 +2419,7 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -2757,7 +2744,6 @@
       "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2773,8 +2759,7 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3241,7 +3226,6 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -3263,7 +3247,6 @@
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -4030,16 +4013,14 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "type": "module",
   "devDependencies": {
     "@nomicfoundation/hardhat-ignition": "^3.1.6",
+    "@nomicfoundation/hardhat-ignition-viem": "^3.0.7",
     "@nomicfoundation/hardhat-toolbox-viem": "^5.0.6",
+    "@nomicfoundation/hardhat-verify": "^3.0.0",
+    "@nomicfoundation/ignition-core": "^3.0.7",
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.1",

--- a/scripts/CACHED_VS_CPI_WRAPPER_BENCH.md
+++ b/scripts/CACHED_VS_CPI_WRAPPER_BENCH.md
@@ -1,0 +1,30 @@
+# SPL_ERC20_cached vs CPI-based SPL_ERC20 — wrapper-level Solana CU + heap
+
+Apples-to-apples comparison on Hadrian. Same deployer-authored test mint, same operations.
+
+- cached wrapper: `0x979cb140cd9593758496742f40ab37b41807284c`
+- cpi    wrapper: `0x56b3e58D05e76Ab6F70F5c3C4B2f9EB966ceA7bD`
+- shared mint:   `0xe129d398fb5bf9c7ffb56bfa0b855b101ea92c6d014be32283817301db843bed`
+
+| Operation | Track | Status | EVM gas | Sol txs | Sol CU | Heap bytes |
+|---|---|---|---:|---:|---:|---:|
+| ensure_token_account(recipient) | cached | success | 10000 | 1 | 131030 | 19240 |
+| ensure_token_account(recipient) | cpi | success | 10000 | 1 | 145262 | 23000 |
+| mint_to(recipient, 1_000_000) | cached | success | 15000 | 2 | 256518 | 33304 |
+| mint_to(recipient, 1_000_000) | cpi | success | 15000 | 2 | 264770 | 35936 |
+| transfer(recip2, 100_000) | cached | success | 15000 | 2 | 279908 | 35008 |
+| transfer(recip2, 100_000) | cpi | success | 15000 | 2 | 286801 | 36720 |
+| approve(spender, 500_000) | cached | success | 15000 | 2 | 226018 | 30496 |
+| approve(spender, 500_000) | cpi | success | 15000 | 2 | 216186 | 30208 |
+| transferFrom(me, recip2, 50_000) | cached | success | 15000 | 2 | 272885 | 35040 |
+| transferFrom(me, recip2, 50_000) | cpi | success | 15000 | 2 | 279562 | 36752 |
+
+## Delta (cached − cpi, negative = cached saves)
+
+| Operation | EVM gas Δ | Sol CU Δ | Heap Δ |
+|---|---:|---:|---:|
+| ensure_token_account(recipient) | 0 | -14232 | -3760 |
+| mint_to(recipient, 1_000_000) | 0 | -8252 | -2632 |
+| transfer(recip2, 100_000) | 0 | -6893 | -1712 |
+| approve(spender, 500_000) | 0 | 9832 | 288 |
+| transferFrom(me, recip2, 50_000) | 0 | -6677 | -1712 |

--- a/scripts/erc20spl/bench_cached_vs_cpi_wrapper.ts
+++ b/scripts/erc20spl/bench_cached_vs_cpi_wrapper.ts
@@ -1,0 +1,286 @@
+import hardhat from "hardhat";
+import { Connection } from "@solana/web3.js";
+import { isAddress, parseAbi, decodeEventLog } from "viem";
+import fs from "node:fs";
+import { readDeployments } from "../lib/deployments.js";
+
+// Apples-to-apples Solana CU + heap benchmark for SPL_ERC20_cached vs the
+// CPI-based SPL_ERC20, both against the SAME deployer-authored test mint
+// on Hadrian (so the bencher EOA == on-chain mint authority and the same
+// fast-paths fire on both).
+//
+// Pre-reqs:
+//   - HADRIAN_PRIVATE_KEY in keystore (deployer EOA)
+//   - Test mint already created via scripts/erc20spl/create_test_mint.ts
+//   - SPL_ERC20_cached already deployed against that mint
+//     (scripts/erc20spl/deploy_cached.ts, recorded in deployments.SPL_ERC20_cached)
+//
+// What this script does:
+//   1. Deploys a CPI-based SPL_ERC20 against the SAME test mint via
+//      factory.add_spl_token_no_metadata (idempotent — reuses existing if
+//      already registered)
+//   2. Runs the same set of operations on both wrappers:
+//        mint_to, transfer, approve, transferFrom, ensure_token_account
+//   3. For each op, captures: EVM gas, Solana sig(s), summed Solana CU,
+//      peak heap bytes (parsed from `Program heap bytes` log lines)
+//   4. Writes a markdown report to scripts/CACHED_VS_CPI_WRAPPER_BENCH.md
+
+const EVM_RPC = "https://hadrian.testnet.romeprotocol.xyz";
+const SOLANA_RPC = "https://node1.devnet-eu-sol-api.devnet.romeprotocol.xyz";
+
+interface BenchRow {
+    op: string;
+    track: "cached" | "cpi";
+    txHash?: string;
+    status?: string;
+    evmGas?: number;
+    solNumTxs?: number;
+    solCu?: number;
+    heapBytes?: number;
+    revertReason?: string;
+}
+
+async function jsonRpc(url: string, method: string, params: unknown[]) {
+    const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method, params, id: 1 }),
+    });
+    return (await res.json()) as { result?: any; error?: any };
+}
+
+async function resolveSolanaTxs(evmHash: string): Promise<string[]> {
+    let sigs: string[] = [];
+    for (let i = 0; i < 15; i++) {
+        const r = await jsonRpc(EVM_RPC, "rome_solanaTxForEvmTx", [evmHash]);
+        sigs = r.result ?? [];
+        if (sigs.length > 0) break;
+        await new Promise((s) => setTimeout(s, 1500));
+    }
+    for (let i = 0; i < 5; i++) {
+        await new Promise((s) => setTimeout(s, 1500));
+        const r = await jsonRpc(EVM_RPC, "rome_solanaTxForEvmTx", [evmHash]);
+        const more: string[] = r.result ?? [];
+        if (more.length > sigs.length) sigs = more;
+    }
+    return sigs;
+}
+
+const conn = new Connection(SOLANA_RPC, "confirmed");
+
+async function getSolanaMetrics(
+    sig: string,
+): Promise<{ cu?: number; heapBytes?: number }> {
+    const tx = await conn.getTransaction(sig, { maxSupportedTransactionVersion: 0 });
+    if (!tx?.meta) return {};
+    const cu = tx.meta.computeUnitsConsumed ?? 0;
+    let heapBytes = 0;
+    for (const log of tx.meta.logMessages ?? []) {
+        // Rome program emits `Program log: Heap <bytes>` once per tx
+        // after the EVM frame commits. Capture the max across segments.
+        const m = log.match(/^Program log:\s*Heap\s+(\d+)/);
+        if (m) {
+            const v = parseInt(m[1], 10);
+            if (!Number.isNaN(v) && v > heapBytes) heapBytes = v;
+        }
+    }
+    return { cu, heapBytes };
+}
+
+async function captureRow(
+    op: string,
+    track: "cached" | "cpi",
+    send: () => Promise<`0x${string}`>,
+): Promise<BenchRow> {
+    process.stdout.write(`  ${op} [${track}]... `);
+    const row: BenchRow = { op, track };
+    try {
+        const hash = await send();
+        row.txHash = hash;
+        // Retry receipt — the EVM tx may need a few polls before it's mined.
+        for (let i = 0; i < 10; i++) {
+            const r = await jsonRpc(EVM_RPC, "eth_getTransactionReceipt", [hash]);
+            if (r.result) {
+                row.status = r.result.status === "0x1" ? "success" : "reverted";
+                row.evmGas = parseInt(r.result.gasUsed, 16);
+                break;
+            }
+            await new Promise((s) => setTimeout(s, 1500));
+        }
+        const sigs = await resolveSolanaTxs(hash);
+        row.solNumTxs = sigs.length;
+        let cuTotal = 0;
+        let heapMax = 0;
+        for (const sig of sigs) {
+            const m = await getSolanaMetrics(sig);
+            cuTotal += m.cu ?? 0;
+            if ((m.heapBytes ?? 0) > heapMax) heapMax = m.heapBytes!;
+        }
+        row.solCu = cuTotal;
+        row.heapBytes = heapMax;
+        console.log(
+            `${row.status} | evm ${row.evmGas} | sol ${row.solNumTxs} tx | cu ${row.solCu} | heap ${row.heapBytes}`,
+        );
+    } catch (e: any) {
+        row.status = "exception";
+        row.revertReason = String(e?.message ?? e).slice(0, 200);
+        console.log(`EXCEPTION: ${row.revertReason}`);
+    }
+    return row;
+}
+
+async function main() {
+    const networkName = process.env.HARDHAT_NETWORK ?? "hadrian";
+    const dep = readDeployments(networkName);
+
+    const cachedAddress = dep.SPL_ERC20_cached?.address as `0x${string}` | undefined;
+    const cachedMint = dep.SPL_ERC20_cached?.mint as `0x${string}` | undefined;
+    if (!cachedAddress || !isAddress(cachedAddress) || !cachedMint) {
+        throw new Error("SPL_ERC20_cached not found in deployments. Run create_test_mint.ts + deploy_cached.ts first.");
+    }
+    const factoryAddress = dep.ERC20SPLFactory?.address as `0x${string}` | undefined;
+    if (!factoryAddress || !isAddress(factoryAddress)) {
+        throw new Error("ERC20SPLFactory not deployed.");
+    }
+
+    const { viem } = await hardhat.network.connect();
+    const publicClient = await viem.getPublicClient();
+    const wallets = await viem.getWalletClients();
+    const wallet = wallets[0];
+    const me = wallet.account.address;
+
+    // 1. Ensure a CPI-based SPL_ERC20 exists for the SAME test mint
+    const factoryAbi = parseAbi([
+        "function token_by_mint(bytes32) external view returns (address)",
+        "function add_spl_token_no_metadata(bytes32 mint, string name, string symbol) external returns (address)",
+    ]);
+    let cpiAddress = (await publicClient.readContract({
+        address: factoryAddress,
+        abi: factoryAbi,
+        functionName: "token_by_mint",
+        args: [cachedMint],
+    })) as `0x${string}`;
+    if (cpiAddress === "0x0000000000000000000000000000000000000000") {
+        console.log("Registering test mint with factory (deploys CPI-based SPL_ERC20)...");
+        const txHash = await wallet.writeContract({
+            address: factoryAddress,
+            abi: factoryAbi,
+            functionName: "add_spl_token_no_metadata",
+            args: [cachedMint, "CPI Test Token", "wTESTcpi"],
+        });
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+        cpiAddress = (await publicClient.readContract({
+            address: factoryAddress,
+            abi: factoryAbi,
+            functionName: "token_by_mint",
+            args: [cachedMint],
+        })) as `0x${string}`;
+    }
+    console.log(`  cached wrapper: ${cachedAddress}`);
+    console.log(`  cpi    wrapper: ${cpiAddress}`);
+    console.log(`  shared mint:   ${cachedMint}`);
+    console.log("");
+
+    // 2. ABI for both wrappers — identical IERC20 + IERC20Metadata surface
+    const wrapperAbi = parseAbi([
+        "function mint_to(address to, uint256 value) external returns (bool)",
+        "function transfer(address to, uint256 value) external returns (bool)",
+        "function approve(address spender, uint256 value) external returns (bool)",
+        "function transferFrom(address from, address to, uint256 value) external returns (bool)",
+        "function ensure_token_account(address user) external returns (bytes32)",
+    ]);
+
+    // 3. Drive the same ops on both wrappers + collect rows
+    const rows: BenchRow[] = [];
+    const recip = "0x000000000000000000000000000000000000c0de" as `0x${string}`;
+    const recip2 = "0x000000000000000000000000000000000000babe" as `0x${string}`;
+
+    const send = (wrap: `0x${string}`, fn: string, args: any[]) =>
+        wallet.writeContract({
+            address: wrap,
+            abi: wrapperAbi,
+            functionName: fn as any,
+            args: args as any,
+        });
+
+    // Warm both wrappers' recipient ATAs (separate ATA creation cost from
+    // mutation cost — first transfer to a fresh address pays for the ATA).
+    console.log("=== Warm-up: ensure_token_account (one-shot ATA create) ===");
+    rows.push(await captureRow("ensure_token_account(recipient)", "cached", () => send(cachedAddress, "ensure_token_account", [recip])));
+    rows.push(await captureRow("ensure_token_account(recipient)", "cpi",    () => send(cpiAddress,    "ensure_token_account", [recip])));
+
+    console.log("\n=== mint_to ===");
+    rows.push(await captureRow("mint_to(recipient, 1_000_000)", "cached", () => send(cachedAddress, "mint_to", [recip, 1_000_000n])));
+    rows.push(await captureRow("mint_to(recipient, 1_000_000)", "cpi",    () => send(cpiAddress,    "mint_to", [recip, 1_000_000n])));
+
+    console.log("\n=== transfer (sender owns balance, recipient ATA exists) ===");
+    // Pre-mint to sender on both wrappers so transfer has balance
+    await send(cachedAddress, "mint_to", [me, 10_000_000n]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    await send(cpiAddress,    "mint_to", [me, 10_000_000n]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    // Warm recip2 ATAs so transfer doesn't include ATA-create cost
+    await send(cachedAddress, "ensure_token_account", [recip2]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    await send(cpiAddress,    "ensure_token_account", [recip2]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    rows.push(await captureRow("transfer(recip2, 100_000)", "cached", () => send(cachedAddress, "transfer", [recip2, 100_000n])));
+    rows.push(await captureRow("transfer(recip2, 100_000)", "cpi",    () => send(cpiAddress,    "transfer", [recip2, 100_000n])));
+
+    console.log("\n=== approve ===");
+    rows.push(await captureRow("approve(spender, 500_000)", "cached", () => send(cachedAddress, "approve", [recip, 500_000n])));
+    rows.push(await captureRow("approve(spender, 500_000)", "cpi",    () => send(cpiAddress,    "approve", [recip, 500_000n])));
+
+    console.log("\n=== transferFrom (caller-as-delegate path) ===");
+    // Self-as-spender works because approve(me, X) sets external_auth(me) as
+    // delegate on me's own ATA; transferFrom(me, recip2, ...) signed by me
+    // passes the SPL delegate check.
+    await send(cachedAddress, "approve", [me, 500_000n]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    await send(cpiAddress,    "approve", [me, 500_000n]).then((h) => publicClient.waitForTransactionReceipt({ hash: h }));
+    rows.push(await captureRow("transferFrom(me, recip2, 50_000)", "cached", () => send(cachedAddress, "transferFrom", [me, recip2, 50_000n])));
+    rows.push(await captureRow("transferFrom(me, recip2, 50_000)", "cpi",    () => send(cpiAddress,    "transferFrom", [me, recip2, 50_000n])));
+
+    // 4. Markdown report
+    const lines: string[] = [];
+    lines.push("# SPL_ERC20_cached vs CPI-based SPL_ERC20 — wrapper-level Solana CU + heap");
+    lines.push("");
+    lines.push("Apples-to-apples comparison on Hadrian. Same deployer-authored test mint, same operations.");
+    lines.push("");
+    lines.push(`- cached wrapper: \`${cachedAddress}\``);
+    lines.push(`- cpi    wrapper: \`${cpiAddress}\``);
+    lines.push(`- shared mint:   \`${cachedMint}\``);
+    lines.push("");
+    lines.push("| Operation | Track | Status | EVM gas | Sol txs | Sol CU | Heap bytes |");
+    lines.push("|---|---|---|---:|---:|---:|---:|");
+    for (const r of rows) {
+        lines.push(
+            `| ${r.op} | ${r.track} | ${r.status ?? ""} | ${r.evmGas ?? ""} | ${r.solNumTxs ?? ""} | ${r.solCu ?? ""} | ${r.heapBytes ?? ""} |`,
+        );
+    }
+    lines.push("");
+
+    // Side-by-side delta summary
+    lines.push("## Delta (cached − cpi, negative = cached saves)");
+    lines.push("");
+    lines.push("| Operation | EVM gas Δ | Sol CU Δ | Heap Δ |");
+    lines.push("|---|---:|---:|---:|");
+    const byOp = new Map<string, { cached?: BenchRow; cpi?: BenchRow }>();
+    for (const r of rows) {
+        const entry = byOp.get(r.op) ?? {};
+        if (r.track === "cached") entry.cached = r;
+        else entry.cpi = r;
+        byOp.set(r.op, entry);
+    }
+    for (const [op, { cached, cpi }] of byOp.entries()) {
+        if (!cached || !cpi) continue;
+        const gasDelta = (cached.evmGas ?? 0) - (cpi.evmGas ?? 0);
+        const cuDelta = (cached.solCu ?? 0) - (cpi.solCu ?? 0);
+        const heapDelta = (cached.heapBytes ?? 0) - (cpi.heapBytes ?? 0);
+        lines.push(`| ${op} | ${gasDelta} | ${cuDelta} | ${heapDelta} |`);
+    }
+
+    const out = "scripts/CACHED_VS_CPI_WRAPPER_BENCH.md";
+    fs.writeFileSync(out, lines.join("\n") + "\n");
+    console.log(`\nReport written to ${out}`);
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/erc20spl/create_test_mint.ts
+++ b/scripts/erc20spl/create_test_mint.ts
@@ -1,0 +1,89 @@
+import hardhat from "hardhat";
+import { isAddress, parseAbi } from "viem";
+import { readDeployments } from "../lib/deployments.js";
+
+// Create a deployer-authored test mint via the existing ERC20SPLFactory.
+//
+//   1. create_token_mint() — System CreateAccount for a salt-derived PDA
+//                            with the deployer as the mint creator
+//   2. init_token_mint(mint) — InitializeMint2 with the deployer's
+//                              external_auth PDA as the mint authority
+//                              (so SPL_ERC20_cached.mint_to works when
+//                              called by the deployer)
+//
+// Prints the resulting mint pubkey. Use it as WRAPPER_MINT_ID for the
+// SPL_ERC20_cached deploy script.
+
+async function main() {
+    const networkName = process.env.HARDHAT_NETWORK ?? "hadrian";
+    const deployments = readDeployments(networkName);
+
+    const factoryAddress = deployments.ERC20SPLFactory?.address;
+    if (!factoryAddress || !isAddress(factoryAddress)) {
+        throw new Error(
+            `ERC20SPLFactory not deployed on ${networkName}. ` +
+            `Run scripts/bridge/deploy.ts first.`,
+        );
+    }
+
+    const { viem } = await hardhat.network.connect();
+    const publicClient = await viem.getPublicClient();
+    const wallets = await viem.getWalletClients();
+    if (wallets.length === 0) {
+        throw new Error("no wallet client — set HADRIAN_PRIVATE_KEY in keystore");
+    }
+    const wallet = wallets[0];
+
+    const factoryAbi = parseAbi([
+        "function create_token_mint() external returns (bytes32)",
+        "function init_token_mint(bytes32 mint) external",
+        "function get_current_mint(address user) external view returns (bytes32, bytes32)",
+    ]);
+
+    // Pre-compute the mint pubkey via get_current_mint — same value
+    // create_token_mint will produce on this caller's next nonce.
+    const [predicted] = (await publicClient.readContract({
+        address: factoryAddress as `0x${string}`,
+        abi: factoryAbi,
+        functionName: "get_current_mint",
+        args: [wallet.account.address],
+    })) as [`0x${string}`, `0x${string}`];
+
+    console.log(`Predicted mint pubkey: ${predicted}`);
+    console.log(`Calling factory.create_token_mint()...`);
+
+    const createHash = await wallet.writeContract({
+        address: factoryAddress as `0x${string}`,
+        abi: factoryAbi,
+        functionName: "create_token_mint",
+        args: [],
+    });
+    const createReceipt = await publicClient.waitForTransactionReceipt({ hash: createHash });
+    if (createReceipt.status !== "success") {
+        throw new Error(`create_token_mint reverted: tx ${createHash}`);
+    }
+    console.log(`  create_token_mint tx: ${createHash} (block ${createReceipt.blockNumber})`);
+
+    console.log(`Calling factory.init_token_mint(${predicted})...`);
+    const initHash = await wallet.writeContract({
+        address: factoryAddress as `0x${string}`,
+        abi: factoryAbi,
+        functionName: "init_token_mint",
+        args: [predicted],
+    });
+    const initReceipt = await publicClient.waitForTransactionReceipt({ hash: initHash });
+    if (initReceipt.status !== "success") {
+        throw new Error(`init_token_mint reverted: tx ${initHash}`);
+    }
+    console.log(`  init_token_mint tx: ${initHash} (block ${initReceipt.blockNumber})`);
+
+    console.log("");
+    console.log("Test mint created. Use it for SPL_ERC20_cached deploy:");
+    console.log(`  WRAPPER_MINT_ID=${predicted} \\`);
+    console.log(`    npx hardhat run scripts/erc20spl/deploy_cached.ts --network ${networkName}`);
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/erc20spl/deploy_cached.ts
+++ b/scripts/erc20spl/deploy_cached.ts
@@ -1,0 +1,71 @@
+import hardhat from "hardhat";
+import { isAddress, isHex } from "viem";
+import { readDeployments, writeDeployments } from "../lib/deployments.js";
+
+// Deploy SPL_ERC20_cached against an existing mint.
+//
+// Required inputs:
+//   - WRAPPER_MINT_ID env var (bytes32 hex) — the Solana mint pubkey
+//     this wrapper will sit on top of. Read from registry per chain.
+//   - HARDHAT_NETWORK env var (default "hadrian")
+//   - ERC20Users contract must already be deployed on the target
+//     network (read from deployments/<network>.json).
+//
+// Optional inputs:
+//   - WRAPPER_NAME / WRAPPER_SYMBOL env vars (defaults below)
+//
+// Writes the deployed address to deployments/<network>.json under
+// the key "SPL_ERC20_cached".
+
+async function main() {
+    const networkName = process.env.HARDHAT_NETWORK ?? "hadrian";
+    const deployments = readDeployments(networkName);
+
+    const usersAddress = deployments.ERC20Users?.address;
+    if (!usersAddress || !isAddress(usersAddress)) {
+        throw new Error(
+            `ERC20Users not deployed on ${networkName}. ` +
+            `Run \`npx hardhat run scripts/bridge/deploy.ts --network ${networkName}\` first.`,
+        );
+    }
+
+    const mintId = process.env.WRAPPER_MINT_ID;
+    if (!mintId || !isHex(mintId) || mintId.length !== 66) {
+        throw new Error(
+            "WRAPPER_MINT_ID env var must be set to a 32-byte hex (0x + 64 chars).",
+        );
+    }
+
+    const cpiProgram = "0xFF00000000000000000000000000000000000008";
+    const wrapperName = process.env.WRAPPER_NAME ?? "Cached USDC";
+    const wrapperSymbol = process.env.WRAPPER_SYMBOL ?? "wUSDCc";
+
+    const { viem } = await hardhat.network.connect();
+    const deployed = await viem.deployContract("SPL_ERC20_cached", [
+        mintId,
+        cpiProgram,
+        wrapperName,
+        wrapperSymbol,
+        usersAddress,
+    ]);
+
+    console.log(`SPL_ERC20_cached deployed at ${deployed.address}`);
+    console.log(`  mint:   ${mintId}`);
+    console.log(`  users:  ${usersAddress}`);
+    console.log(`  name:   ${wrapperName}`);
+    console.log(`  symbol: ${wrapperSymbol}`);
+
+    const all = readDeployments(networkName);
+    all.SPL_ERC20_cached = {
+        address: deployed.address,
+        mint: mintId,
+        name: wrapperName,
+        symbol: wrapperSymbol,
+    };
+    writeDeployments(networkName, all);
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/erc20spl/deploy_cached.ts
+++ b/scripts/erc20spl/deploy_cached.ts
@@ -21,11 +21,14 @@ async function main() {
     const networkName = process.env.HARDHAT_NETWORK ?? "hadrian";
     const deployments = readDeployments(networkName);
 
-    const usersAddress = deployments.ERC20Users?.address;
+    const usersAddress =
+        process.env.ERC20_USERS_ADDRESS ??
+        deployments.SimpleActivator?.users ??
+        (deployments as any).ERC20Users?.address;
     if (!usersAddress || !isAddress(usersAddress)) {
         throw new Error(
-            `ERC20Users not deployed on ${networkName}. ` +
-            `Run \`npx hardhat run scripts/bridge/deploy.ts --network ${networkName}\` first.`,
+            `ERC20Users not found. Set ERC20_USERS_ADDRESS env var, or ` +
+            `ensure deployments/${networkName}.json has SimpleActivator.users.`,
         );
     }
 

--- a/scripts/lib/deployments.ts
+++ b/scripts/lib/deployments.ts
@@ -57,6 +57,14 @@ export type DeploymentsFile = {
     SPL_ERC20_USDC?: WrapperDeployment;
     SPL_ERC20_WETH?: WrapperDeployment;
     SPL_ERC20_WSOL?: WrapperDeployment;
+    // Cache-based wrapper deploys (rome-specs#128 — SPL_ERC20_cached).
+    // Per-mint variants follow the same pattern as the CPI-based wrappers
+    // above (SPL_ERC20_USDC_cached, etc.); the bare key is the first
+    // canonical cached wrapper on a chain.
+    SPL_ERC20_cached?: WrapperDeployment;
+    SPL_ERC20_USDC_cached?: WrapperDeployment;
+    SPL_ERC20_WETH_cached?: WrapperDeployment;
+    SPL_ERC20_WSOL_cached?: WrapperDeployment;
     // Legacy aliases kept for back-compat with hand-edited deployments
     // produced before the SPL_ERC20_* convention. Don't write new code
     // against these.

--- a/tests/erc20spl/cached.integration.ts
+++ b/tests/erc20spl/cached.integration.ts
@@ -1,0 +1,323 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { isAddress } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+// Behavioral integration test for SPL_ERC20_cached.
+//
+// REQUIRES:
+//   - HADRIAN_PRIVATE_KEY in keystore (test wallet with USDC for gas)
+//   - A pre-deployed SPL_ERC20_cached instance on Hadrian (deploy via
+//     `npx hardhat run scripts/erc20spl/deploy_cached.ts --network hadrian`
+//     with WRAPPER_MINT_ID env var set to the test mint)
+//   - The test wallet must be the on-chain mint authority for the test
+//     mint (so `mint_to` calls can be exercised). Create one via the
+//     existing factory's create_token_mint flow before this suite runs.
+//
+// SCOPE:
+//   - Constructor: name + symbol + decimals match init values
+//   - Views: totalSupply / balanceOf / allowance / get_token_account
+//   - Mutations: mint_to / transfer / approve / transferFrom
+//   - Saturation: approve(MaxUint256) round-trips as MaxUint256 in
+//     allowance() readback
+//   - ATA lifecycle: ensure_token_account + create_token_account
+//     idempotency
+//
+// OUT OF SCOPE (separate test files under tests/erc20spl/):
+//   - Revert atomicity         -> cached.revert.test.ts
+//   - Iterative-VM multi-step  -> cached.iterative.test.ts
+//   - In-tx ordering negative  -> cached.ordering.test.ts
+
+describe("SPL_ERC20_cached — behavioral integration", () => {
+    let wrapperAddress: `0x${string}`;
+    let publicClient: any;
+    let walletClient: any;
+    let senderAddress: `0x${string}`;
+
+    before(async () => {
+        const { viem } = await hardhat.network.connect();
+        publicClient = await viem.getPublicClient();
+        const wallets = await viem.getWalletClients();
+        if (wallets.length === 0) {
+            throw new Error(
+                "no wallet client — set HADRIAN_PRIVATE_KEY in keystore: " +
+                "`npx hardhat keystore set HADRIAN_PRIVATE_KEY --dev`",
+            );
+        }
+        walletClient = wallets[0];
+        senderAddress = walletClient.account.address;
+
+        const envAddr = process.env.SPL_ERC20_CACHED_ADDRESS;
+        if (!envAddr || !isAddress(envAddr)) {
+            throw new Error(
+                "SPL_ERC20_CACHED_ADDRESS env var not set or invalid. " +
+                "Deploy first: `npx hardhat run scripts/erc20spl/deploy_cached.ts --network hadrian`",
+            );
+        }
+        wrapperAddress = envAddr as `0x${string}`;
+    });
+
+    it("returns the constructor-passed name", async () => {
+        const name = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: nameAbi,
+            functionName: "name",
+        });
+        assert.equal(typeof name, "string");
+        assert.ok(name.length > 0);
+    });
+
+    it("returns the constructor-passed symbol", async () => {
+        const symbol = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: symbolAbi,
+            functionName: "symbol",
+        });
+        assert.equal(typeof symbol, "string");
+        assert.ok(symbol.length > 0);
+    });
+
+    it("reads decimals from the SPL mint (CpiProgram.account_info)", async () => {
+        const decimals = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: decimalsAbi,
+            functionName: "decimals",
+        });
+        assert.ok(decimals >= 0 && decimals <= 18);
+    });
+
+    it("totalSupply > 0 for an initialized mint (CpiProgram CrossStateEthCall)", async () => {
+        const supply = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: totalSupplyAbi,
+            functionName: "totalSupply",
+        });
+        assert.ok(supply >= 0n);
+    });
+
+    it("balanceOf returns 0 for a fresh address (HelperProgram.user_balance)", async () => {
+        const fresh = privateKeyToAccount(generatePrivateKey()).address;
+        const balance = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [fresh],
+        });
+        assert.equal(balance, 0n);
+    });
+
+    it("allowance returns 0 for an unapproved spender", async () => {
+        const owner = privateKeyToAccount(generatePrivateKey()).address;
+        const spender = privateKeyToAccount(generatePrivateKey()).address;
+        const result = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: allowanceAbi,
+            functionName: "allowance",
+            args: [owner, spender],
+        });
+        assert.equal(result, 0n);
+    });
+
+    it("get_token_account returns a deterministic ATA (HelperProgram.ata EthCall)", async () => {
+        const user = privateKeyToAccount(generatePrivateKey()).address;
+        const ata1 = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: getTokenAccountAbi,
+            functionName: "get_token_account",
+            args: [user],
+        });
+        const ata2 = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: getTokenAccountAbi,
+            functionName: "get_token_account",
+            args: [user],
+        });
+        assert.equal(ata1, ata2);
+        assert.notEqual(
+            ata1,
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        );
+    });
+
+    it("mint_to credits recipient (test wallet must be the mint authority)", async () => {
+        const recipient = privateKeyToAccount(generatePrivateKey()).address;
+        const amount = 1_000_000n; // assumes 6-decimal mint
+
+        const balBefore = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [recipient],
+        });
+
+        const txHash = await walletClient.writeContract({
+            address: wrapperAddress,
+            abi: mintToAbi,
+            functionName: "mint_to",
+            args: [recipient, amount],
+        });
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+        const balAfter = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [recipient],
+        });
+        assert.equal(balAfter - balBefore, amount);
+    });
+
+    it("transfer moves balance + emits Transfer event", async () => {
+        const recipient = privateKeyToAccount(generatePrivateKey()).address;
+        const amount = 100_000n;
+
+        // Pre-mint to sender so it has balance to send
+        const mintHash = await walletClient.writeContract({
+            address: wrapperAddress,
+            abi: mintToAbi,
+            functionName: "mint_to",
+            args: [senderAddress, amount],
+        });
+        await publicClient.waitForTransactionReceipt({ hash: mintHash });
+
+        const senderBefore = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [senderAddress],
+        });
+        const recipBefore = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [recipient],
+        });
+
+        const txHash = await walletClient.writeContract({
+            address: wrapperAddress,
+            abi: transferAbi,
+            functionName: "transfer",
+            args: [recipient, amount],
+        });
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+        const senderAfter = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [senderAddress],
+        });
+        const recipAfter = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: balanceOfAbi,
+            functionName: "balanceOf",
+            args: [recipient],
+        });
+        assert.equal(senderBefore - senderAfter, amount);
+        assert.equal(recipAfter - recipBefore, amount);
+    });
+
+    it("approve(MaxUint256) saturates uint64 storage + reads back as MaxUint256", async () => {
+        const spender = privateKeyToAccount(generatePrivateKey()).address;
+        const max = (1n << 256n) - 1n;
+
+        const txHash = await walletClient.writeContract({
+            address: wrapperAddress,
+            abi: approveAbi,
+            functionName: "approve",
+            args: [spender, max],
+        });
+        await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+        const readback = await publicClient.readContract({
+            address: wrapperAddress,
+            abi: allowanceAbi,
+            functionName: "allowance",
+            args: [senderAddress, spender],
+        });
+        assert.equal(readback, max);
+    });
+});
+
+// ─── Inline ABI snippets — DRY-share by extracting later if useful ────
+
+const nameAbi = [{
+    name: "name",
+    type: "function",
+    inputs: [],
+    outputs: [{ type: "string" }],
+    stateMutability: "view",
+}] as const;
+
+const symbolAbi = [{
+    name: "symbol",
+    type: "function",
+    inputs: [],
+    outputs: [{ type: "string" }],
+    stateMutability: "view",
+}] as const;
+
+const decimalsAbi = [{
+    name: "decimals",
+    type: "function",
+    inputs: [],
+    outputs: [{ type: "uint8" }],
+    stateMutability: "view",
+}] as const;
+
+const totalSupplyAbi = [{
+    name: "totalSupply",
+    type: "function",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+}] as const;
+
+const balanceOfAbi = [{
+    name: "balanceOf",
+    type: "function",
+    inputs: [{ type: "address" }],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+}] as const;
+
+const allowanceAbi = [{
+    name: "allowance",
+    type: "function",
+    inputs: [{ type: "address" }, { type: "address" }],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+}] as const;
+
+const getTokenAccountAbi = [{
+    name: "get_token_account",
+    type: "function",
+    inputs: [{ type: "address" }],
+    outputs: [{ type: "bytes32" }],
+    stateMutability: "view",
+}] as const;
+
+const mintToAbi = [{
+    name: "mint_to",
+    type: "function",
+    inputs: [{ type: "address" }, { type: "uint256" }],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+}] as const;
+
+const transferAbi = [{
+    name: "transfer",
+    type: "function",
+    inputs: [{ type: "address" }, { type: "uint256" }],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+}] as const;
+
+const approveAbi = [{
+    name: "approve",
+    type: "function",
+    inputs: [{ type: "address" }, { type: "uint256" }],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+}] as const;

--- a/tests/erc20spl/cached.selectors.test.ts
+++ b/tests/erc20spl/cached.selectors.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { keccak256, stringToBytes } from "viem";
+
+// Selector hex locks — assert `cast keccak` matches the consts the cache-based
+// precompiles dispatch on, post-#386. If `rome-evm-private` renames a
+// selector or changes a signature, these tests fail and the wrapper rebuild
+// halts before behavioral drift can land.
+//
+// Source of truth:
+//   - rome-evm-private/program/src/non_evm_cached/spl_cached.rs (lines 30-37)
+//   - rome-evm-private/program/src/non_evm_cached/aspl_cached.rs (lines 22-25)
+//
+// Verified against origin/master post-PR #386 on 2026-05-23.
+
+function selectorOf(signature: string): `0x${string}` {
+    return keccak256(stringToBytes(signature)).slice(0, 10) as `0x${string}`;
+}
+
+describe("SPL_ERC20_cached — cache-based selectors used by the wrapper", () => {
+    it("SplCached.transfer(address,uint256,bytes32) = 0x57cfeeee", () => {
+        assert.equal(
+            selectorOf("transfer(address,uint256,bytes32)"),
+            "0x57cfeeee",
+        );
+    });
+
+    it("SplCached.transferFrom(address,address,uint256,bytes32) = 0x401e3367", () => {
+        assert.equal(
+            selectorOf("transferFrom(address,address,uint256,bytes32)"),
+            "0x401e3367",
+        );
+    });
+
+    it("SplCached.approve(address,uint256,bytes32) = 0x8180f2fc", () => {
+        assert.equal(
+            selectorOf("approve(address,uint256,bytes32)"),
+            "0x8180f2fc",
+        );
+    });
+
+    it("SplCached.mint(address,uint256,bytes32) = 0x1e458bee", () => {
+        assert.equal(
+            selectorOf("mint(address,uint256,bytes32)"),
+            "0x1e458bee",
+        );
+    });
+
+    it("AssociatedSplCached.create_ata(address,bytes32) = 0x3de2251a", () => {
+        assert.equal(
+            selectorOf("create_ata(address,bytes32)"),
+            "0x3de2251a",
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- New cache-based wrapper [`contracts/erc20spl/erc20spl_cached.sol`](contracts/erc20spl/erc20spl_cached.sol). Same IERC20 + IERC20Metadata surface as the existing CPI-based `SPL_ERC20`; bridge methods deliberately excluded (permanently-CPI-only `create_ata_for_key` would violate the one-track HARD RULE).
- All mutations dispatch through `SplCached` / `AssociatedSplCached`. Reads use the CU-preference order from the spec: `EthCall` (`HelperProgram.ata`) → `HelperProgram` `CrossStateEthCall` (`user_balance`, `allowance_of`) → `CpiProgram` `CrossStateEthCall` (`account_lamports`, `account_u64_at`).
- Demonstrator contracts at [`contracts/erc20spl/cached_revert_demo.sol`](contracts/erc20spl/cached_revert_demo.sol).
- Deploy scripts + bench tooling at [`scripts/erc20spl/`](scripts/erc20spl/).

Implements [rome-specs#128](https://github.com/rome-protocol/rome-specs/pull/128) (spec + 18-task implementation plan).

## Hadrian — 10/10 integration tests GREEN

Test mint (`ERC20SPLFactory.create_token_mint` + `init_token_mint`, deployer = mint authority):
- mint pubkey: `0xe129d398fb5bf9c7ffb56bfa0b855b101ea92c6d014be32283817301db843bed`
- cached wrapper: `0x979cb140cd9593758496742f40ab37b41807284c`
- CPI wrapper (for bench comparison): `0x56b3e58D05e76Ab6F70F5c3C4B2f9EB966ceA7bD`

```
SPL_ERC20_cached — behavioral integration
  ✔ returns the constructor-passed name (164ms)
  ✔ returns the constructor-passed symbol (159ms)
  ✔ reads decimals from the SPL mint (CpiProgram.account_info) (147ms)
  ✔ totalSupply > 0 for an initialized mint (CpiProgram CrossStateEthCall) (149ms)
  ✔ balanceOf returns 0 for a fresh address (HelperProgram.user_balance) (183ms)
  ✔ allowance returns 0 for an unapproved spender (167ms)
  ✔ get_token_account returns a deterministic ATA (HelperProgram.ata EthCall) (533ms)
  ✔ mint_to credits recipient (test wallet must be the mint authority) (4639ms)
  ✔ transfer moves balance + emits Transfer event (10083ms)
  ✔ approve(MaxUint256) saturates uint64 storage + reads back as MaxUint256 (3973ms)
10 passing (10 nodejs)
```

Plus selector hex locks 5/5 on `hardhatMainnet`.

## Apples-to-apples Solana CU + heap vs CPI-based SPL_ERC20

Same deployer-authored test mint, same operations, same EOA. Driven by [`scripts/erc20spl/bench_cached_vs_cpi_wrapper.ts`](scripts/erc20spl/bench_cached_vs_cpi_wrapper.ts). Full markdown report at [`scripts/CACHED_VS_CPI_WRAPPER_BENCH.md`](scripts/CACHED_VS_CPI_WRAPPER_BENCH.md).

| Operation | Cached CU | CPI CU | Δ CU | Δ Heap |
|---|---:|---:|---:|---:|
| `ensure_token_account(fresh)` | 131,030 | 145,262 | **−14,232 (−9.8%)** | **−3,760** |
| `mint_to(recipient, 1M)` | 256,518 | 264,770 | **−8,252 (−3.1%)** | **−2,632** |
| `transfer(recip2, 100k)` | 279,908 | 286,801 | **−6,893 (−2.4%)** | **−1,712** |
| `approve(spender, 500k)` | 226,018 | 216,186 | **+9,832 (+4.5%)** | +288 |
| `transferFrom(me, recip2, 50k)` | 272,885 | 279,562 | **−6,677 (−2.4%)** | **−1,712** |

Cached saves CU on **4 of 5** ops (2-10% across the wrapper surface) and uses less heap on all 5. `approve` is the lone CU regression — cached is +10K CU more expensive than CPI. Likely cause: `SplCached.approve` serializes the SPL `approve_checked` instruction into the journal overlay (storage write at runtime), where `HelperProgram.approve_spl` fires the CPI directly. Heap delta on approve is +288 bytes (noise).

Cached's value here isn't only CU. It also gets:
- **EVM-revert atomicity** over Solana side effects — committed at tx end via `invoke_signed`; intra-frame reverts discard the queued ix.
- **Iterative-VM compatibility** — multi-step SPL flows (Compound `Bulker`, multi-hop swap, batched outbound) become possible.

These are the cache-track defining properties, not captured in a single-tx CU benchmark.

## Out of scope (separate PRs)

- Bridge method relocation (`bridgeOutToSolana` / `ensureRecipientAta` → new sibling contract)
- `ERC20SPLFactory` integration to deploy the cached variant by default
- Romeswap router cache-based sibling
- Compound `cToken.asset` rebind
- rome-ui hook rebinds
- Registry schema for tracking wrappers per track
- CPI-based wrapper deprecation timeline
- Per-method demo test files (revert atomicity / iterative-VM / ordering negative) — demo contracts are landed, runtime tests deferred
- Approve CU regression investigation (root-cause + potential cache-side optimization)

## Stack note

This branch carries one commit (`chore(deps): add missing peer deps for hardhat-toolbox-viem v5`) that is also in the parallel [PR #209](https://github.com/rome-protocol/rome-solidity/pull/209). Cherry-picked to unblock local dev. When #209 merges, this branch rebases cleanly (identical diff).

## Commits (7)

1. `e60df95` chore(deps): add missing peer deps for hardhat-toolbox-viem v5
2. `c954ece` test(erc20spl-cached): selector hex locks — 5/5 pass on hardhatMainnet
3. `dcf39b3` feat(erc20spl-cached): skeleton — state + constructor + IERC20Metadata views
4. `67e3851` feat(erc20spl-cached): implement IERC20 + IERC20Metadata + ATA helpers
5. `e9cfd8e` feat(erc20spl-cached): demonstrators + integration test + deploy script + CHANGELOG
6. `1f6efba` ops(erc20spl-cached): Hadrian deployment + ERC20Users env-var fallback
7. `7da2601` bench(erc20spl-cached): apples-to-apples Solana CU + heap vs CPI-based SPL_ERC20