### PR TITLE
feat(interface): IHelperProgram.transfer_spl_to_signer(uint64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-### Added — `IHelperProgram.transfer_spl_to_signer(uint64)` (selector `0x988977f5`)
+### Added — `IHelperProgram.transfer_spl_to_signer(uint64,bytes32)` (selector `0x46efa679`)
 
-Mirrors the new HelperProgram entry on rome-evm-private's `unsigned_tx` branch (`pub const TRANSFER_SPL_TO_SIGNER: &[u8] = &[0x98, 0x89, 0x77, 0xf5]`). Transfers `tokens` of the chain's gas mint from the caller's `external_auth(caller)`-PDA-owned ATA to the **Solana transaction signer's** ATA via SPL `transfer_checked`. Gas-mint chains only; single-state mode only (the Rust dispatch gates with `single_state_only`).
+Mirrors the new HelperProgram entry on rome-evm-private's `unsigned_tx` branch (`pub const TRANSFER_SPL_TO_SIGNER: &[u8] = &[0x46, 0xef, 0xa6, 0x79]`). Transfers `tokens` of `mint` from the caller's `external_auth(caller)`-PDA-owned ATA to the **Solana transaction signer's** ATA via SPL `transfer_checked`. Single-state mode only (the Rust dispatch gates with `single_state_only`).
 
-Pairs with the in-flight unsigned-tx instruction (EIP-1559 RLP without signature; EVM sender derived from `derive_sender(signer.key) = keccak256(signer_pubkey)[12..32]`) — the EVM body can settle the SPL leg back to the Solana payer without needing the payer's EVM address. Selector verified via `keccak256("transfer_spl_to_signer(uint64)")[0:4] == 0x988977f5`.
+Pairs with the in-flight unsigned-tx instruction (EIP-1559 RLP without signature; EVM sender derived from `derive_sender(signer.key) = keccak256(signer_pubkey)[12..32]`) — the EVM body can settle the SPL leg back to the Solana payer without needing the payer's EVM address. Selector verified via `keccak256("transfer_spl_to_signer(uint64,bytes32)")[0:4] == 0x46efa679`.
 
 This PR is the interface mirror only — no rome-ui consumer is wired yet; that comes alongside the unsigned-tx end-to-end bring-up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `IHelperProgram.transfer_spl_to_signer(uint64)` (selector `0x988977f5`)
+
+Mirrors the new HelperProgram entry on rome-evm-private's `unsigned_tx` branch (`pub const TRANSFER_SPL_TO_SIGNER: &[u8] = &[0x98, 0x89, 0x77, 0xf5]`). Transfers `tokens` of the chain's gas mint from the caller's `external_auth(caller)`-PDA-owned ATA to the **Solana transaction signer's** ATA via SPL `transfer_checked`. Gas-mint chains only; single-state mode only (the Rust dispatch gates with `single_state_only`).
+
+Pairs with the in-flight unsigned-tx instruction (EIP-1559 RLP without signature; EVM sender derived from `derive_sender(signer.key) = keccak256(signer_pubkey)[12..32]`) — the EVM body can settle the SPL leg back to the Solana payer without needing the payer's EVM address. Selector verified via `keccak256("transfer_spl_to_signer(uint64)")[0:4] == 0x988977f5`.
+
+This PR is the interface mirror only — no rome-ui consumer is wired yet; that comes alongside the unsigned-tx end-to-end bring-up.
+
 ### Added — `EnsureAta` library + Meteora swap pre-flight (closes user-side ATA stalls)
 
 New library `contracts/cpi/EnsureAta.sol`: idempotently ensure a user's ATA for a given SPL mint exists, before an EVM contract dispatches a Solana CPI that requires it. Wraps `HelperProgram.create_ata(address, bytes32)` — selector `0x3de2251a` — which itself dispatches Solana's `create_associated_token_account_idempotent`, so the probe-and-skip dance at the EVM layer is collapsed into a single call. CU: ~50K (ATA exists, idempotent no-op CPI) to ~110K (creates).

--- a/contracts/examples/helper.sol
+++ b/contracts/examples/helper.sol
@@ -89,8 +89,9 @@ contract helper_example {
         require(success, "revert");
     }
     function transfer_spl_to_signer() external {
+        bytes32 mint = SystemProgram.mint_id();
         (bool success, ) = address(HelperProgram).delegatecall(
-            abi.encodeWithSignature("transfer_spl_to_signer(uint64)", 1000000)
+            abi.encodeWithSignature("transfer_spl_to_signer(uint64,bytes32)", 1000000, mint)
         );
         require(success, "revert");
     }

--- a/contracts/examples/helper.sol
+++ b/contracts/examples/helper.sol
@@ -88,4 +88,10 @@ contract helper_example {
         );
         require(success, "revert");
     }
+    function transfer_spl_to_signer() external {
+        (bool success, ) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature("transfer_spl_to_signer(uint64)", 1000000)
+        );
+        require(success, "revert");
+    }
 }

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -169,6 +169,13 @@ interface IHelperProgram {
     function allowance_of(address owner, address spender, bytes32 mint) external view returns (uint64);
     // deposit gas-token from ata
     function deposit_from_ata(uint256 wei_) external;
+    // transfer_spl_to_signer — SPL transfer of the chain's gas mint from
+    // caller's external_auth-PDA-owned ATA to the Solana transaction
+    // signer's ATA. Gas-mint chains only; single-state mode only.
+    // Pairs with the unsigned-tx flow on rome-evm-private (EIP-1559 RLP
+    // without signature; sender derived from the Solana signer key) —
+    // lets the EVM body settle the SPL leg back to the Solana payer.
+    function transfer_spl_to_signer(uint64 tokens) external;
 }
 
 // IEd25519 — generic ed25519 signature verification primitive at `0xff..0a`.

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -169,13 +169,13 @@ interface IHelperProgram {
     function allowance_of(address owner, address spender, bytes32 mint) external view returns (uint64);
     // deposit gas-token from ata
     function deposit_from_ata(uint256 wei_) external;
-    // transfer_spl_to_signer — SPL transfer of the chain's gas mint from
-    // caller's external_auth-PDA-owned ATA to the Solana transaction
-    // signer's ATA. Gas-mint chains only; single-state mode only.
+    // transfer_spl_to_signer — SPL transfer of `mint` from caller's
+    // external_auth-PDA-owned ATA to the Solana transaction signer's
+    // ATA. Single-state mode only.
     // Pairs with the unsigned-tx flow on rome-evm-private (EIP-1559 RLP
     // without signature; sender derived from the Solana signer key) —
     // lets the EVM body settle the SPL leg back to the Solana payer.
-    function transfer_spl_to_signer(uint64 tokens) external;
+    function transfer_spl_to_signer(uint64 tokens, bytes32 mint) external;
 }
 
 // IEd25519 — generic ed25519 signature verification primitive at `0xff..0a`.


### PR DESCRIPTION
## Summary

- Adds `IHelperProgram.transfer_spl_to_signer(uint64)` (selector `0x988977f5`) to `contracts/interface.sol`, mirroring the new HelperProgram entry on rome-evm-private's `unsigned_tx` branch (`TRANSFER_SPL_TO_SIGNER`).
- Adds the `transfer_spl_to_signer` worked example to `contracts/examples/helper.sol` (delegatecall pattern, matches the surrounding examples).
- CHANGELOG entry under `Unreleased`.

The new selector transfers `tokens` of the chain's gas mint from `external_auth(caller)`'s ATA to the **Solana transaction signer's** ATA via SPL `transfer_checked`. Gas-mint chains only; single-state mode only — the Rust dispatch gates with `single_state_only(self.state, addr)`.

Pairs with the in-flight unsigned-tx instruction on rome-evm-private (EIP-1559 RLP without signature; EVM sender derived from `derive_sender(signer.key) = keccak256(signer_pubkey)[12..32]`) — letting the EVM body settle the SPL leg back to the Solana payer without needing the payer's EVM address.

Interface-mirror PR only. No rome-ui consumer is wired yet; that lands alongside the unsigned-tx end-to-end bring-up.

## Verification

- `keccak256("transfer_spl_to_signer(uint64)")[0:4]` → `0x988977f5` (matches `TRANSFER_SPL_TO_SIGNER` in `program/src/non_evm/helper.rs` on rome-evm-private's `unsigned_tx` branch — selector-lock test pinned upstream in commit `8309a44`).
- `npx hardhat compile` → Compiled 82 Solidity files with solc 0.8.28; only pre-existing warnings.

## Upstream

rome-evm-private `unsigned_tx` branch (commits `a6f49a6 impl HelperProgram.transfer_spl_to_signer(uint64)` and `8309a44 test: pin derive_sender derivation + transfer_spl_to_signer selector`).

## Test plan

- [x] `npx hardhat compile` passes
- [ ] On-chain integration testing pending a Rome chain upgrade to the rome-evm-private `unsigned_tx` build (no merged primary carries this selector yet).