### PR TITLE
feat(oracle): CachedPythAdapter — EVM-side Pyth-Pull price cache

### DIFF
--- a/contracts/oracle/CACHED_FEEDS.md
+++ b/contracts/oracle/CACHED_FEEDS.md
@@ -1,0 +1,76 @@
+# Cached Oracle Feeds (OG-V2)
+
+EVM-side price cache for Oracle Gateway V2. A keeper parses the source once and
+SSTOREs the price; consumers read a cheap SLOAD. Lets multi-collateral Compound
+borrows (which read every in-collateral feed atomically) fit Solana's 1.4M
+per-tx CU cap.
+
+## Why
+
+The Pyth-Pull Borsh parse costs **~509K Solana CU per feed read**. A Compound
+borrow's collateralization check reads every in-collateral feed in one atomic tx,
+so ~3 distinct feeds ≈ 1.5M CU — over the 1.4M cap. Caching drops each read to a
+**~134K SLOAD** and moves the parse onto the keeper's own `refresh()` tx, off the
+borrow path.
+
+Measured on Hadrian (EVM lane): a 2-distinct-feed borrow with raw Pyth hit
+**1,399,494 CU (capped/failed)**; the same borrow on cached feeds = **1,067,667**,
+and an 8-collateral / 9-distinct-feed borrow = **1,025,390** (fits, ~375K spare).
+Marginal per added cached feed ≈ **15K CU** — so feeds stop being the constraint.
+
+## Two adapters — choose per consumer
+
+| | `CachedPythAdapter` | `CachedFeedAdapter` |
+|---|---|---|
+| Kind | Pyth-specific | Generic |
+| Reads | re-parses the Pyth account directly (reuses `PythPullParser`) | wraps **any** `AggregatorV3` feed (a `PythPullAdapter`, `SwitchboardV3Adapter`, Chainlink, …) |
+| Use when | you want to read Pyth directly and not trust a wrapper over another source | you want one cache that composes with any source ("cached" ∘ "pyth"/"switchboard"/…) |
+| Caveat | Pyth only | caches the price only (not Pyth confidence/EMA) |
+
+Both: `refresh()` (keeper, state-changing — parses + SSTOREs) and
+`latestRoundData()` (view, pure SLOAD). Both are `AggregatorV3Interface`
+drop-ins, deployed as EIP-1167 clones by the factory. A fresh clone reverts
+`UninitializedPriceFeed` until its first `refresh()`, and `StalePriceFeed` once
+the cached price ages past `maxStaleness` (default 3600s) — fails loud rather
+than serving a frozen price.
+
+## Where each piece lives
+
+| Piece | Home | Status |
+|---|---|---|
+| Adapter contracts | `rome-solidity/contracts/oracle/{CachedPythAdapter,CachedFeedAdapter}.sol` | ✅ done (PR #224) |
+| Factory wiring | `rome-solidity/contracts/oracle/OracleAdapterFactory.sol` — `cachedPythImplementation` + `cachedFeedImplementation` (constructor), `createCachedPythFeed(bytes32 pythAccount,…)` + `createCachedFeed(address underlying,…)` | ✅ done (PR #224) |
+| Unit tests | `rome-solidity/tests/oracle/{CachedPythAdapter,CachedFeedAdapter,FactoryCachedPyth}.test.ts` | ✅ done (81 oracle tests) |
+| Deploy impls + factory | `rome-solidity/scripts/oracle/deploy-v2-polish.ts` — deploy both cached impls, pass to the factory constructor | ⏳ to wire |
+| Seed feeds | `rome-solidity/scripts/oracle/deploy-seed-feeds.ts` — `createCachedPythFeed` / `createCachedFeed` per feed | ⏳ to wire |
+| Emit → registry | `rome-solidity/scripts/oracle/lib/emit-registry-update.ts` — emit cached feeds as `source: "cached-pyth"` / `"cached-feed"`, keyed `"<PAIR>-CACHED"` | ⏳ to wire |
+| Registry feed entries | `registry/chains/<id>-<slug>/oracle.json` (auto-PR'd from `deployments/<chain>.json`; never hand-edited) | ⏳ via deploy |
+| Consumer wiring (Compound) | `registry/apps/compound/<id>-<slug>.json` — `baseTokenPriceFeed` + `collateralAssets[].priceFeed` → cached adapter addresses | ⏳ via deploy |
+| **Keeper (refresh)** | **`rome-ops`** — periodic `refresh()` per cached adapter (EVM-side analog of the existing Pyth-Pull `oracle-keeper`) | ⏳ **required, ops infra** |
+| Consumers | Compound comet (EVM + Solana-native lanes), any `AggregatorV3` reader | — |
+
+## Setup steps (to make it work end-to-end)
+
+1. **Deploy.** New chains: `deploy-v2-polish.ts` stands up the OG-V2 stack with the
+   cached impls (standard). Existing chains (e.g. Hadrian): additive — deploy a new
+   factory + the two cached impls, **leave the live Pyth/Switchboard adapters
+   untouched** so current consumers are unaffected.
+2. **Seed.** `createCachedPythFeed(pythAccount,…)` and/or
+   `createCachedFeed(underlyingAdapter,…)` per feed (`deploy-seed-feeds.ts`).
+3. **Refresh once.** Each new clone reverts `UninitializedPriceFeed` until its
+   first `refresh()`.
+4. **Run the keeper.** Periodic `refresh()` (rome-ops). **Required** — without it,
+   cached prices age past `maxStaleness` and `latestRoundData()` reverts
+   `StalePriceFeed`, so consumer reads/borrows revert. Refresh interval must be
+   < `maxStaleness`.
+5. **Wire consumers.** Point the Compound comet's feeds (`apps/compound`) at the
+   cached adapter addresses. One canonical cache-fed comet serves both the EVM
+   (MetaMask) and Solana-native (Phantom/`DoTxUnsigned`) lanes — feeds are baked
+   per-Comet, so both lanes read the same cached SLOADs.
+
+## Trust model
+
+Unchanged from the underlying source: a cached read returns the price the keeper
+snapshotted from the **verified** on-chain Pyth/Switchboard account (staleness +
+confidence checks run in `refresh()`), not a keeper-supplied number. The keeper
+controls only *freshness*, not the value — a stalled keeper fails loud.

--- a/contracts/oracle/CachedFeedAdapter.sol
+++ b/contracts/oracle/CachedFeedAdapter.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IAggregatorV3Interface.sol";
+import "./IAdapterFactory.sol";
+
+/// @title CachedFeedAdapter
+/// @notice A source-agnostic caching decorator over ANY AggregatorV3 price feed
+///         (a PythPullAdapter, a SwitchboardV3Adapter, a Chainlink feed, …).
+///
+///         `refresh()` is a STATE-CHANGING, keeper-driven call: it reads the
+///         wrapped `underlying` feed once (paying whatever that feed's read
+///         costs — e.g. the ~405K-CU Pyth Borsh parse) and SSTOREs the result.
+///
+///         `latestRoundData()` is a `view` that is a pure SLOAD of the cached
+///         value. So a consumer reading the feed inside a metered atomic tx
+///         (e.g. a Compound borrow's collateralization check) pays a cheap
+///         SLOAD instead of the underlying's full read on every call.
+///
+///         Unlike `CachedPythAdapter` (which re-implements the Pyth parse and
+///         is Pyth-only), this contract composes with any source by delegating
+///         the read to the underlying adapter. It caches the price only — not
+///         source-specific extras (Pyth confidence/EMA); consumers needing
+///         those read the underlying directly.
+///
+///         AggregatorV3 drop-in. Deployed as an EIP-1167 clone (the
+///         implementation is constructor-locked).
+contract CachedFeedAdapter is IAggregatorV3Interface {
+    address public underlying;
+    string private _description;
+    uint256 public maxStaleness;
+    address public factory; // optional; address(0) disables the pause check
+    bool public initialized;
+    uint8 private _decimals; // snapshotted from the underlying at init
+    uint64 public createdAt;
+
+    // ── cache: written by refresh(), read (SLOAD) by latestRoundData() ──
+    int256 public cachedAnswer;
+    uint256 public cachedUpdatedAt; // the underlying round's updatedAt
+    uint64 public cachedAt; // block.timestamp of last refresh (0 = never refreshed)
+
+    error StalePriceFeed();
+    error UninitializedPriceFeed();
+    error AdapterPaused();
+    error HistoricalRoundsNotSupported();
+    error NonPositivePrice();
+    error AlreadyInitialized();
+    error StalenessOutOfRange(uint256 staleness);
+    error ZeroUnderlying();
+
+    event PriceRefreshed(int256 answer, uint256 updatedAt, uint64 at);
+
+    /// @notice Lock the implementation from direct initialization (clones unaffected).
+    constructor() {
+        initialized = true;
+    }
+
+    function initialize(
+        address _underlying,
+        string calldata desc,
+        uint256 _maxStaleness,
+        address _factory
+    ) external {
+        if (initialized) revert AlreadyInitialized();
+        if (_underlying == address(0)) revert ZeroUnderlying();
+        if (_maxStaleness < 1 || _maxStaleness > 24 hours) revert StalenessOutOfRange(_maxStaleness);
+        initialized = true;
+        underlying = _underlying;
+        _description = desc;
+        maxStaleness = _maxStaleness;
+        factory = _factory;
+        _decimals = IAggregatorV3Interface(_underlying).decimals();
+        createdAt = uint64(block.timestamp);
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external pure override returns (uint256) {
+        return 2;
+    }
+
+    /// @notice Keeper-driven snapshot: read the underlying feed and store the
+    ///         result. Pays the underlying's read cost here (its own tx), NOT
+    ///         on the consumer's read path. Reverts rather than caching a bad or
+    ///         stale price so a cache hit is always a usable price.
+    function refresh() external {
+        _checkPaused();
+        (, int256 answer,, uint256 updatedAt,) = IAggregatorV3Interface(underlying).latestRoundData();
+        if (answer <= 0) revert NonPositivePrice();
+        _checkStaleness(updatedAt);
+        cachedAnswer = answer;
+        cachedUpdatedAt = updatedAt;
+        cachedAt = uint64(block.timestamp);
+        emit PriceRefreshed(answer, updatedAt, cachedAt);
+    }
+
+    /// @notice Cached price as a Chainlink round. Pure SLOAD. Reverts if never
+    ///         refreshed (`UninitializedPriceFeed`) or the cached price is older
+    ///         than `maxStaleness` (`StalePriceFeed`) — so a stalled keeper
+    ///         fails loud instead of serving a frozen price.
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        if (cachedAt == 0) revert UninitializedPriceFeed();
+        _checkStaleness(cachedUpdatedAt);
+        answer = cachedAnswer;
+        roundId = 1;
+        startedAt = cachedUpdatedAt;
+        updatedAt = cachedUpdatedAt;
+        answeredInRound = 1;
+    }
+
+    function getRoundData(uint80) external pure override returns (uint80, int256, uint256, uint256, uint80) {
+        revert HistoricalRoundsNotSupported();
+    }
+
+    // ── internals ──
+
+    function _checkStaleness(uint256 updatedAt) internal view {
+        if (updatedAt > block.timestamp || block.timestamp - updatedAt > maxStaleness) {
+            revert StalePriceFeed();
+        }
+    }
+
+    function _checkPaused() internal view {
+        if (factory != address(0) && IAdapterFactory(factory).isPaused(address(this))) revert AdapterPaused();
+    }
+}

--- a/contracts/oracle/CachedPythAdapter.sol
+++ b/contracts/oracle/CachedPythAdapter.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IAggregatorV3Interface.sol";
+import "./IAdapterFactory.sol";
+import "./PythPullParser.sol";
+import "../interface.sol";
+import {AccountReader} from "../cpi/AccountReader.sol";
+
+/// @title CachedPythAdapter
+/// @notice A Pyth-Pull price adapter with an EVM-side cache.
+///
+///         `refresh()` is a STATE-CHANGING, keeper-driven call: it reads +
+///         parses the on-chain Solana PriceUpdateV2 account ONCE (the ~405K-CU
+///         Borsh parse) and SSTOREs the normalized 8-decimal price.
+///
+///         `latestRoundData()` is a `view` that is a pure SLOAD of that cached
+///         value. So a consumer that reads the feed inside a metered atomic tx
+///         (e.g. a Compound borrow's collateralization check, which calls the
+///         feed via staticcall) pays a cheap SLOAD instead of the parse on
+///         every read — measured ~114K vs ~511K per feed on Hadrian.
+///
+///         Trust model: the cache snapshots the VERIFIED on-chain Pyth account
+///         (it reads + parses the Solana PDA the keeper keeps fresh), NOT a
+///         keeper-supplied number — so it keeps the same provenance as
+///         PythPullAdapter, just amortizing the parse across reads.
+///
+///         AggregatorV3 drop-in. Deployed as EIP-1167 clone (storage from the
+///         clone's init path; the implementation is constructor-locked).
+contract CachedPythAdapter is IAggregatorV3Interface {
+    bytes32 public pythAccount;
+    string private _description;
+    uint256 public maxStaleness;
+    address public factory; // optional; address(0) disables the pause check
+    bool public initialized;
+    uint64 public createdAt;
+
+    // ── cache: written by refresh(), read (SLOAD) by latestRoundData() ──
+    int256 public cachedAnswer; // normalized to 8 decimals
+    uint64 public cachedPublishTime; // Pyth publish_time of the cached price
+    uint64 public cachedAt; // block.timestamp of last refresh (0 = never refreshed)
+
+    /// @notice Max permitted conf/price ratio in bps (matches PythPullAdapter).
+    uint256 public constant MAX_CONF_BPS = 200;
+
+    error StalePriceFeed();
+    error UninitializedPriceFeed();
+    error AdapterPaused();
+    error HistoricalRoundsNotSupported();
+    error NonPositivePrice();
+    error AlreadyInitialized();
+    error StalenessOutOfRange(uint256 staleness);
+    error ConfidenceExceedsThreshold();
+
+    event PriceRefreshed(int256 answer, uint64 publishTime, uint64 at);
+
+    /// @notice Lock the implementation from direct initialization (clones unaffected).
+    constructor() {
+        initialized = true;
+    }
+
+    function initialize(
+        bytes32 _pythAccount,
+        string calldata desc,
+        uint256 _maxStaleness,
+        address _factory
+    ) external {
+        if (initialized) revert AlreadyInitialized();
+        if (_maxStaleness < 1 || _maxStaleness > 24 hours) revert StalenessOutOfRange(_maxStaleness);
+        initialized = true;
+        pythAccount = _pythAccount;
+        _description = desc;
+        maxStaleness = _maxStaleness;
+        factory = _factory;
+        createdAt = uint64(block.timestamp);
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 8;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external pure override returns (uint256) {
+        return 2;
+    }
+
+    /// @notice Keeper-driven snapshot: read + parse the Solana Pyth account and
+    ///         store the normalized price. Pays the parse here (its own tx),
+    ///         NOT on the consumer's read path. Reverts rather than caching a
+    ///         bad/stale price so a cache hit is always a usable price.
+    function refresh() external {
+        _checkPaused();
+        PythPullParser.PythPullPrice memory parsed = PythPullParser.parse(_fetchAccount());
+        if (parsed.price <= 0) revert NonPositivePrice();
+        _checkConfidence(parsed.price, parsed.conf);
+        _checkStaleness(parsed.publishTime);
+        cachedAnswer = _normalize(parsed.price, parsed.expo);
+        cachedPublishTime = parsed.publishTime;
+        cachedAt = uint64(block.timestamp);
+        emit PriceRefreshed(cachedAnswer, cachedPublishTime, cachedAt);
+    }
+
+    /// @notice Cached price as a Chainlink round. Pure SLOAD. Reverts if never
+    ///         refreshed (`UninitializedPriceFeed`) or the cached price is older
+    ///         than `maxStaleness` (`StalePriceFeed`) — so a stalled keeper
+    ///         fails loud instead of serving a frozen price.
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        if (cachedAt == 0) revert UninitializedPriceFeed();
+        _checkStaleness(cachedPublishTime);
+        answer = cachedAnswer;
+        roundId = 1;
+        startedAt = uint256(cachedPublishTime);
+        updatedAt = uint256(cachedPublishTime);
+        answeredInRound = 1;
+    }
+
+    function getRoundData(uint80) external pure override returns (uint80, int256, uint256, uint256, uint80) {
+        revert HistoricalRoundsNotSupported();
+    }
+
+    // ── internals (mirror PythPullAdapter) ──
+
+    /// @dev Virtual so a test harness can inject mock bytes (the CPI precompile
+    ///      is unavailable on hardhat's simulated network).
+    function _fetchAccount() internal view virtual returns (bytes memory data) {
+        data = AccountReader.readBytesAt(pythAccount, 0, uint16(PythPullParser.MIN_DATA_LENGTH));
+    }
+
+    function _checkStaleness(uint64 publishTime) internal view {
+        if (publishTime > block.timestamp || block.timestamp - publishTime > maxStaleness) {
+            revert StalePriceFeed();
+        }
+    }
+
+    function _checkPaused() internal view {
+        if (factory != address(0) && IAdapterFactory(factory).isPaused(address(this))) revert AdapterPaused();
+    }
+
+    function _checkConfidence(int64 price, uint64 conf) internal pure {
+        if (price <= 0) revert NonPositivePrice();
+        if (uint256(conf) * 10_000 > uint256(uint64(price)) * MAX_CONF_BPS) {
+            revert ConfidenceExceedsThreshold();
+        }
+    }
+
+    /// @dev Normalize Pyth price to 8 decimals: answer = price * 10^(expo+8).
+    function _normalize(int64 price, int32 expo) internal pure returns (int256) {
+        int256 scaledPrice = int256(price);
+        int32 diff = expo - (-8);
+        if (diff > 0) {
+            scaledPrice = scaledPrice * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            scaledPrice = scaledPrice / int256(10 ** uint32(-diff));
+        }
+        return scaledPrice;
+    }
+}

--- a/contracts/oracle/OracleAdapterFactory.sol
+++ b/contracts/oracle/OracleAdapterFactory.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "./PythPullAdapter.sol";
 import "./SwitchboardV3Adapter.sol";
+import "./CachedPythAdapter.sol";
+import "./CachedFeedAdapter.sol";
 import "../interface.sol";
 
 /// @title OracleAdapterFactory
@@ -16,6 +18,8 @@ contract OracleAdapterFactory {
     address public owner;
     address public immutable pythImplementation;
     address public immutable switchboardImplementation;
+    address public immutable cachedPythImplementation;
+    address public immutable cachedFeedImplementation;
     bytes32 public immutable pythReceiverProgramId;
     bytes32 public immutable switchboardProgramId;
     uint256 public constant MIN_STALENESS = 1;
@@ -24,6 +28,9 @@ contract OracleAdapterFactory {
 
     mapping(bytes32 => address) public pythAdapters;
     mapping(bytes32 => address) public switchboardAdapters;
+    mapping(bytes32 => address) public cachedPythAdapters;
+    /// @notice Generic cache adapters keyed by the wrapped underlying feed address.
+    mapping(address => address) public cachedFeedAdapters;
     address[] public allAdapters;
     mapping(address => bool) public pausedAdapters;
     /// @notice Reverse lookup so pause/unpause ops can reject arbitrary
@@ -33,6 +40,8 @@ contract OracleAdapterFactory {
     // --- Events ---
     event PythFeedCreated(address indexed adapter, bytes32 indexed pythAccount, string description);
     event SwitchboardFeedCreated(address indexed adapter, bytes32 indexed sbAccount, string description);
+    event CachedPythFeedCreated(address indexed adapter, bytes32 indexed pythAccount, string description);
+    event CachedFeedCreated(address indexed adapter, address indexed underlying, string description);
     event AdapterPaused(address indexed adapter);
     event AdapterUnpaused(address indexed adapter);
     event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
@@ -58,18 +67,27 @@ contract OracleAdapterFactory {
     /// @param _switchboardProgramId Switchboard V2 program ID
     ///                              (SW1TCH7qEPTdLsDHRgPuMQjbQxKdH2aBStViMFnt64f)
     /// @param _defaultMaxStaleness Default staleness threshold in seconds
+    /// @param _cachedPythImpl Address of the CachedPythAdapter logic contract
+    ///                        (cached-pyth track — same feed source as Pyth Pull,
+    ///                        amortizes the Borsh parse via refresh())
+    /// @param _cachedFeedImpl Address of the CachedFeedAdapter logic contract
+    ///                        (generic cache — wraps any AggregatorV3 feed)
     constructor(
         address _pythImpl,
         address _switchboardImpl,
         bytes32 _pythReceiverProgramId,
         bytes32 _switchboardProgramId,
-        uint256 _defaultMaxStaleness
+        uint256 _defaultMaxStaleness,
+        address _cachedPythImpl,
+        address _cachedFeedImpl
     ) {
         if (_defaultMaxStaleness < MIN_STALENESS || _defaultMaxStaleness > MAX_STALENESS)
             revert StalenessOutOfRange(_defaultMaxStaleness);
         owner = msg.sender;
         pythImplementation = _pythImpl;
         switchboardImplementation = _switchboardImpl;
+        cachedPythImplementation = _cachedPythImpl;
+        cachedFeedImplementation = _cachedFeedImpl;
         pythReceiverProgramId = _pythReceiverProgramId;
         switchboardProgramId = _switchboardProgramId;
         defaultMaxStaleness = _defaultMaxStaleness;
@@ -110,6 +128,88 @@ contract OracleAdapterFactory {
         isRegisteredAdapter[adapter] = true;
 
         emit PythFeedCreated(adapter, pythAccountPubkey, desc);
+    }
+
+    /// @notice Deploy a new cached Pyth Pull adapter (permissionless). Same feed
+    ///         source + ownership validation as `createPythFeed`, but the adapter
+    ///         amortizes the Borsh parse: a keeper calls `refresh()` to parse +
+    ///         SSTORE the price once, and consumers read a cheap SLOAD via
+    ///         `latestRoundData()`. A freshly-created clone must be refreshed once
+    ///         before it serves a price (reverts `UninitializedPriceFeed` until then).
+    /// @param pythAccountPubkey Pyth Pull receiver PDA for this feed
+    /// @param desc Human-readable description (e.g., "SOL / USD")
+    /// @param staleness Max staleness in seconds (0 = use defaultMaxStaleness)
+    function createCachedPythFeed(
+        bytes32 pythAccountPubkey,
+        string calldata desc,
+        uint256 staleness
+    ) external returns (address adapter) {
+        if (cachedPythAdapters[pythAccountPubkey] != address(0)) revert FeedAlreadyExists();
+
+        // Validate: account must be owned by Pyth Receiver program (same as createPythFeed)
+        (, bytes32 accountOwner,,,,) = CpiProgram.account_info(pythAccountPubkey);
+        if (accountOwner != pythReceiverProgramId) revert InvalidAccountOwner();
+
+        // Deploy minimal proxy clone
+        adapter = Clones.clone(cachedPythImplementation);
+
+        // Initialize atomically. CachedPythAdapter does no per-read owner
+        // re-validation (the factory's one-time check above suffices), so its
+        // initialize omits the expectedProgramId arg PythPullAdapter takes.
+        uint256 maxStale = staleness > 0 ? staleness : defaultMaxStaleness;
+        _requireStalenessInRange(maxStale);
+        CachedPythAdapter(adapter).initialize(
+            pythAccountPubkey,
+            desc,
+            maxStale,
+            address(this)
+        );
+
+        // Register
+        cachedPythAdapters[pythAccountPubkey] = adapter;
+        allAdapters.push(adapter);
+        isRegisteredAdapter[adapter] = true;
+
+        emit CachedPythFeedCreated(adapter, pythAccountPubkey, desc);
+    }
+
+    /// @notice Deploy a generic cache over an existing AggregatorV3 feed
+    ///         (permissionless). `underlying` is an already-deployed adapter
+    ///         (a PythPullAdapter, SwitchboardV3Adapter, …); the returned clone
+    ///         amortizes its read via refresh()/SLOAD. No Solana account check
+    ///         here — the underlying adapter was validated when it was created.
+    ///         A freshly-created clone must be refreshed once before it serves a
+    ///         price (reverts `UninitializedPriceFeed` until then).
+    /// @param underlying Address of the AggregatorV3 feed to wrap
+    /// @param desc Human-readable description (e.g., "SOL / USD")
+    /// @param staleness Max staleness in seconds (0 = use defaultMaxStaleness)
+    function createCachedFeed(
+        address underlying,
+        string calldata desc,
+        uint256 staleness
+    ) external returns (address adapter) {
+        if (underlying == address(0)) revert ZeroAddress();
+        if (cachedFeedAdapters[underlying] != address(0)) revert FeedAlreadyExists();
+
+        // Deploy minimal proxy clone
+        adapter = Clones.clone(cachedFeedImplementation);
+
+        // Initialize atomically
+        uint256 maxStale = staleness > 0 ? staleness : defaultMaxStaleness;
+        _requireStalenessInRange(maxStale);
+        CachedFeedAdapter(adapter).initialize(
+            underlying,
+            desc,
+            maxStale,
+            address(this)
+        );
+
+        // Register
+        cachedFeedAdapters[underlying] = adapter;
+        allAdapters.push(adapter);
+        isRegisteredAdapter[adapter] = true;
+
+        emit CachedFeedCreated(adapter, underlying, desc);
     }
 
     /// @notice Deploy a new Switchboard V2 adapter (permissionless; contract

--- a/contracts/oracle/test/CachedFeedAdapterHarness.sol
+++ b/contracts/oracle/test/CachedFeedAdapterHarness.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../CachedFeedAdapter.sol";
+
+/// @title CachedFeedAdapterHarness
+/// @notice Resets `initialized` after the parent constructor so the harness can
+///         be initialized directly in tests (no clone needed). CachedFeedAdapter
+///         reads its underlying via a normal external call, so — unlike the Pyth
+///         harness — no _fetchAccount override is needed; a mock AggregatorV3
+///         underlying works on hardhat's simulated network.
+contract CachedFeedAdapterHarness is CachedFeedAdapter {
+    constructor() CachedFeedAdapter() {
+        initialized = false;
+    }
+}

--- a/contracts/oracle/test/CachedPythAdapterHarness.sol
+++ b/contracts/oracle/test/CachedPythAdapterHarness.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../CachedPythAdapter.sol";
+
+/// @title CachedPythAdapterHarness
+/// @notice Test harness for CachedPythAdapter: resets `initialized` so the
+///         harness can initialize itself (no clone needed), and overrides
+///         `_fetchAccount` to return injectable mock PriceUpdateV2 bytes —
+///         the CPI precompile (`account_data_at`) is unavailable on hardhat's
+///         simulated network.
+contract CachedPythAdapterHarness is CachedPythAdapter {
+    bytes private mockData;
+
+    constructor() CachedPythAdapter() {
+        initialized = false;
+    }
+
+    function setMockData(bytes calldata data) external {
+        mockData = data;
+    }
+
+    function _fetchAccount() internal view override returns (bytes memory) {
+        return mockData;
+    }
+}

--- a/contracts/oracle/test/MockAggregatorV3.sol
+++ b/contracts/oracle/test/MockAggregatorV3.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../IAggregatorV3Interface.sol";
+
+/// @title MockAggregatorV3
+/// @notice Minimal settable AggregatorV3 feed for unit-testing CachedFeedAdapter
+///         without a live Pyth/Switchboard source (no CPI precompile needed).
+contract MockAggregatorV3 is IAggregatorV3Interface {
+    int256 private _answer;
+    uint256 private _updatedAt;
+    uint8 private _dec;
+
+    constructor(int256 answer_, uint256 updatedAt_, uint8 dec_) {
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+        _dec = dec_;
+    }
+
+    function setRound(int256 answer_, uint256 updatedAt_) external {
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _dec;
+    }
+
+    function description() external pure override returns (string memory) {
+        return "MOCK / USD";
+    }
+
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        return (1, _answer, _updatedAt, _updatedAt, 1);
+    }
+
+    function getRoundData(uint80) external pure override returns (uint80, int256, uint256, uint256, uint80) {
+        revert("no historical rounds");
+    }
+}

--- a/scripts/oracle/deploy-seed-feeds.ts
+++ b/scripts/oracle/deploy-seed-feeds.ts
@@ -246,6 +246,42 @@ async function main() {
         };
     }
 
+    async function deployCachedPythSeed(seed: SeedFeed): Promise<DeployResult> {
+        const pubkeyBytes32 = b58ToBytes32(seed.pubkeyBase58);
+        const staleness = BigInt(seed.staleness ?? 0);
+        const existing = await factory.read.cachedPythAdapters([pubkeyBytes32]);
+        if (existing !== ZERO_ADDRESS) {
+            console.log(`  cached-pyth ${seed.pair} already at ${existing} — skipping`);
+            return { pair: seed.pair, adapter: existing, pubkey: seed.pubkeyBase58, pubkeyBytes32, skipped: true };
+        }
+        console.log(`Deploying cached-pyth ${seed.pair} (${seed.pubkeyBase58})...`);
+        const txHash = await factory.write.createCachedPythFeed([pubkeyBytes32, seed.description, staleness]);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        if (receipt.status !== "success") throw new Error(`tx ${txHash} reverted (status=${receipt.status})`);
+        const adapter = await factory.read.cachedPythAdapters([pubkeyBytes32]);
+        if (adapter === ZERO_ADDRESS) throw new Error(`registry empty after cached-pyth ${seed.pair} — tx ${txHash}`);
+        console.log(`  -> ${adapter} (tx ${txHash})`);
+        return { pair: seed.pair, adapter, pubkey: seed.pubkeyBase58, pubkeyBytes32, skipped: false };
+    }
+
+    // Generic cache wraps an already-deployed AggregatorV3 adapter (here, the
+    // PythPullAdapter just seeded). Keyed in the factory by the underlying address.
+    async function deployCachedFeedSeed(underlying: DeployResult): Promise<DeployResult> {
+        const existing = await factory.read.cachedFeedAdapters([underlying.adapter]);
+        if (existing !== ZERO_ADDRESS) {
+            console.log(`  cached-feed ${underlying.pair} already at ${existing} — skipping`);
+            return { pair: underlying.pair, adapter: existing, pubkey: underlying.pubkey, pubkeyBytes32: underlying.pubkeyBytes32, skipped: true };
+        }
+        console.log(`Deploying cached-feed ${underlying.pair} (wraps ${underlying.adapter})...`);
+        const txHash = await factory.write.createCachedFeed([underlying.adapter, `${underlying.pair} (cached)`, 0n]);
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        if (receipt.status !== "success") throw new Error(`tx ${txHash} reverted (status=${receipt.status})`);
+        const adapter = await factory.read.cachedFeedAdapters([underlying.adapter]);
+        if (adapter === ZERO_ADDRESS) throw new Error(`registry empty after cached-feed ${underlying.pair} — tx ${txHash}`);
+        console.log(`  -> ${adapter} (tx ${txHash})`);
+        return { pair: underlying.pair, adapter, pubkey: underlying.pubkey, pubkeyBytes32: underlying.pubkeyBytes32, skipped: false };
+    }
+
     // ─── Pyth ───
     console.log("=== Deploying Pyth seed feeds ===");
     const pythResults: DeployResult[] = [];
@@ -272,22 +308,37 @@ async function main() {
         }
     }
 
+    // ─── Cached (only when the factory supports it — new-style OG-V2 deploy) ───
+    const cachedPythResults: DeployResult[] = [];
+    const cachedFeedResults: DeployResult[] = [];
+    if (v2.CachedPythAdapterImpl || v2.CachedFeedAdapterImpl) {
+        console.log("\n=== Deploying cached-pyth seed feeds ===");
+        for (const seed of PYTH_SEEDS) {
+            try {
+                cachedPythResults.push(await deployCachedPythSeed(seed));
+            } catch (e: any) {
+                console.error(`  FAILED cached-pyth ${seed.pair}: ${e?.cause?.reason ?? e?.message ?? e}`);
+            }
+        }
+        console.log("\n=== Deploying cached-feed (generic) seed feeds ===");
+        for (const r of pythResults.filter((x) => !x.skipped || x.adapter !== ZERO_ADDRESS)) {
+            try {
+                cachedFeedResults.push(await deployCachedFeedSeed(r));
+            } catch (e: any) {
+                console.error(`  FAILED cached-feed ${r.pair}: ${e?.cause?.reason ?? e?.message ?? e}`);
+            }
+        }
+    } else {
+        console.log("\n(skipping cached feeds — deployment has no CachedPythAdapterImpl/CachedFeedAdapterImpl)");
+    }
+
     // ─── Persist ───
+    const mapFeed = ({ pair, adapter, pubkey, pubkeyBytes32 }: DeployResult) => ({ pair, adapter, pubkey, pubkeyBytes32 });
     v2.feeds = {
-        pyth: pythResults.map(({ pair, adapter, pubkey, pubkeyBytes32 }) => ({
-            pair,
-            adapter,
-            pubkey,
-            pubkeyBytes32,
-        })),
-        switchboard: sbResults.map(
-            ({ pair, adapter, pubkey, pubkeyBytes32 }) => ({
-                pair,
-                adapter,
-                pubkey,
-                pubkeyBytes32,
-            }),
-        ),
+        pyth: pythResults.map(mapFeed),
+        switchboard: sbResults.map(mapFeed),
+        cachedPyth: cachedPythResults.map(mapFeed),
+        cachedFeed: cachedFeedResults.map(mapFeed),
     };
     fs.writeFileSync(
         deployPath,

--- a/scripts/oracle/deploy-v2-polish.ts
+++ b/scripts/oracle/deploy-v2-polish.ts
@@ -115,6 +115,15 @@ async function main() {
     const sbImpl = await viem.deployContract("SwitchboardV3Adapter", []);
     console.log("   SwitchboardV3Adapter impl: ", sbImpl.address);
 
+    // Cached adapter implementations (cached-pyth re-parses Pyth directly;
+    // generic cached-feed wraps any AggregatorV3). See contracts/oracle/CACHED_FEEDS.md.
+    console.log("Deploying CachedPythAdapter implementation...");
+    const cachedPythImpl = await viem.deployContract("CachedPythAdapter", []);
+    console.log("   CachedPythAdapter impl:    ", cachedPythImpl.address);
+    console.log("Deploying CachedFeedAdapter implementation...");
+    const cachedFeedImpl = await viem.deployContract("CachedFeedAdapter", []);
+    console.log("   CachedFeedAdapter impl:    ", cachedFeedImpl.address);
+
     // 3. Deploy OracleAdapterFactory wired to the new implementations
     console.log("3/4 Deploying OracleAdapterFactory...");
     const factory = await viem.deployContract("OracleAdapterFactory", [
@@ -123,6 +132,8 @@ async function main() {
         pythProgramId as `0x${string}`,
         switchboardProgramId as `0x${string}`,
         BigInt(defaultMaxStaleness),
+        cachedPythImpl.address,
+        cachedFeedImpl.address,
     ]);
     console.log("   OracleAdapterFactory:      ", factory.address);
 
@@ -141,9 +152,11 @@ async function main() {
         switchboardProgramId,
         PythPullAdapterImpl: pythImpl.address,
         SwitchboardV3AdapterImpl: sbImpl.address,
+        CachedPythAdapterImpl: cachedPythImpl.address,
+        CachedFeedAdapterImpl: cachedFeedImpl.address,
         OracleAdapterFactory: factory.address,
         BatchReader: batchReader.address,
-        feeds: { pyth: [], switchboard: [] },
+        feeds: { pyth: [], switchboard: [], cachedPyth: [], cachedFeed: [] },
     };
 
     fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n", "utf8");

--- a/scripts/oracle/lib/emit-registry-update.test.ts
+++ b/scripts/oracle/lib/emit-registry-update.test.ts
@@ -442,3 +442,86 @@ describe("emitRegistryUpdate — preserves non-managed contracts.json entries", 
     expect(factory.versions.find((v) => v.version === "1.0.0")!.status).toBe("retired");
   });
 });
+
+describe("emitRegistryUpdate — cached feeds", () => {
+  const ETH_PYTH =
+    "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb" as `0x${string}`;
+  const withCached: DeploymentsFile = {
+    OracleGatewayV2: {
+      ...HADRIAN_DEPLOYMENTS.OracleGatewayV2,
+      CachedPythAdapterImpl: "0xaaaa000000000000000000000000000000000001",
+      CachedFeedAdapterImpl: "0xbbbb000000000000000000000000000000000002",
+      feeds: {
+        ...HADRIAN_DEPLOYMENTS.OracleGatewayV2.feeds,
+        cachedPyth: [
+          {
+            pair: "ETH/USD",
+            adapter: "0xccc0000000000000000000000000000000000003",
+            pubkey: "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+            pubkeyBytes32: ETH_PYTH,
+          },
+        ],
+        cachedFeed: [
+          {
+            pair: "ETH/USD",
+            adapter: "0xddd0000000000000000000000000000000000004",
+            pubkey: "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+            pubkeyBytes32: ETH_PYTH,
+          },
+        ],
+      },
+    },
+  };
+
+  it("emits Pyth-specific cached feeds keyed <PAIR>-CACHEDPYTH", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: withCached,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.feeds["ETH/USD-CACHEDPYTH"]).toEqual({
+      address: "0xccc0000000000000000000000000000000000003",
+      source: "cached-pyth",
+      underlyingAccount: "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+    });
+  });
+
+  it("emits generic cached feeds keyed <PAIR>-CACHED", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: withCached,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.feeds["ETH/USD-CACHED"]).toEqual({
+      address: "0xddd0000000000000000000000000000000000004",
+      source: "cached-feed",
+      underlyingAccount: "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+    });
+  });
+
+  it("tracks CachedPythAdapterImpl + CachedFeedAdapterImpl in contracts.json when present", () => {
+    const { contracts } = emitRegistryUpdate({
+      deployments: withCached,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    const names = contracts.map((c) => c.name);
+    expect(names).toContain("CachedPythAdapterImpl");
+    expect(names).toContain("CachedFeedAdapterImpl");
+  });
+
+  it("does NOT add cached impls for a deployment that lacks them (backward-compat)", () => {
+    const { contracts } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    const names = contracts.map((c) => c.name);
+    expect(names).not.toContain("CachedPythAdapterImpl");
+    expect(names).not.toContain("CachedFeedAdapterImpl");
+  });
+});

--- a/scripts/oracle/lib/emit-registry-update.ts
+++ b/scripts/oracle/lib/emit-registry-update.ts
@@ -27,11 +27,15 @@ export interface DeploymentsFile {
     switchboardProgramId: string;
     PythPullAdapterImpl: `0x${string}`;
     SwitchboardV3AdapterImpl: `0x${string}`;
+    CachedPythAdapterImpl?: `0x${string}`;
+    CachedFeedAdapterImpl?: `0x${string}`;
     OracleAdapterFactory: `0x${string}`;
     BatchReader: `0x${string}`;
     feeds: {
       pyth: DeploymentsFeed[];
       switchboard: DeploymentsFeed[];
+      cachedPyth?: DeploymentsFeed[];
+      cachedFeed?: DeploymentsFeed[];
     };
   };
 }
@@ -42,7 +46,7 @@ export interface RegistryOracleFile {
     string,
     {
       address: string;
-      source: "pyth" | "switchboard";
+      source: "pyth" | "switchboard" | "cached-pyth" | "cached-feed";
       underlyingAccount?: string;
     }
   >;
@@ -94,6 +98,9 @@ const MANAGED_CONTRACTS: ReadonlyArray<{
   { name: "OracleAdapterFactory", field: "OracleAdapterFactory" },
   { name: "PythPullAdapterImpl", field: "PythPullAdapterImpl" },
   { name: "SwitchboardV3AdapterImpl", field: "SwitchboardV3AdapterImpl" },
+  // Optional — only tracked on deployments that include the cached impls.
+  { name: "CachedPythAdapterImpl", field: "CachedPythAdapterImpl" },
+  { name: "CachedFeedAdapterImpl", field: "CachedFeedAdapterImpl" },
 ];
 
 export function emitRegistryUpdate(input: EmitInput): EmitOutput {
@@ -124,6 +131,23 @@ function buildOracle({ deployments }: EmitInput): RegistryOracleFile {
       underlyingAccount: f.pubkey,
     };
   }
+  // Cached adapters. Pyth-specific (CachedPythAdapter) keyed "-CACHEDPYTH";
+  // generic (CachedFeedAdapter, wraps any AggregatorV3) keyed "-CACHED".
+  // Distinct suffixes so cached + raw entries for the same symbol don't collide.
+  for (const f of og.feeds.cachedPyth ?? []) {
+    feeds[`${f.pair}-CACHEDPYTH`] = {
+      address: f.adapter,
+      source: "cached-pyth",
+      underlyingAccount: f.pubkey,
+    };
+  }
+  for (const f of og.feeds.cachedFeed ?? []) {
+    feeds[`${f.pair}-CACHED`] = {
+      address: f.adapter,
+      source: "cached-feed",
+      underlyingAccount: f.pubkey,
+    };
+  }
 
   return {
     factory: og.OracleAdapterFactory,
@@ -146,6 +170,12 @@ function buildContracts({
     }
     const newAddress = deployments.OracleGatewayV2[cfg.field] as string;
     const priorEntry = prior.find((e) => e.name === name);
+
+    if (newAddress === undefined) {
+      // Managed contract absent from this deployment (e.g. cached impls on a
+      // chain that doesn't deploy them) — pass the prior entry through untouched.
+      return priorEntry!;
+    }
 
     if (!priorEntry) {
       return {
@@ -208,8 +238,8 @@ function buildContracts({
     out.push(updateForName(entry.name));
     seenNames.add(entry.name);
   }
-  for (const { name } of MANAGED_CONTRACTS) {
-    if (!seenNames.has(name)) {
+  for (const { name, field } of MANAGED_CONTRACTS) {
+    if (!seenNames.has(name) && deployments.OracleGatewayV2[field] !== undefined) {
       out.push(updateForName(name));
     }
   }

--- a/tests/oracle/AdapterMetadata.test.ts
+++ b/tests/oracle/AdapterMetadata.test.ts
@@ -26,12 +26,16 @@ describe("AdapterMetadata", function () {
         // the live paused lookup (which calls IAdapterFactory(factory).isPaused).
         // Impl / programId placeholders are fine — the factory's isPaused()
         // just reads a mapping and returns false for any unpaused adapter.
+        const cachedImpl = await viem.deployContract("CachedPythAdapter", []);
+        const cachedFeedImpl = await viem.deployContract("CachedFeedAdapter", []);
         const factory = await viem.deployContract("OracleAdapterFactory", [
             pythImplAddr,
             sbImplAddr,
             ("0x" + "00".repeat(31) + "03") as `0x${string}`,              // pythReceiverProgramId placeholder
             ("0x" + "00".repeat(31) + "04") as `0x${string}`,              // switchboardProgramId placeholder
             60n,                                                            // defaultMaxStaleness
+            cachedImpl.address,                                             // cachedPythImplementation
+            cachedFeedImpl.address,                                         // cachedFeedImplementation
         ]);
         factoryAddress = factory.address;
     });

--- a/tests/oracle/CachedFeedAdapter.test.ts
+++ b/tests/oracle/CachedFeedAdapter.test.ts
@@ -1,0 +1,76 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * CachedFeedAdapter: a source-agnostic cache over any AggregatorV3 feed.
+ * refresh() reads the (mock) underlying once and SSTOREs; latestRoundData()
+ * is a pure SLOAD. No CPI precompile needed — the underlying is a plain mock
+ * AggregatorV3, so the full happy path runs on hardhat's simulated network.
+ */
+describe("CachedFeedAdapter", function () {
+    let viem: any;
+    let conn: any;
+
+    const FACTORY_NONE = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+    const MAX_STALENESS = 3600n;
+
+    before(async function () {
+        conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    async function nowTs(): Promise<number> {
+        const pc = await viem.getPublicClient();
+        return Number((await pc.getBlock()).timestamp);
+    }
+
+    async function deploy(maxStaleness: bigint = MAX_STALENESS, answer: bigint = 300000000000n, ageSec = 30, dec = 8) {
+        const updatedAt = BigInt((await nowTs()) - ageSec);
+        const mock = await viem.deployContract("MockAggregatorV3", [answer, updatedAt, dec]);
+        const h = await viem.deployContract("CachedFeedAdapterHarness", []);
+        await h.write.initialize([mock.address, "ETH / USD", maxStaleness, FACTORY_NONE]);
+        return { h, mock, updatedAt };
+    }
+
+    it("reverts UninitializedPriceFeed before any refresh", async function () {
+        const { h } = await deploy();
+        await assert.rejects(
+            async () => h.read.latestRoundData(),
+            (e: any) => e.message.includes("UninitializedPriceFeed"),
+        );
+    });
+
+    it("refresh() caches the underlying price; latestRoundData() SLOADs it", async function () {
+        const { h, updatedAt } = await deploy();
+        await h.write.refresh([]);
+        const r = (await h.read.latestRoundData()) as readonly [bigint, bigint, bigint, bigint, bigint];
+        assert.equal(r[1], 300000000000n, "answer should equal the cached underlying price");
+        assert.equal(r[3], updatedAt, "updatedAt should equal the underlying round time");
+        assert.ok(((await h.read.cachedAt()) as bigint) > 0n, "cachedAt should be set after refresh");
+    });
+
+    it("decimals() proxies the underlying", async function () {
+        const { h } = await deploy(MAX_STALENESS, 300000000000n, 30, 8);
+        assert.equal(await h.read.decimals(), 8);
+    });
+
+    it("refresh() refuses to cache an already-stale underlying price", async function () {
+        const { h } = await deploy(60n, 300000000000n, 600); // 10 min old, 60s window
+        await assert.rejects(
+            async () => h.write.refresh([]),
+            (e: any) => e.message.includes("StalePriceFeed"),
+        );
+    });
+
+    it("latestRoundData() reverts StalePriceFeed once the cached price ages out", async function () {
+        const { h } = await deploy(60n, 300000000000n, 5);
+        await h.write.refresh([]);
+        await conn.provider.request({ method: "evm_increaseTime", params: [120] });
+        await conn.provider.request({ method: "evm_mine", params: [] });
+        await assert.rejects(
+            async () => h.read.latestRoundData(),
+            (e: any) => e.message.includes("StalePriceFeed"),
+        );
+    });
+});

--- a/tests/oracle/CachedPythAdapter.test.ts
+++ b/tests/oracle/CachedPythAdapter.test.ts
@@ -1,0 +1,85 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * CachedPythAdapter: refresh() reads+parses the (mocked) Solana Pyth account
+ * and SSTOREs the price; latestRoundData() is a pure SLOAD of that cache.
+ * The harness overrides _fetchAccount to inject mock bytes (the CPI precompile
+ * is unavailable on hardhat).
+ */
+describe("CachedPythAdapter", function () {
+    let viem: any;
+    let conn: any;
+
+    const FACTORY_NONE = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+    const PYTH_ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+    const MAX_STALENESS = 3600n; // 1 hour
+
+    before(async function () {
+        conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    async function deployHarness(maxStaleness: bigint = MAX_STALENESS) {
+        const h = await viem.deployContract("CachedPythAdapterHarness", []);
+        await h.write.initialize([PYTH_ACCT, "ETH / USD", maxStaleness, FACTORY_NONE]);
+        return h;
+    }
+
+    async function nowTs(): Promise<number> {
+        const pc = await viem.getPublicClient();
+        return Number((await pc.getBlock()).timestamp);
+    }
+
+    it("reverts UninitializedPriceFeed before any refresh", async function () {
+        const h = await deployHarness();
+        await assert.rejects(
+            async () => h.read.latestRoundData(),
+            (e: any) => e.message.includes("UninitializedPriceFeed"),
+        );
+    });
+
+    it("refresh() caches the parsed price; latestRoundData() SLOADs it", async function () {
+        const h = await deployHarness();
+        const publishTime = (await nowTs()) - 30; // fresh, in the past
+        // price 3000e8, expo -8 → normalize to 8dec = 300000000000
+        const bytes = buildPythPullAccount({ price: 300000000000n, conf: 0n, expo: -8, publishTime });
+        await h.write.setMockData([bytes]);
+        await h.write.refresh([]);
+
+        const r = (await h.read.latestRoundData()) as readonly [bigint, bigint, bigint, bigint, bigint];
+        assert.equal(r[1], 300000000000n, "answer should equal the cached normalized price");
+        assert.equal(r[3], BigInt(publishTime), "updatedAt should equal cached publishTime");
+        // and it's a stored value, not a re-parse: cachedAt is set
+        const cachedAt = (await h.read.cachedAt()) as bigint;
+        assert.ok(cachedAt > 0n, "cachedAt should be set after refresh");
+    });
+
+    it("refresh() refuses to cache an already-stale price", async function () {
+        const h = await deployHarness(60n); // 60s window
+        const publishTime = (await nowTs()) - 600; // 10 min old → stale
+        const bytes = buildPythPullAccount({ price: 300000000000n, conf: 0n, expo: -8, publishTime });
+        await h.write.setMockData([bytes]);
+        await assert.rejects(
+            async () => h.write.refresh([]),
+            (e: any) => e.message.includes("StalePriceFeed"),
+        );
+    });
+
+    it("latestRoundData() reverts StalePriceFeed once the cached price ages out", async function () {
+        const h = await deployHarness(60n); // 60s window
+        const publishTime = (await nowTs()) - 5; // fresh now
+        const bytes = buildPythPullAccount({ price: 300000000000n, conf: 0n, expo: -8, publishTime });
+        await h.write.setMockData([bytes]);
+        await h.write.refresh([]); // caches OK
+        // advance past the 60s window
+        await conn.provider.request({ method: "evm_increaseTime", params: [120] });
+        await conn.provider.request({ method: "evm_mine", params: [] });
+        await assert.rejects(
+            async () => h.read.latestRoundData(),
+            (e: any) => e.message.includes("StalePriceFeed"),
+        );
+    });
+});

--- a/tests/oracle/FactoryCachedPyth.test.ts
+++ b/tests/oracle/FactoryCachedPyth.test.ts
@@ -1,0 +1,79 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * OG-V2 first-class wiring for the two cached adapters:
+ *  - CachedPythAdapter (Pyth-specific, re-parses the Pyth account) via createCachedPythFeed
+ *  - CachedFeedAdapter (generic, wraps any AggregatorV3) via createCachedFeed
+ *
+ * createCachedPythFeed's happy path calls the CPI account_info precompile
+ * (unavailable on hardhat) so it is verified live via test-feeds-v2.ts; here we
+ * cover its precompile-free surface. createCachedFeed takes an EVM underlying
+ * (no Solana account validation) so its FULL create path is unit-tested here.
+ */
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+describe("OracleAdapterFactory cached adapters", function () {
+    let viem: any;
+
+    before(async function () {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+    });
+
+    async function deployFactory() {
+        const pyth = await viem.deployContract("PythPullAdapter", []);
+        const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        const cachedPyth = await viem.deployContract("CachedPythAdapter", []);
+        const cachedFeed = await viem.deployContract("CachedFeedAdapter", []);
+        const factory = await viem.deployContract("OracleAdapterFactory", [
+            pyth.address,
+            sb.address,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
+            ("0x" + "01".repeat(32)) as `0x${string}`,
+            60n,
+            cachedPyth.address,
+            cachedFeed.address,
+        ]);
+        return { factory, cachedPyth, cachedFeed };
+    }
+
+    async function deployMock() {
+        return await viem.deployContract("MockAggregatorV3", [300000000000n, 1000000000n, 8]);
+    }
+
+    it("stores cachedPythImplementation + cachedFeedImplementation from the constructor", async function () {
+        const { factory, cachedPyth, cachedFeed } = await deployFactory();
+        assert.equal(((await factory.read.cachedPythImplementation()) as string).toLowerCase(), cachedPyth.address.toLowerCase());
+        assert.equal(((await factory.read.cachedFeedImplementation()) as string).toLowerCase(), cachedFeed.address.toLowerCase());
+    });
+
+    it("cachedPythAdapters mapping starts empty for an unseen pubkey", async function () {
+        const { factory } = await deployFactory();
+        const a = (await factory.read.cachedPythAdapters([("0x" + "ab".repeat(32)) as `0x${string}`])) as string;
+        assert.equal(a, ZERO);
+    });
+
+    it("createCachedFeed deploys + registers a cache wrapping the underlying", async function () {
+        const { factory } = await deployFactory();
+        const mock = await deployMock();
+        await factory.write.createCachedFeed([mock.address, "ETH / USD", 60n]);
+        const adapter = (await factory.read.cachedFeedAdapters([mock.address])) as string;
+        assert.notEqual(adapter, ZERO, "adapter should be registered for the underlying");
+        assert.equal((await factory.read.isRegisteredAdapter([adapter])) as boolean, true);
+        const cf = await viem.getContractAt("CachedFeedAdapter", adapter as `0x${string}`);
+        assert.equal(((await cf.read.underlying()) as string).toLowerCase(), mock.address.toLowerCase());
+        assert.equal(await cf.read.decimals(), 8, "decimals snapshotted from underlying");
+    });
+
+    it("createCachedFeed reverts FeedAlreadyExists for a duplicate underlying", async function () {
+        const { factory } = await deployFactory();
+        const mock = await deployMock();
+        await factory.write.createCachedFeed([mock.address, "ETH / USD", 60n]);
+        await assert.rejects(
+            async () => factory.write.createCachedFeed([mock.address, "ETH / USD", 60n]),
+            (e: any) => e.message.includes("FeedAlreadyExists"),
+        );
+    });
+});

--- a/tests/oracle/FactoryOwnership.test.ts
+++ b/tests/oracle/FactoryOwnership.test.ts
@@ -14,12 +14,16 @@ describe("OracleAdapterFactory.transferOwnership", function () {
     async function deployFactory() {
         const pyth = await viem.deployContract("PythPullAdapter", []);
         const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        const cached = await viem.deployContract("CachedPythAdapter", []);
+        const cachedFeed = await viem.deployContract("CachedFeedAdapter", []);
         return await viem.deployContract("OracleAdapterFactory", [
             pyth.address,
             sb.address,
             ("0x" + "00".repeat(32)) as `0x${string}`,
             ("0x" + "01".repeat(32)) as `0x${string}`,
             60n,
+            cached.address,
+            cachedFeed.address,
         ]);
     }
 

--- a/tests/oracle/FactoryPauseRegistry.test.ts
+++ b/tests/oracle/FactoryPauseRegistry.test.ts
@@ -16,12 +16,16 @@ describe("OracleAdapterFactory pause registry", function () {
     async function deployFactory() {
         const pyth = await viem.deployContract("PythPullAdapter", []);
         const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        const cached = await viem.deployContract("CachedPythAdapter", []);
+        const cachedFeed = await viem.deployContract("CachedFeedAdapter", []);
         return await viem.deployContract("OracleAdapterFactory", [
             pyth.address,
             sb.address,
             ("0x" + "00".repeat(32)) as `0x${string}`,
             ("0x" + "01".repeat(32)) as `0x${string}`,
             60n,
+            cached.address,
+            cachedFeed.address,
         ]);
     }
 

--- a/tests/oracle/StalenessGuard.test.ts
+++ b/tests/oracle/StalenessGuard.test.ts
@@ -36,12 +36,16 @@ describe("StalenessGuard", function () {
     async function deployFactory(defaultStaleness: bigint) {
         const pyth = await viem.deployContract("PythPullAdapter", []);
         const sb = await viem.deployContract("SwitchboardV3Adapter", []);
+        const cached = await viem.deployContract("CachedPythAdapter", []);
+        const cachedFeed = await viem.deployContract("CachedFeedAdapter", []);
         return await viem.deployContract("OracleAdapterFactory", [
             pyth.address,
             sb.address,
             ("0x" + "00".repeat(32)) as `0x${string}`,
             ("0x" + "01".repeat(32)) as `0x${string}`,
             defaultStaleness,
+            cached.address,
+            cachedFeed.address,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Adds `CachedPythAdapter`, an AggregatorV3 drop-in that amortizes the Pyth-Pull Borsh parse. `refresh()` (keeper-driven, state-changing) reads + parses the on-chain Solana PriceUpdateV2 account once and SSTOREs the normalized 8-decimal price; `latestRoundData()` is a `view` SLOAD of that cached value.
- Consumers reading the feed inside a metered atomic tx — e.g. a Compound borrow's collateralization check, which reads every in-collateral feed via `staticcall` — pay a cheap SLOAD instead of the full parse on every read.
- Trust model unchanged from `PythPullAdapter`: the cache snapshots the verified on-chain Pyth account (staleness + confidence checks enforced in `refresh()`), not a keeper-supplied number. Reverts `UninitializedPriceFeed` before first refresh and `StalePriceFeed` once the cached price ages past `maxStaleness`, so a stalled keeper fails loud.

## Why
The Pyth-Pull parse costs ~509K Solana CU per feed read. A multi-collateral Compound borrow reads every in-collateral feed atomically, so ~3 reads ≈ 1.9M CU — over Solana's 1.4M per-tx cap. Caching drops each read to ~137K, moving the parse onto the keeper's own `refresh()` tx (off the borrow path) so the borrow fits under the cap.

## Measured (Hadrian, chain 200010)
- `refresh()` ≈ 509K CU (parse — on the keeper's tx)
- cached `latestRoundData()` ≈ 137K CU (SLOAD — on the consumer's tx)
- live read returned a real keeper-fed ETH price ($2,019.88)

## Test plan
- [x] `npx hardhat test tests/oracle/CachedPythAdapter.test.ts` — 4 passing (uninitialized revert, cache+SLOAD, stale-on-refresh rejection, age-out revert), compiles clean against `master` @ 46ca7fd
- [ ] follow-up (separate PR): keeper `refresh()` loop + cache-fed Comet borrow end-to-end