### PR TITLE
feat(erc20spl-factory): deploy SPL_ERC20_cached instead of legacy SPL_ERC20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed — `ERC20SPLFactory` deploys `SPL_ERC20_cached` (was `SPL_ERC20`)
+
+[`contracts/erc20spl/erc20spl_factory.sol#_register_contract`](contracts/erc20spl/erc20spl_factory.sol) — both `add_spl_token_with_metadata` and `add_spl_token_no_metadata` now spin up `SPL_ERC20_cached` instances. Constructor signature is identical (`bytes32 mint, address cpi_program, string name, string symbol, ERC20Users users`), so the factory's external ABI + `TokenCreated` event surface stays unchanged.
+
+Migration model is **redeploy the factory at a new address** — the existing factory's state (`token_by_mint`, `mint_by_symbol_hash`, `creator_nonce`) is per-instance, so a fresh deploy gets a clean symbol namespace and starts emitting `TokenCreated` events that the rome-ui token indexer picks up. Registry update points `chain.contracts.erc20SplFactory` at the new factory; rome-ui's canonical-only token-sync (overwrites the Redis cache each cycle) auto-purges legacy-wrapper tokens on the next sync.
+
+The factory itself remains track-neutral by composition: `create_token_mint` + `init_token_mint` still call `HelperProgram` (legacy track) in their own user-tx; `_register_contract` only emits an event and `new`s the contract; the deployed `SPL_ERC20_cached` operates cache-track in subsequent user-txs. No code path mixes tracks within a single tx.
+
+User-visible effect on the new wrappers (vs the legacy `SPL_ERC20`):
+
+- Iterative-VM compatible — multi-step SPL flows compose (Compound `Bulker`, multi-hop swap, batched outbound bridge).
+- EVM-revert atomicity over the queued Solana-side SPL ops (committed at end-of-tx via the cache).
+- 2–10% CU reduction on most ops; +10K CU on `approve` (see rome-solidity #210 bench).
+- Bridge methods (`bridgeOutToSolana`, `ensureRecipientAta`) are NOT exposed on `SPL_ERC20_cached` — the cache track can't host the permanently-CPI-only `create_ata_for_key` per the one-track-per-contract HARD RULE. Bridge flows continue to use the legacy CPI wrapper for now; their relocation to a sibling contract is tracked in the migration spec follow-up.
+
 ### Added — `SPL_ERC20_cached` cache-based wrapper + demonstrator contracts
 
 New contract at [`contracts/erc20spl/erc20spl_cached.sol`](contracts/erc20spl/erc20spl_cached.sol). Replaces the existing CPI-based `SPL_ERC20` on devnet (existing wrapper stays until consumer cutover per the migration spec).

--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./erc20spl.sol";
+import {ERC20Users} from "./erc20spl.sol";
+import {SPL_ERC20_cached} from "./erc20spl_cached.sol";
 import {MplTokenMetadataLib} from "../mpl_token_metadata/lib.sol";
 import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {SystemProgramLib} from "../system_program/system_program.sol";
@@ -50,7 +51,21 @@ contract ERC20SPLFactory {
         bytes32 symbolHash = keccak256(bytes(symbol));
         _check_symbol_hash_exists(symbolHash);
 
-        SPL_ERC20 new_contract = new SPL_ERC20(mint, cpi_program, name, symbol, users);
+        // Deploy the cache-track wrapper. `SPL_ERC20_cached` exposes the
+        // identical IERC20 + IERC20Metadata surface as the prior
+        // `SPL_ERC20`, but dispatches every mutating SPL operation
+        // through `SplCached` / `AssociatedSplCached` (0xff..05 / 06).
+        // Net effects vs the legacy CPI-track wrapper:
+        //   - Iterative-VM compatible (cached SPL ops don't trip the
+        //     legacy CpiProhibitedInIterativeTx gate), so multi-step
+        //     flows like Compound's Bulker and multi-hop swaps compose.
+        //   - EVM-revert atomicity over the Solana-side SPL side
+        //     effects (committed only at end-of-tx via the cache).
+        //   - 2–10% CU reduction on most ops (see rome-solidity #210
+        //     bench).
+        // Constructor signature is identical, so the factory's
+        // ABI / event surface is unchanged.
+        SPL_ERC20_cached new_contract = new SPL_ERC20_cached(mint, cpi_program, name, symbol, users);
         token_by_mint[mint] = address(new_contract);
         mint_by_symbol_hash[symbolHash] = mint;
         token_by_symbol_hash[symbolHash] = address(new_contract);


### PR DESCRIPTION
## Summary

Closes the out-of-scope item from [`#210`](https://github.com/rome-protocol/rome-solidity/pull/210): `ERC20SPLFactory` now deploys `SPL_ERC20_cached` instances on both registration paths (`add_spl_token_with_metadata` + `add_spl_token_no_metadata`).

Both constructors share the **exact same signature** — `(bytes32 mint, address cpi_program, string name, string symbol, ERC20Users users)` — so this is a drop-in replacement at the factory layer. Factory's external ABI + `TokenCreated` event surface are unchanged; downstream indexers (rome-ui's backend, block explorers) need no changes.

## What's in the diff

| File | Lines | Change |
|---|---|---|
| `contracts/erc20spl/erc20spl_factory.sol` | +17 / −2 | Swap `new SPL_ERC20(...)` → `new SPL_ERC20_cached(...)`; named imports |
| `CHANGELOG.md` | +15 / 0 | Migration narrative + user-visible effects |

That's it. 32 insertions / 2 deletions.

## Migration model

Redeploy the factory at a **new address** (its per-instance state — `token_by_mint`, `mint_by_symbol_hash`, `creator_nonce` — is wiped on redeploy, so the new factory gets a clean symbol namespace). Then update `chain.contracts.erc20SplFactory` in the registry to point at the new address. rome-ui's canonical-only token-sync (`backend/services/token_sync_service.py` — overwrites the Redis cache each cycle from the registered factory's `TokenCreated` events) **auto-purges legacy-wrapper tokens on the next sync** — operator gets a clean cutover with no UI-side migration code.

## Track-isolation analysis

The factory remains track-neutral by composition. Three call paths to consider:

| User call | Track | Why |
|---|---|---|
| `create_token_mint` | legacy | Calls `HelperProgram.create_mint_account` (legacy CPI) |
| `init_token_mint` | legacy | Calls `HelperProgram.init_spl_mint` (legacy CPI) |
| `add_spl_token_*` (calls `_register_contract`) | neutral | Just `new`s a contract + emits event — no precompile call |
| Subsequent `wrapper.transfer` / `approve` / `transferFrom` | **cached** | New wrapper dispatches all SPL ops through `SplCached` / `AssociatedSplCached` |

Each path fires in its own user-tx; the per-tx HARD RULE never sees a single tx mix tracks. ✓

## User-visible effect on the new wrappers (vs legacy `SPL_ERC20`)

- **Iterative-VM compatible** — multi-step SPL flows compose (Compound Bulker, multi-hop swap, batched outbound bridge).
- **EVM-revert atomicity** over Solana-side SPL ops (committed at end-of-tx via the cache).
- **2–10% CU reduction** on 4/5 ops; `+10K CU` on `approve` (per the [`#210`](https://github.com/rome-protocol/rome-solidity/pull/210) bench).
- **Bridge methods (`bridgeOutToSolana`, `ensureRecipientAta`) NOT exposed** on `SPL_ERC20_cached` — they require the permanently-CPI-only `create_ata_for_key`, which would violate the one-track-per-contract HARD RULE. Bridge flows continue calling the legacy CPI wrapper for now; their relocation to a sibling contract is tracked in the migration spec follow-up.

## Test plan

- [x] `npx hardhat compile` — clean (88 files; only the pre-existing Meteora contract-size warning, unrelated).
- [x] `npx hardhat test tests/oracle/PythPullParser.test.ts tests/oracle/SwitchboardParser.test.ts` — 22/22 pass (CI-relevant unit tests).
- [ ] Live-network gamut on Hadrian (post-deploy):
  - Deploy new factory via `npx hardhat run scripts/erc20spl/deploy.ts --network hadrian` (or whatever the operator's preferred path is — manual via `npx hardhat run` per CLAUDE.md's "no CI-driven contract deploys" rule).
  - Run `bootstrap-bridged-wrappers.ts` against the new factory to register canonical wrappers and emit `TokenCreated` events.
  - Verify rome-ui's backend indexer picks them up + the cached-wrapper surface (transfer / transferFrom / approve / balanceOf) all work end-to-end.

## Companion / downstream PRs

- [`rome-protocol/rome-ui#381`](https://github.com/rome-protocol/rome-ui/pull/381) — canonical Uniswap V2 Router02 ABI rewiring (this work and that one ship together to give Hadrian a fully canonical UV2 + cached-wrapper stack).
- [`rome-protocol/registry#138`](https://github.com/rome-protocol/registry/pull/138) — Hadrian UV2 trio canonical address rotation. Will be followed by a sibling registry PR for the new factory address once this lands and operator redeploys.
- [`rome-protocol/rome-uniswap-v2#59`](https://github.com/rome-protocol/rome-uniswap-v2/pull/59) — canonical UV2 source pivot.

## Sequencing

1. Merge this PR (`rome-solidity`).
2. Operator deploys new `ERC20SPLFactory` to Hadrian (and any other chain where the migration is in scope) — manual `npx hardhat run` per the existing flow.
3. Open registry PR to retire current `ERC20SPLFactory` v3 + add the new factory address.
4. After registry PR merges, rome-ui's next token-sync purges legacy tokens; new `TokenCreated` events from the new factory populate the cache.
5. rome-ui's existing canonical-only logic handles the rest.