### PR TITLE
docs(claude.md): list 4 canonical protocol forks validated against SPL_ERC20_cached

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Target: `0.8.28`. Production profile enables optimizer with 200 runs.
 | `RomeBridgeWithdraw.burnUSDC` / `burnETH` / `approveBurnETH` | **rome-ui** `src/features/bridge/hooks/useOutboundCctpSend.ts`, `useOutboundWhSend.ts`. Inline parseAbi, no JSON regen. |
 | `RomeBridgePaymaster` / `RomeBridgeInbound` | **Legacy** since 2026-04-26 inbound rewrite — superseded by `settle_inbound_bridge` on rome-evm-private. rome-ui keeps these in `chain.contracts` config for back-compat parsing only; no active call sites. |
 | Oracle adapter interfaces | Consuming contracts in this repo that use the adapters |
-| SPL token wrapper logic | `rome-uniswap-v2/` (uses SPL wrappers for trading pairs); `rome-ui/src/features/portfolio` (renders wrapper rows via `useRomeHoldings`) |
+| SPL token wrapper logic (`SPL_ERC20` / `SPL_ERC20_cached`) | Four canonical protocol forks validated end-to-end against `SPL_ERC20_cached` on Hadrian: `rome-uniswap-v2/` (canonical UV2, PR #59), `rome-uniswap-v3/` (canonical UV3, PR #1 — `METRICS.md` in `scripts/`), `rome-aave-v3/` (canonical Aave V3 slim-cut, PR #1 — METRICS.md), `compound-on-rome-comet/` (canonical Compound v3, PR #18 — [`scripts/hadrian-cached-test/METRICS.md`](https://github.com/rome-protocol/compound-on-rome-comet/blob/main/scripts/hadrian-cached-test/METRICS.md)). All four follow the same one-line operational gotcha: `wrapper.ensure_token_account(<protocolContract>)` once per (protocol, cached-wrapper) pair before first deposit/supply. Plus `rome-ui/src/features/portfolio` (renders wrapper rows via `useRomeHoldings`). |
 | Hardhat network config | `rome-solidity-sdk/` uses same network definitions |
 
 ## Cross-repo dependencies — rome-ui


### PR DESCRIPTION
## Summary

rome-solidity is the source of truth for `SPL_ERC20_cached`. CLAUDE.md's 'Change impact map' should list every downstream consumer that has **empirically validated** cached-wrapper composition end-to-end on a live chain.

As of 2026-05-24 there are four:

| Protocol fork | PR | Result |
|---|---|---|
| `rome-uniswap-v2` (UV2 + cached_v2 wrapper) | [PR #59](https://github.com/rome-protocol/rome-uniswap-v2/pull/59) | 18/18 PASS on Hadrian |
| `rome-uniswap-v3` (canonical UV3 + NFT positions) | [PR #1](https://github.com/rome-protocol/rome-uniswap-v3/pull/1) | 40/40 PASS extended gamut |
| `rome-aave-v3` (canonical Aave V3 slim-cut) | [PR #1](https://github.com/rome-protocol/rome-aave-v3/pull/1) | 24/24 PASS with 2-wallet liquidation + flash loan |
| `compound-on-rome-comet` (canonical Compound v3) | [PR #18](https://github.com/rome-protocol/compound-on-rome-comet/pull/18) | 19/20 single-collat + 32/33 5-collat |

All four follow the same one-line operational gotcha: `wrapper.ensure_token_account(<protocolContract>)` once per (protocol, cached-wrapper) pair before first deposit/supply.

## What's added

One-line update to the 'Change impact map' table row for SPL token wrapper logic — now lists all four forks with PR links + METRICS.md pointer for Compound (where the deepest per-action measurement lives).

## Why

Future sessions auditing or modifying `SPL_ERC20_cached` should know which downstream consumers will need re-validation if the wrapper changes. The METRICS.md link in particular saves them from re-running the gamuts to get the empirical CU/heap envelope.

## Test plan

- [x] No code changes; docs-only edit
- [x] All linked PRs are merged and reachable

## Related

- `rome-specs/active/technical/2026-05-23-canonical-uniswap-v2-on-rome.md`
- `rome-specs/active/technical/2026-05-23-canonical-uniswap-v3-on-rome.md`
- `rome-specs/active/technical/2026-05-24-canonical-aave-v3-on-rome.md`
- `rome-specs/active/technical/2026-05-24-canonical-compound-v3-on-rome.md` (PR pending)