### PR TITLE
feat(interface): add IHelperProgram.transfer_spl_to_signer(uint64,bytes32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `IHelperProgram.transfer_spl_to_signer(uint64,bytes32)`
+
+[`contracts/interface.sol`](contracts/interface.sol) — declares the `transfer_spl_to_signer(uint64 amount, bytes32 mint)` helper (selector `0x46efa679`, mirrors rome-evm-private). Returns SPL from the caller's `external_auth` ATA to the outer Solana tx signer's own ATA — the return leg for Solana-native users (`do_tx_unsigned` / `activate_ata` flow). Worked call-site added to [`contracts/examples/helper.sol`](contracts/examples/helper.sol).
+
 ### Fixed — `SPL_ERC20_cached` views + approve no longer revert on uninitialized ATA
 
 [`contracts/erc20spl/erc20spl_cached.sol`](contracts/erc20spl/erc20spl_cached.sol) — three ERC-20-spec violations fixed:

--- a/contracts/examples/helper.sol
+++ b/contracts/examples/helper.sol
@@ -67,6 +67,17 @@ contract helper_example {
         );
         require(success, "revert");
     }
+    // Return SPL from the synthetic account's ATA to the outer Solana tx
+    // signer's own ATA (the user's wallet) — the return leg for Solana-native
+    // users. Works for any mint; here the chain gas mint.
+    function transfer_spl_to_signer() external {
+        bytes32 mint = SystemProgram.mint_id();
+
+        (bool success, ) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature("transfer_spl_to_signer(uint64,bytes32)", 1000000, mint)
+        );
+        require(success, "revert");
+    }
     function ata() external view returns(bytes32) {
         bytes32 mint = SystemProgram.mint_id();
         bytes32 ata_ = HelperProgram.ata(msg.sender, mint);

--- a/contracts/interface.sol
+++ b/contracts/interface.sol
@@ -206,6 +206,13 @@ interface IHelperProgram {
     // Distinct from the bytes32-ATA variant above (0x766b362a).
     // Replaces SPL_ERC20.transferFrom's delegate path.
     function transfer_spl(address from, address to, uint64 tokens, bytes32 mint) external;
+    // transfer_spl_to_signer — return SPL to the outer Solana tx signer's own
+    // ATA. Source = ata(external_auth(caller), mint); destination =
+    // ata(signer, mint), where signer is the Solana keypair that signed the
+    // Rome tx (the real user wallet, not a PDA). Signs as external_auth(caller).
+    // The return leg for Solana-native users (do_tx_unsigned / activate_ata
+    // flow): moves rome-evm_user_ata -> user_ata for any mint. Selector 0x46efa679.
+    function transfer_spl_to_signer(uint64 amount, bytes32 mint) external;
     // approve_spl — caller-PDA-as-owner sets delegate_pda(spender) on the
     // owner-ATA via SPL approve_checked. Replaces v1 SPL_ERC20.approve's
     // SplTokenLib.approve + raw invoke_signed marshaling path. Signs as


### PR DESCRIPTION
## Summary
Mirrors the new rome-evm-private `HelperProgram` selector `0x46efa679` (landed in rome-evm-private #393) into the Solidity interface so contracts can call it.

`transfer_spl_to_signer(uint64 amount, bytes32 mint)` returns SPL from the caller's `external_auth` ATA to the **outer Solana tx signer's own ATA** (the user's wallet) — the return leg for Solana-native users in the `do_tx_unsigned` / `activate_ata` flow. Works for any mint (base + collateral).

## Changes
- `contracts/interface.sol` — declare `transfer_spl_to_signer(uint64,bytes32)` in `IHelperProgram`.
- `contracts/examples/helper.sol` — worked call-site (delegatecall pattern).
- `CHANGELOG.md` — entry.

## Test plan
- [x] `npx hardhat compile` clean (88 files).
- [x] Selector verified `0x46efa679` via `cast keccak` AND `ethers.id(...)` on the canonical signature — matches the on-chain const in rome-evm-private.