### PR TITLE
chore: gitignore .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ deployments/local.json
 /contracts/.deps
 /contracts/.states
 /contracts/remix.config.json
+.worktrees/


### PR DESCRIPTION
Adds `.worktrees/` to .gitignore so linked worktrees stop showing as phantom dirt and can't be accidentally committed as gitlinks. No code change.