### PR TITLE
feat(oracle): cached-feeds keeper refresh script + deploy runbook

### DIFF
--- a/contracts/oracle/CACHED_FEEDS.md
+++ b/contracts/oracle/CACHED_FEEDS.md
@@ -74,3 +74,47 @@ Unchanged from the underlying source: a cached read returns the price the keeper
 snapshotted from the **verified** on-chain Pyth/Switchboard account (staleness +
 confidence checks run in `refresh()`), not a keeper-supplied number. The keeper
 controls only *freshness*, not the value — a stalled keeper fails loud.
+
+## Deploy runbook (parameterized — no hardcoded addresses)
+
+Everything is env / config-driven; changing a param and re-running re-provisions.
+
+**New chain (cached is standard):**
+```bash
+# 1. OG-V2 stack incl. both cached impls + the 7-arg factory
+ETH_PK=<deployer> npx hardhat run scripts/oracle/deploy-v2-polish.ts --network <chain>
+# 2. Seed feeds — pyth/switchboard + cached (cached auto-seeded when the
+#    deployment has the cached impls; Switchboard skippable per chain)
+ETH_PK=<deployer> npx hardhat run scripts/oracle/deploy-seed-feeds.ts --network <chain>
+# 3. emit-registry-update (run by the contract-deploys oracle-deploy workflow)
+#    writes oracle.json (cached feeds keyed "<PAIR>-CACHEDPYTH" / "<PAIR>-CACHED")
+#    + contracts.json, and auto-PRs them to the registry. Don't hand-edit oracle.json.
+```
+
+**Existing chain (additive — keep the live Pyth/Switchboard feeds):** deploy a new
+cached-capable `OracleAdapterFactory` reusing the chain's existing pyth/switchboard
+impls (constructor args), then per feed call `createCachedPythFeed(pythAccount, desc,
+staleness)` and/or `createCachedFeed(underlyingAdapter, desc, staleness)`. Both are
+permissionless. The existing factory + adapters are untouched.
+
+**Comet (config-driven, in `compound-on-rome-comet`):**
+```bash
+CHAIN_ID=<id> REGISTRY_ROOT=<registry-checkout> ETH_PK=<deployer> \
+  npx hardhat run scripts/registry-driven-deploy/deploy.ts --network <chain>
+```
+The comet's feeds come from `apps/compound/<chainId>-<slug>.json` — set each
+`priceFeed` to the cached adapter address with `priceFeedKind: "cached-pyth"` (or
+`"cached-feed"`). One canonical comet serves both lanes.
+
+## Keeper (required — `scripts/oracle/refresh-cached-feeds.ts`)
+
+Refresh the cached adapters on a cron at an interval **< `maxStaleness`** (default
+3600s). Without it, `latestRoundData()` reverts `StalePriceFeed` and consumer
+reads/borrows revert.
+```bash
+# adapters sourced from deployments/<network>.json feeds.cachedPyth + .cachedFeed:
+npx hardhat run scripts/oracle/refresh-cached-feeds.ts --network <chain>
+# or an explicit list (ad-hoc / cast-deployed feeds not yet in the deployments file):
+CACHED_FEEDS=0x..,0x.. npx hardhat run scripts/oracle/refresh-cached-feeds.ts --network <chain>
+```
+Wire this into rome-ops (the EVM-side analog of the Pyth-Pull `oracle-keeper`).

--- a/scripts/oracle/refresh-cached-feeds.ts
+++ b/scripts/oracle/refresh-cached-feeds.ts
@@ -1,0 +1,81 @@
+import hardhat from "hardhat";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Keeper: refresh every OG-V2 cached adapter on a chain so its SLOAD cache stays
+ * within maxStaleness. Cron this at an interval < the feeds' maxStaleness
+ * (default 3600s) — without it, `latestRoundData()` reverts `StalePriceFeed` and
+ * any consumer read/borrow reverts. See contracts/oracle/CACHED_FEEDS.md.
+ *
+ * Adapter list, in precedence order (parameterized — no hardcoded addresses):
+ *   1. CACHED_FEEDS env — comma-separated adapter addresses (ad-hoc, or chains
+ *      whose cached feeds aren't yet recorded in the deployments file).
+ *   2. deployments/<network>.json OracleGatewayV2.feeds.cachedPyth + .cachedFeed
+ *      (written by deploy-seed-feeds.ts).
+ *
+ * Usage:
+ *   npx hardhat run scripts/oracle/refresh-cached-feeds.ts --network <chain>
+ *   CACHED_FEEDS=0x..,0x.. npx hardhat run scripts/oracle/refresh-cached-feeds.ts --network <chain>
+ */
+
+const REFRESH_GAS = 80_000_000n;
+
+async function main() {
+    const { viem, networkName } = await hardhat.network.connect();
+    const [deployer] = await viem.getWalletClients();
+    if (!deployer?.account) {
+        throw new Error("No deployer wallet found. Configure a funded account for this network.");
+    }
+    const publicClient = await viem.getPublicClient();
+
+    let feeds: string[] = [];
+    const envList = (process.env.CACHED_FEEDS ?? "").trim();
+    if (envList) {
+        feeds = envList.split(",").map((s) => s.trim()).filter(Boolean);
+        console.log(`Source: CACHED_FEEDS env (${feeds.length} feed(s))`);
+    } else {
+        const deployPath = path.resolve(process.cwd(), "deployments", `${networkName}.json`);
+        if (fs.existsSync(deployPath)) {
+            const og = JSON.parse(fs.readFileSync(deployPath, "utf8")).OracleGatewayV2;
+            const adapters = (arr: Array<{ adapter: string }> | undefined) => (arr ?? []).map((f) => f.adapter);
+            feeds = [...adapters(og?.feeds?.cachedPyth), ...adapters(og?.feeds?.cachedFeed)];
+            console.log(`Source: deployments/${networkName}.json feeds.cachedPyth + .cachedFeed (${feeds.length} feed(s))`);
+        }
+    }
+    if (feeds.length === 0) {
+        throw new Error(
+            "No cached feeds found. Set CACHED_FEEDS=0x..,0x.. or run deploy-seed-feeds.ts first.",
+        );
+    }
+
+    console.log(`=== Refreshing ${feeds.length} cached feed(s) on ${networkName} ===`);
+    let ok = 0;
+    let fail = 0;
+    for (const addr of feeds) {
+        try {
+            // Any cached adapter (CachedPythAdapter / CachedFeedAdapter) exposes refresh();
+            // the CachedPythAdapter ABI supplies the selector for both.
+            const c = await viem.getContractAt("CachedPythAdapter", addr as `0x${string}`);
+            const tx = await c.write.refresh([], { gas: REFRESH_GAS });
+            const r = await publicClient.waitForTransactionReceipt({ hash: tx });
+            if (r.status === "success") {
+                console.log(`  ✓ ${addr}`);
+                ok++;
+            } else {
+                console.error(`  ✗ ${addr} (status=${r.status})`);
+                fail++;
+            }
+        } catch (e: any) {
+            console.error(`  ✗ ${addr}: ${e?.cause?.reason ?? e?.message ?? e}`);
+            fail++;
+        }
+    }
+    console.log(`=== ${ok} refreshed, ${fail} failed ===`);
+    if (fail > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- **`scripts/oracle/refresh-cached-feeds.ts`** — the cached-feeds keeper. Refreshes every OG-V2 cached adapter on a chain so its SLOAD cache stays within `maxStaleness`. **Parameterized, no hardcoded addresses**: sources the adapter list from `CACHED_FEEDS` env (comma-separated) or `deployments/<network>.json` `feeds.cachedPyth`/`.cachedFeed`.
- **`contracts/oracle/CACHED_FEEDS.md`** — deploy runbook: parameterized commands for new chains, existing chains (additive), the comet, and the keeper.

## Why
Cached feeds need periodic `refresh()` or they go stale (`latestRoundData()` reverts `StalePriceFeed` → consumer reads/borrows revert). This is the EVM-side analog of the Pyth-Pull `oracle-keeper`; cron it at an interval < `maxStaleness` (default 3600s) and wire it into rome-ops.

## Test plan
- [x] Ran on Hadrian against the 8 canonical cached feeds → **8 refreshed, 0 failed**