### PR TITLE
fix(erc20spl-cached): overlay-aware balanceOf for V3 Pool.mint

### DIFF
--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -86,14 +86,36 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
     }
 
     /// @notice ERC-20: balanceOf returns 0 (not revert) for any address.
-    ///         SplCached.account reverts on an uninitialized ATA, so probe
-    ///         lamports first and short-circuit when the ATA is missing.
+    ///         Uses try/catch on `SplCached.account` instead of a legacy
+    ///         `AccountReader.lamportsOf` short-circuit.
+    ///
+    ///         Why the change: legacy CpiProgram CrossStateEthCall reads
+    ///         (e.g. `account_lamports`) hit on-chain state directly and
+    ///         are NOT overlay-aware. Cached-track writes (SplCached.
+    ///         transferFrom inside the same tx) update the `NonEvmState`
+    ///         overlay; `CachedState::account` consults overlay first.
+    ///         If `balanceOf` short-circuits on legacy lamports, the
+    ///         AFTER-callback balance read inside V3 Pool.mint sees
+    ///         stale 0 from on-chain, so the
+    ///         `require(balance0Before + amount0 <= balance0())` check
+    ///         reverts with 'M0' even though the cached transferFrom
+    ///         succeeded.
+    ///
+    ///         Try/catch on SplCached.account is the overlay-aware
+    ///         short-circuit: precompile reverts on missing ATA → catch
+    ///         returns 0; precompile succeeds → returns amount from
+    ///         whichever state (overlay if written, on-chain otherwise).
+    ///
+    ///         Discovered 2026-05-25 during Hadrian V3 create-pool
+    ///         smoke (rome-ui PR #402). Cross-ref:
+    ///         rome-uniswap-v3/contracts/UniswapV3Pool.sol:486-490.
     function balanceOf(address account) external view returns (uint256) {
         bytes32 ata = HelperProgram.ata(account, mint_id);
-        if (AccountReader.lamportsOf(ata) == 0) {
+        try SplCached.account(ata) returns (ISplCached.Account memory acc) {
+            return uint256(acc.amount);
+        } catch {
             return 0;
         }
-        return uint256(SplCached.account(ata).amount);
     }
 
     /// @notice ERC-20: allowance returns 0 (not revert) for any (owner, spender).

--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -119,19 +119,24 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
     }
 
     /// @notice ERC-20: allowance returns 0 (not revert) for any (owner, spender).
-    ///         Probe owner ATA lamports before reading delegate fields.
+    ///         Same overlay-aware pattern as `balanceOf` — try/catch on
+    ///         `SplCached.account` instead of a legacy lamports probe.
+    ///         Reason: a protocol that calls `approve` then reads
+    ///         `allowance` within the same tx would see stale (0) data
+    ///         from the legacy probe, since `SplCached.approve` writes
+    ///         to overlay but the legacy lamports read is on-chain-only.
     ///         Saturates uint64::max → uint256::max for wallet "infinite approval".
     function allowance(address owner, address spender) external view returns (uint256) {
         bytes32 ownerAta = HelperProgram.ata(owner, mint_id);
-        if (AccountReader.lamportsOf(ownerAta) == 0) {
+        try SplCached.account(ownerAta) returns (ISplCached.Account memory acc) {
+            bytes32 spenderPda = HelperProgram.pda(spender);
+            if (acc.delegate != spenderPda) return 0;
+            return acc.delegated_amount == type(uint64).max
+                ? type(uint256).max
+                : uint256(acc.delegated_amount);
+        } catch {
             return 0;
         }
-        ISplCached.Account memory acc = SplCached.account(ownerAta);
-        bytes32 spenderPda = HelperProgram.pda(spender);
-        if (acc.delegate != spenderPda) return 0;
-        return acc.delegated_amount == type(uint64).max
-            ? type(uint256).max
-            : uint256(acc.delegated_amount);
     }
 
     /// @notice Pure EthCall derivation — `external_auth(user) + mint_id`
@@ -233,13 +238,22 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
 
     /// @notice ERC-20: approve succeeds for any caller regardless of balance.
     ///         SPL approve_checked writes the delegate fields on the owner ATA,
-    ///         so the ATA must exist. Auto-create if missing; the lamports probe
-    ///         skips the cost when the owner already has tokens.
+    ///         so the ATA must exist. Auto-create if missing; the existence
+    ///         probe uses overlay-aware `SplCached.account` (try/catch) so
+    ///         repeated approves in the same tx skip the redundant
+    ///         ensure_token_account call. The previous legacy
+    ///         `AccountReader.lamportsOf` probe read on-chain only — it
+    ///         saw stale lamports for an ATA that was created earlier in
+    ///         the same tx (overlay), so it would fire the idempotent
+    ///         AssociatedSplCached.create_ata CPI every time → ~30K CU
+    ///         per redundant call.
     ///         Saturates uint64::max → uint256::max for wallet "infinite approval".
     function approve(address spender, uint256 value) external returns (bool) {
         _users.ensure_user(msg.sender);
         bytes32 ownerAta = HelperProgram.ata(msg.sender, mint_id);
-        if (AccountReader.lamportsOf(ownerAta) == 0) {
+        try SplCached.account(ownerAta) returns (ISplCached.Account memory) {
+            // ATA exists in cache (overlay or on-chain) — skip create.
+        } catch {
             ensure_token_account(msg.sender);
         }
         uint64 storedAmount = value > type(uint64).max


### PR DESCRIPTION
## Summary
Replaces the legacy `AccountReader.lamportsOf` short-circuit in `SPL_ERC20_cached.balanceOf` with a try/catch on `SplCached.account`. The legacy `CpiProgram.account_lamports` read isn't overlay-aware — Cached-track writes (e.g. `SplCached.transferFrom` from inside V3 Pool's mint callback) stage state in `NonEvmState` overlay, but the legacy lamports probe reads directly from on-chain. Inside V3 Pool.mint's balance-delta check, the AFTER read sees stale 0 and reverts with `M0`.

Reproduces on Hadrian (cast call NPM `multicall(create, mint)` → `execution reverted, data: 0x` while `multicall(createOnly)` succeeds).

Also aligns the contract more strictly with the one-track-per-contract HARD RULE — `balanceOf` no longer touches the legacy CpiProgram precompile family.

## Behavioral notes
- Cached precompile reverts on missing ATA → try/catch returns 0 (preserves ERC-20 "balanceOf never reverts" invariant)
- Overlay-aware: after `SplCached.transferFrom` writes the overlay, subsequent `SplCached.account` reads see the updated amount (CachedState::account checks `NonEvmState` first, falls through to on-chain)
- Compound v3 + V2 unaffected (don't balance-delta-check in tx); V3 Pool.mint + Pool.swap + V3-style flash callbacks now work

## Test plan
- [ ] `npx hardhat compile` — clean (verified locally)
- [ ] Deploy new SPL_ERC20_cached + new ERC20SPLFactory v6 to Hadrian via contract-deploys
- [ ] Bootstrap wrappers (wUSDC, wETH, wSOL) via factory
- [ ] Register Hadrian addresses in registry
- [ ] V3 create-pool smoke: `cast call NPM multicall([create, mint])` on v6 wUSDC × v6 wETH × 0.30% — expect non-revert
- [ ] rome-ui A4 smoke: operator click "Create pool & mint" on /liquidity?addV3=true — expect 3 popups + success
- [ ] Compound v3 + V2 + V3 swap regression sweep against new wrapper

## Follow-ups
- `allowance` has the same legacy-probe pattern. Not on V3 hot path (no observed protocol that allowance-delta-checks in tx) — defer to a follow-up PR.
- The 6 existing v5 wrappers on Hadrian (wUSDC `0x7632…`, wETH `0xDaA3…`, wSOL `0x101a…`, wHEAT `0x88d7…`, wSALT `0xb62e…`, wMILK `0x6590…`, wOIL `0x6fb8…`) need redeployment.