### PR TITLE
docs(deploy): cold-ledger mainnet deploy runbook (viem)

### DIFF
--- a/COLD_LEDGER_MAINNET_DEPLOY.md
+++ b/COLD_LEDGER_MAINNET_DEPLOY.md
@@ -1,7 +1,9 @@
 # Cold-Ledger Mainnet Deploy — rome-solidity (Hardhat 3 + viem)
 
 Scaffold for moving mainnet (`rubicon`, chain **7531**) Solidity deploys off the hot-key to a cold Ledger.
-Branch: `mainnet-cold-ledger-deploy-solidity`. **Runbook; approach devnet-verified via `cast` (2026-06-16 — see Signer mechanism).** The in-repo TS adapter is a follow-up — needs gated `npm install` + a physical Ledger.
+Branch: `mainnet-cold-ledger-deploy-solidity`. **IMPLEMENTED + devnet-validated (2026-06-16):** viem Ledger adapter `scripts/lib/ledger.ts` + unified `getDeployer` `scripts/lib/deployer.ts` (Ledger or hot key, reads artifacts from FS) + entrypoint `scripts/deploy-ledger.ts`. ERC20SPLFactory was deployed via the Ledger on trajan (chain 121302) at `0x7659efa8898928b042ff6bbde2adb45c3a0c27cd`.
+
+**Run:** `npx hardhat compile && DEPLOY_VIA_LEDGER=1 ROME_RPC_URL=<rpc> ROME_CHAIN_ID=<id> npx tsx scripts/deploy-ledger.ts`. The Ledger path MUST run under **`tsx`**, not `hardhat run` (Hardhat's CJS script runner hits an ESM require-cycle in `@ledgerhq`). `scripts/deploy-ledger.ts` currently deploys ERC20SPLFactory; remaining Phase-6 contracts extend it with the same `deployer.deploy(<name>, [args])` pattern (library-linked contracts need link handling added to `getDeployer`).
 
 ## Current mechanism (verified)
 - Stack: Hardhat 3 (`hardhat ^3.9.0`) + viem (`@nomicfoundation/hardhat-toolbox-viem ^5.0.7`) — `hardhat.config.ts:1,5`.

--- a/COLD_LEDGER_MAINNET_DEPLOY.md
+++ b/COLD_LEDGER_MAINNET_DEPLOY.md
@@ -1,7 +1,7 @@
 # Cold-Ledger Mainnet Deploy — rome-solidity (Hardhat 3 + viem)
 
 Scaffold for moving mainnet (`rubicon`, chain **7531**) Solidity deploys off the hot-key to a cold Ledger.
-Branch: `mainnet-cold-ledger-deploy-solidity`. **Not yet implemented** — needs gated `npm install` + a physical Ledger.
+Branch: `mainnet-cold-ledger-deploy-solidity`. **Runbook; approach devnet-verified via `cast` (2026-06-16 — see Signer mechanism).** The in-repo TS adapter is a follow-up — needs gated `npm install` + a physical Ledger.
 
 ## Current mechanism (verified)
 - Stack: Hardhat 3 (`hardhat ^3.9.0`) + viem (`@nomicfoundation/hardhat-toolbox-viem ^5.0.7`) — `hardhat.config.ts:1,5`.
@@ -46,3 +46,9 @@ Point `DEPLOY_VIA_LEDGER=1` at a devnet chain (trajan, 121302): deploy `deploy_e
 - ⚠️ `@nomicfoundation/hardhat-ledger` HH3+viem support uncertain (built for HH2/ethers). In-script viem approach avoids depending on it.
 - ⚠️ Physical Ledger required to implement + test.
 - Derivation path + device — operator to confirm (distinct Ethereum-app key vs the Solana program-authority key).
+
+## Signer mechanism — decision (2026-06-16; approach devnet-verified)
+The three Ledger-signing options are not interchangeable for the full stack deploy:
+- **viem in-script Ledger account (this repo) = PRIMARY.** Deploy keeps running through the existing tested TS scripts; only the signer changes. Match the repo's native stack (viem here; ethers in rome-uniswap-v2) — do not rewrite to unify (all paths emit the identical signed EIP-1559 tx the proxy accepts).
+- **`cast send --ledger` = VALIDATED FALLBACK.** Devnet-verified end-to-end 2026-06-16: a Ledger signed an EIP-1559 contract-creation on trajan (121302); the proxy accepted it (contract `0x35c6878c82C03f6773bf8c3eF0C3bBaF73D56a1B`, status success). Zero-install. Use for one-off redeploys / emergencies, or if hardhat-ledger HH3 support proves painful. Do not drive all of Phase 6 through cast (reimplements orchestration + diverges mainnet from the devnet-tested scripts).
+- **Pre-flight (learned in the rehearsal): enable Blind signing on the Ledger Ethereum app** — an unknown chain id otherwise returns APDU `6a80 INVALID_DATA` on every deploy tap.

--- a/COLD_LEDGER_MAINNET_DEPLOY.md
+++ b/COLD_LEDGER_MAINNET_DEPLOY.md
@@ -1,0 +1,48 @@
+# Cold-Ledger Mainnet Deploy — rome-solidity (Hardhat 3 + viem)
+
+Scaffold for moving mainnet (`rubicon`, chain **7531**) Solidity deploys off the hot-key to a cold Ledger.
+Branch: `mainnet-cold-ledger-deploy-solidity`. **Not yet implemented** — needs gated `npm install` + a physical Ledger.
+
+## Current mechanism (verified)
+- Stack: Hardhat 3 (`hardhat ^3.9.0`) + viem (`@nomicfoundation/hardhat-toolbox-viem ^5.0.7`) — `hardhat.config.ts:1,5`.
+- Per network: `{ chainId, url, accounts: [configVariable("<NET>_PRIVATE_KEY")] }` — `hardhat.config.ts:24-44`.
+- Deploy scripts sign via `const [deployer] = await viem.getWalletClients();` (e.g. `scripts/deploy_erc20spl_factory.ts:33`) — `deployer` is a viem WalletClient bound to the network's first private key.
+
+## Risk being fixed
+Plaintext key in env at deploy time. On mainnet the deployer **is** the contract admin (Ownable owner, factory admin, paymaster/bridge authority). Key compromise = contract takeover. Cold Ledger keeps the admin key in hardware.
+
+## Recommended approach — viem-native (no hardhat-ledger dependency)
+HH3+viem has no first-class Ledger plugin (`@nomicfoundation/hardhat-ledger` is ethers/HH2-oriented — see Open items). Build the signer in-script:
+
+1. **Deps** (⚠️ GATED — `npm install` fetches external; run in the focused session): `@ledgerhq/hw-app-eth`, `@ledgerhq/hw-transport-node-hid`.
+2. **Ledger-backed viem account** — `scripts/lib/ledgerAccount.ts`:
+   - `const transport = await TransportNodeHid.create(); const eth = new AppEth(transport);`
+   - Wrap with viem `toAccount({ address, signTransaction, signMessage, signTypedData })`, delegating to `eth.signTransaction` / `eth.signPersonalMessage` / `eth.signEIP712Message`. Derivation path operator-confirmed (e.g. `m/44'/60'/0'/0/0`).
+3. **`getDeployer()` helper** — returns the Ledger wallet client when `DEPLOY_VIA_LEDGER=1`, else `(.getWalletClients())[0]` (devnet/testnet keep the hot-key path):
+   ```ts
+   const account = await makeLedgerAccount(process.env.LEDGER_PATH ?? "m/44'/60'/0'/0/0");
+   return createWalletClient({ account, chain: rubicon, transport: http("https://rubicon.romeprotocol.xyz") });
+   ```
+   Swap the ~10 deploy scripts from `viem.getWalletClients()` → `getDeployer()`.
+4. **hardhat.config.ts** — add rubicon: `rubicon: { type: "http", chainId: 7531, url: "https://rubicon.romeprotocol.xyz/", accounts: [] }` (empty — signing is in-script).
+5. **Device** — Ethereum app, enable **blind signing** (chain 7531 is unknown to the device, so contract deploys require it). One physical tap per tx.
+
+## Deploy set (tap-count driver) — order per `rome-ops/scripts/deploy-solidity.sh` Phase 6
+1. `scripts/deploy_erc20spl_factory.ts`
+2. `scripts/bridge/bootstrap-bridged-wrappers.ts`
+3. `scripts/bridge/deploy.ts` (paymaster + SPL_ERC20 wrappers + withdraw)
+4. `scripts/oracle/deploy-v2-polish.ts` (+ `scripts/oracle/deploy-seed-feeds.ts`)
+5. `scripts/deploy_meteora_factory.ts` (+ `scripts/deploy_meteora_router.ts`)
+6. Romeswap → **rome-uniswap-v2** (separate repo + ethers stack; see that worktree's doc)
+7. `scripts/activation/deploy-simple-activator.ts`
+
+Several are multi-contract → expect **~20-40 Ledger taps**. Budget time + a charged device.
+
+## Devnet rehearsal (needs physical Ledger)
+Point `DEPLOY_VIA_LEDGER=1` at a devnet chain (trajan, 121302): deploy `deploy_erc20spl_factory.ts` + 1-2 more via the Ledger. Confirms the viem-Ledger account, blind-sign UX, tx count, gas — before mainnet.
+
+## Open / gated
+- ⚠️ `npm install` (external) — gated.
+- ⚠️ `@nomicfoundation/hardhat-ledger` HH3+viem support uncertain (built for HH2/ethers). In-script viem approach avoids depending on it.
+- ⚠️ Physical Ledger required to implement + test.
+- Derivation path + device — operator to confirm (distinct Ethereum-app key vs the Solana program-authority key).

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "hardhat": "^3.9.0"
       },
       "devDependencies": {
+        "@ledgerhq/hw-app-eth": "^7.8.6",
+        "@ledgerhq/hw-transport-node-hid": "^6.33.4",
         "@nomicfoundation/hardhat-ignition": "^3.1.7",
         "@nomicfoundation/hardhat-ignition-viem": "^3.1.6",
         "@nomicfoundation/hardhat-toolbox-viem": "^5.0.7",
@@ -90,35 +92,38 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1017,6 +1022,217 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ledgerhq/client-ids": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.10.2.tgz",
+      "integrity": "sha512-6bFdV8uEy/iIJMUdOkbQrlwO45eqjK7UNq732KjPCmh4hZUHFWWM2twGPnrlI5ygTdYeQpWFphRAD6BiqDixYg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/live-env": "^2.38.0",
+        "@reduxjs/toolkit": "2.11.2",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/client-ids/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.15.1.tgz",
+      "integrity": "sha512-o4XEHiwPytnZxYUnOC5JoHX5TPDJpeMXPfXjwhsXVJ9LAbahxQWzC37Iuzk8ZY/oC2yDptzqjs/qNP2y9D9vCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "rxjs": "7.8.2",
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/devices/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ledgerhq/domain-service": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.8.6.tgz",
+      "integrity": "sha512-bSMHDR+SIB3alJyYBCY9NB8wt+nIHHSQzr9oLo5a4SDWIGDuMlIQyVu1f6Nr5MpvKj95LjD6qyRWV+6OR9uNfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "@ledgerhq/types-live": "^6.111.0",
+        "axios": "1.13.5",
+        "eip55": "^2.1.1",
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.36.0.tgz",
+      "integrity": "sha512-o2Q5hNvf2TzAzlH8ORAozppRbzixRPYDfmSQrP7FOcM997OEH7qDleXgp/uMpvRdxR/t3CJCG+n0i+bU/oYMKA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/evm-tools": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/evm-tools/-/evm-tools-1.12.9.tgz",
+      "integrity": "sha512-JQ/xgkgGdB4BrSRa54TPJdM7Lth+xejs9rmidp8fwg3eDgenJHWgtstaVIy8akYqyP3PNLBLOkrtv57ozVjY0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ledgerhq/live-env": "^2.38.0",
+        "axios": "1.13.5",
+        "crypto-js": "4.2.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-eth": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-7.8.6.tgz",
+      "integrity": "sha512-u4s3mix2zqOilJQNTCxIFI8TSZ8EEwNSSTptXAOUuizUyFQsE0SaK5R6SnXUiA+Vhml4F3OxNajwx1pLczJMAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ledgerhq/domain-service": "^1.8.6",
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/evm-tools": "^1.12.9",
+        "@ledgerhq/hw-transport": "6.35.4",
+        "@ledgerhq/hw-transport-mocker": "^6.34.4",
+        "@ledgerhq/logs": "^6.17.0",
+        "@ledgerhq/types-live": "^6.111.0",
+        "axios": "1.13.5",
+        "bignumber.js": "^9.1.2",
+        "semver": "7.7.3"
+      }
+    },
+    "node_modules/@ledgerhq/hw-app-eth/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.35.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.4.tgz",
+      "integrity": "sha512-FMVxiniQp0pgSIEBX9CjXYBuIAH9BTm3OcrN+/2LqkB8QBeFZdiwmO4BeN9nc2aWspe9z6kxN3SuUyouedNokA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.15.1",
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/logs": "^6.17.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-mocker": {
+      "version": "6.34.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-6.34.4.tgz",
+      "integrity": "sha512-EmAXKfwhH30LGOIqvbsOtjOb4AAj1Q0XwEowXQkFhGLWUokhmlWnZSRgYhdiIoo9nDZ5it+7fG7SPUAI2RZsCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "6.35.4",
+        "@ledgerhq/logs": "^6.17.0",
+        "rxjs": "7.8.2"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-node-hid": {
+      "version": "6.33.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-6.33.4.tgz",
+      "integrity": "sha512-/k0rH+wTpTmUifdxWuOER/dM3vPxW7RQIF0tByGC6noszVC3SGOZVcskBqJZ6xwIs1TvAHvZlEFvZWbnUJMBiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.15.1",
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/hw-transport": "6.35.4",
+        "@ledgerhq/hw-transport-node-hid-noevents": "^6.35.4",
+        "@ledgerhq/logs": "^6.17.0",
+        "lodash": "^4.17.21",
+        "node-hid": "2.1.2",
+        "usb": "2.9.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
+      "version": "6.35.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-6.35.4.tgz",
+      "integrity": "sha512-187670Uuuek9ECcT92NQm1PnDfFHT6gBmaJinatnueMLV9lk3q4IrpFZqTotr+LhPNub+YdGQFjYJImcXvYWtw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.15.1",
+        "@ledgerhq/errors": "^6.36.0",
+        "@ledgerhq/hw-transport": "6.35.4",
+        "@ledgerhq/logs": "^6.17.0",
+        "node-hid": "2.1.2"
+      }
+    },
+    "node_modules/@ledgerhq/live-env": {
+      "version": "2.38.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.38.0.tgz",
+      "integrity": "sha512-8HrkOtXDmEc8YIkpjyulbEKoNO/u/XY7eSkibIPUJplIP6lD6RkX/IQfhTG9A+5QWezaYVSss7/6SrOHkgc94g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rxjs": "7.8.2",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/types-live": {
+      "version": "6.111.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.111.0.tgz",
+      "integrity": "sha512-VpEQ75r3TdGDMN9r0ZdyNjDYyWwMyy+CB1u/yD+i75QkV2K9VQfGfAKIbBMRmhuJW1USPX2DOs9vm7L850kIfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/client-ids": "0.10.2",
+        "bignumber.js": "^9.1.2",
+        "rxjs": "7.8.2"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1552,6 +1768,44 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -1773,6 +2027,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2015,6 +2303,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@streamparser/json": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.22.tgz",
@@ -2110,6 +2405,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -2333,6 +2635,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2365,6 +2686,63 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -2458,18 +2836,18 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "node-gyp-build": "^4.3.0"
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">=6.14.2"
+        "node": ">= 0.4"
       }
     },
     "node_modules/camelcase": {
@@ -2531,6 +2909,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2623,6 +3008,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2653,6 +3051,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2685,6 +3090,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/delay": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
@@ -2695,6 +3126,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -2728,12 +3169,37 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eip55": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eip55/-/eip55-2.1.1.tgz",
+      "integrity": "sha512-WcagVAmNu2Ww2cDUfzuWVntYwFxbvZ5MvIyLZpMjTTkjD6sCvkGOiS86jTppzu9/gWsc8isLHAeMBWK02OnZmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "keccak": "^3.0.3"
+      }
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
@@ -2765,6 +3231,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -2787,12 +3263,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -2997,6 +3522,26 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3048,6 +3593,13 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3075,6 +3627,27 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3099,6 +3672,30 @@
       "dev": true,
       "license": "(Apache-2.0 OR MIT)"
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3113,6 +3710,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3122,6 +3729,52 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -3143,6 +3796,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hardhat": {
@@ -3205,6 +3871,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -3214,6 +3909,19 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -3282,6 +3990,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
@@ -3558,6 +4273,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/kleur": {
@@ -3847,6 +4578,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
@@ -3934,6 +4672,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/micro-eth-signer": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/micro-eth-signer/-/micro-eth-signer-0.14.0.tgz",
@@ -3993,6 +4741,42 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -4042,6 +4826,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.7.6",
@@ -4105,6 +4896,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ndjson": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
@@ -4124,6 +4922,26 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -4149,13 +4967,39 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
       }
+    },
+    "node_modules/node-hid": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.1.2.tgz",
+      "integrity": "sha512-qhCyQqrPpP93F/6Wc/xUR7L8mAJW0Z6R7HMQV8jCHHksAxNDe/4z4Un/H9CpLOT+5K39OPyt9tIQlavxWES3lg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "(MIT OR X11)",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^3.0.2",
+        "prebuild-install": "^7.1.1"
+      },
+      "bin": {
+        "hid-showdevices": "src/show-devices.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-hid/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4167,6 +5011,16 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/ox": {
       "version": "0.14.29",
@@ -4438,6 +5292,34 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4468,6 +5350,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4476,6 +5376,55 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -4514,6 +5463,23 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4523,6 +5489,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
@@ -4618,6 +5591,16 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4636,6 +5619,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4701,6 +5691,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/sisteransi": {
@@ -4903,6 +5940,36 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
@@ -5004,6 +6071,19 @@
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -5032,19 +6112,28 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
-    "node_modules/utf-8-validate": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
-      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+    "node_modules/usb": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.9.0.tgz",
+      "integrity": "sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "node-gyp-build": "^4.3.0"
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^6.0.0",
+        "node-gyp-build": "^4.5.0"
       },
       "engines": {
-        "node": ">=6.14.2"
+        "node": ">=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0"
       }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -5052,6 +6141,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -5523,6 +6622,13 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.17.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "type": "module",
   "devDependencies": {
+    "@ledgerhq/hw-app-eth": "^7.8.6",
+    "@ledgerhq/hw-transport-node-hid": "^6.33.4",
     "@nomicfoundation/hardhat-ignition": "^3.1.7",
     "@nomicfoundation/hardhat-ignition-viem": "^3.1.6",
     "@nomicfoundation/hardhat-toolbox-viem": "^5.0.7",

--- a/scripts/deploy-ledger.ts
+++ b/scripts/deploy-ledger.ts
@@ -1,0 +1,31 @@
+// Cold-Ledger deploy entrypoint for the rome-solidity stack.
+//
+//   npx hardhat compile
+//   DEPLOY_VIA_LEDGER=1 ROME_RPC_URL=https://<chain>.romeprotocol.xyz/ ROME_CHAIN_ID=<id> \
+//     npx tsx scripts/deploy-ledger.ts
+//
+// Signs every deploy with a connected Ledger (Ethereum app, Blind signing ON).
+// Currently deploys ERC20SPLFactory (the foundational Phase-6 contract); the
+// remaining stack contracts are added here as `deployer.deploy(<name>, [args])`
+// calls in the same order as scripts/deploy-solidity.sh Phase 6.
+
+import { getDeployer } from "./lib/deployer.js";
+
+const RPC = process.env.ROME_RPC_URL ?? "https://trajan.devnet.romeprotocol.xyz/";
+const CHAIN_ID = Number(process.env.ROME_CHAIN_ID ?? "121302");
+const CPI = (process.env.CPI_CONTRACT_ADDRESS ?? "0xFF00000000000000000000000000000000000008") as `0x${string}`;
+
+async function main() {
+    const deployer = await getDeployer(CHAIN_ID, RPC);
+    console.log(`Deployer: ${deployer.address}`);
+    console.log(`Balance (wei): ${(await deployer.getBalance()).toString()}`);
+
+    console.log("Deploying ERC20SPLFactory — APPROVE ON THE DEVICE...");
+    const factory = await deployer.deploy("ERC20SPLFactory", [CPI]);
+    console.log("✓ ERC20SPLFactory:", factory.address);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/lib/deployer.ts
+++ b/scripts/lib/deployer.ts
@@ -1,0 +1,83 @@
+// Unified deployer for Rome contract deploys — cold Ledger or hot key.
+//
+//   DEPLOY_VIA_LEDGER=1            → sign with a connected Ledger (mainnet path)
+//   DEPLOY_PRIVATE_KEY=0x...       → sign with a hot key (devnet/testnet / CI)
+//
+// Reads compiled artifacts straight from artifacts/ (run `npx hardhat compile`
+// first), so it is runner-agnostic. The Ledger path MUST run under tsx
+// (`npx tsx scripts/<x>.ts`), never `hardhat run` — Hardhat's CJS script runner
+// hits an ESM require-cycle in @ledgerhq. The hot path runs under either.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createPublicClient, createWalletClient, http, type Address, type Hex } from "viem";
+import { DEFAULT_LEDGER_PATH, makeLedgerDeployer, romeChain } from "./ledger.js";
+
+export interface Deployer {
+    address: Address;
+    getBalance: () => Promise<bigint>;
+    deploy: (contractName: string, args?: readonly unknown[]) => Promise<{ address: Address }>;
+}
+
+/** Recursively locate a compiled contract artifact (abi + deployable bytecode) by name. */
+function findArtifact(name: string, root = "artifacts/contracts"): { abi: readonly unknown[]; bytecode: Hex } {
+    const stack = [root];
+    while (stack.length > 0) {
+        const dir = stack.pop()!;
+        let entries: string[];
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const p = join(dir, entry);
+            if (statSync(p).isDirectory()) {
+                stack.push(p);
+            } else if (entry === `${name}.json` && !p.includes(".dbg.")) {
+                const artifact = JSON.parse(readFileSync(p, "utf8"));
+                if (artifact.bytecode && artifact.bytecode !== "0x") {
+                    return { abi: artifact.abi, bytecode: artifact.bytecode as Hex };
+                }
+            }
+        }
+    }
+    throw new Error(`No deployable artifact for ${name} under ${root} — run \`npx hardhat compile\` first`);
+}
+
+export async function getDeployer(chainId: number, rpcUrl: string): Promise<Deployer> {
+    if (process.env.DEPLOY_VIA_LEDGER === "1") {
+        const ledger = await makeLedgerDeployer(chainId, rpcUrl, process.env.LEDGER_PATH ?? DEFAULT_LEDGER_PATH);
+        return {
+            address: ledger.address,
+            getBalance: ledger.getBalance,
+            async deploy(name, args = []) {
+                const { abi, bytecode } = findArtifact(name);
+                return ledger.deploy(abi, bytecode, args);
+            },
+        };
+    }
+
+    const pk = process.env.DEPLOY_PRIVATE_KEY;
+    if (!pk) {
+        throw new Error("Set DEPLOY_VIA_LEDGER=1 (cold Ledger) or DEPLOY_PRIVATE_KEY=0x... (hot key)");
+    }
+    const { privateKeyToAccount } = await import("viem/accounts");
+    const account = privateKeyToAccount((pk.startsWith("0x") ? pk : `0x${pk}`) as Hex);
+    const chain = romeChain(chainId, rpcUrl);
+    const wallet = createWalletClient({ account, chain, transport: http(rpcUrl) });
+    const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+    return {
+        address: account.address,
+        getBalance: () => publicClient.getBalance({ address: account.address }),
+        async deploy(name, args = []) {
+            const { abi, bytecode } = findArtifact(name);
+            const hash = await wallet.deployContract({ abi, bytecode, args } as never);
+            const receipt = await publicClient.waitForTransactionReceipt({ hash });
+            if (receipt.status !== "success" || !receipt.contractAddress) {
+                throw new Error(`Deploy failed: ${name} (status=${receipt.status}, tx=${hash})`);
+            }
+            return { address: receipt.contractAddress as Address };
+        },
+    };
+}

--- a/scripts/lib/ledger.ts
+++ b/scripts/lib/ledger.ts
@@ -1,0 +1,108 @@
+// Cold-Ledger signer for Rome mainnet deploys (Hardhat 3 + viem).
+//
+// Builds a viem LocalAccount backed by a hardware Ledger (Ethereum app),
+// so the existing viem deploy scripts can sign with the device instead of a
+// hot configVariable key. The deployer is the contract admin on mainnet, so
+// it must be hardware-secured.
+//
+// Pre-flight: the Ledger Ethereum app MUST have Blind signing ENABLED — an
+// unknown chain id otherwise returns APDU 6a80 INVALID_DATA on every deploy.
+//
+// Verified mechanism: `cast send --ledger` deployed a contract on trajan
+// (chain 121302) end-to-end (2026-06-16); this is the programmatic equivalent.
+
+import { toAccount } from "viem/accounts";
+import {
+    createWalletClient,
+    createPublicClient,
+    http,
+    serializeTransaction,
+    type Address,
+    type Chain,
+    type Hex,
+    type LocalAccount,
+} from "viem";
+
+// @ledgerhq packages are ESM-only and trip a require-cycle under Hardhat's CJS
+// script runner if imported statically — load them lazily at call time, and
+// unwrap the CJS/ESM `.default` interop shim.
+async function loadLedger() {
+    const EthMod = await import("@ledgerhq/hw-app-eth");
+    const TransportMod = await import("@ledgerhq/hw-transport-node-hid");
+    const Eth = ((EthMod as { default?: unknown }).default ?? EthMod) as typeof import("@ledgerhq/hw-app-eth").default;
+    const Transport = ((TransportMod as { default?: unknown }).default ?? TransportMod) as { create: () => Promise<unknown> };
+    return { Eth, Transport };
+}
+
+export const DEFAULT_LEDGER_PATH = "44'/60'/0'/0/0";
+
+/** Build a viem LocalAccount that signs via a connected Ledger (Ethereum app). */
+export async function makeLedgerAccount(path: string = DEFAULT_LEDGER_PATH): Promise<LocalAccount> {
+    const { Eth, Transport } = await loadLedger();
+    const transport = await Transport.create();
+    const eth = new Eth(transport as never);
+    const { address } = await eth.getAddress(path);
+
+    return toAccount({
+        address: address as Address,
+        async signTransaction(transaction, options) {
+            const serializer = options?.serializer ?? serializeTransaction;
+            const unsigned = await serializer(transaction as never);
+            // hw-app-eth wants the serialized tx hex WITHOUT the 0x prefix.
+            const { r, s, v } = await eth.signTransaction(path, unsigned.slice(2), null);
+            // EIP-1559 (type-2): v is the y-parity (0/1).
+            return await serializer(transaction as never, {
+                r: `0x${r}` as Hex,
+                s: `0x${s}` as Hex,
+                yParity: parseInt(v, 16) & 1,
+            });
+        },
+        async signMessage() {
+            throw new Error("Ledger signMessage not implemented — deploy flow does not need it");
+        },
+        async signTypedData() {
+            throw new Error("Ledger signTypedData not implemented — deploy flow does not need it");
+        },
+    });
+}
+
+/** Minimal viem Chain for a Rome chain (id + RPC URL is all viem needs to send). */
+export function romeChain(id: number, rpcUrl: string): Chain {
+    return {
+        id,
+        name: `rome-${id}`,
+        nativeCurrency: { name: "Rome Gas", symbol: "GAS", decimals: 18 },
+        rpcUrls: { default: { http: [rpcUrl] } },
+    };
+}
+
+export interface LedgerDeployer {
+    address: Address;
+    getBalance: () => Promise<bigint>;
+    deploy: (abi: readonly unknown[], bytecode: Hex, args?: readonly unknown[]) => Promise<{ address: Address }>;
+}
+
+/** A Ledger-backed deployer bound to one Rome chain (id + RPC URL). */
+export async function makeLedgerDeployer(
+    chainId: number,
+    rpcUrl: string,
+    path: string = DEFAULT_LEDGER_PATH,
+): Promise<LedgerDeployer> {
+    const account = await makeLedgerAccount(path);
+    const chain = romeChain(chainId, rpcUrl);
+    const wallet = createWalletClient({ account, chain, transport: http(rpcUrl) });
+    const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+
+    return {
+        address: account.address,
+        getBalance: () => publicClient.getBalance({ address: account.address }),
+        async deploy(abi, bytecode, args = []) {
+            const hash = await wallet.deployContract({ abi, bytecode, args } as never);
+            const receipt = await publicClient.waitForTransactionReceipt({ hash });
+            if (receipt.status !== "success" || !receipt.contractAddress) {
+                throw new Error(`Deploy failed (status=${receipt.status}, tx=${hash})`);
+            }
+            return { address: receipt.contractAddress as Address };
+        },
+    };
+}

--- a/scripts/test-ledger-adapter.ts
+++ b/scripts/test-ledger-adapter.ts
@@ -1,0 +1,29 @@
+// Standalone validation of the viem Ledger adapter (scripts/lib/ledger.ts).
+// Deploys a minimal contract (runtime 0x00) to a Rome chain, signed by the
+// connected Ledger. Proves transport + getAddress + signTransaction + broadcast
+// independent of the full deploy-script machinery.
+//
+//   ROME_RPC_URL=... ROME_CHAIN_ID=... LEDGER_PATH=... npx hardhat run scripts/test-ledger-adapter.ts
+//
+// Defaults target trajan (devnet, chain 121302). Ethereum app open + Blind signing ON.
+
+import { makeLedgerDeployer, DEFAULT_LEDGER_PATH } from "./lib/ledger.js";
+
+const RPC = process.env.ROME_RPC_URL ?? "https://trajan.devnet.romeprotocol.xyz/";
+const CHAIN_ID = Number(process.env.ROME_CHAIN_ID ?? "121302");
+const LEDGER_PATH = process.env.LEDGER_PATH ?? DEFAULT_LEDGER_PATH;
+
+async function main() {
+    console.log(`Connecting Ledger (path ${LEDGER_PATH})...`);
+    const deployer = await makeLedgerDeployer(CHAIN_ID, RPC, LEDGER_PATH);
+    console.log("Ledger address:", deployer.address);
+    console.log("Gas balance (wei):", (await deployer.getBalance()).toString());
+    console.log("Deploying minimal contract (runtime 0x00) — APPROVE ON THE DEVICE...");
+    const { address } = await deployer.deploy([], "0x600060005360016000f3");
+    console.log("✓ Deployed at:", address);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Cold-ledger deploy — validated foundation

Sign Rome contract deploys with a hardware **cold Ledger** instead of a hot key (the deployer is the contract admin on mainnet).

- `scripts/lib/ledger.ts` — viem LocalAccount backed by the Ledger (Ethereum app)
- `scripts/lib/deployer.ts` — `getDeployer` (Ledger via `DEPLOY_VIA_LEDGER=1`, or hot key via `DEPLOY_PRIVATE_KEY`; reads artifacts from FS)
- `scripts/deploy-ledger.ts` — entrypoint (deploys ERC20SPLFactory; extend to full Phase 6)
- `scripts/test-ledger-adapter.ts` — standalone adapter smoke test

**Validated on devnet (trajan, chain 121302):** ERC20SPLFactory deployed via the Ledger -> `0x7659efa8898928b042ff6bbde2adb45c3a0c27cd` (plus a minimal-contract adapter test).

Run: `npx hardhat compile && DEPLOY_VIA_LEDGER=1 ROME_RPC_URL=<rpc> ROME_CHAIN_ID=<id> npx tsx scripts/deploy-ledger.ts`. Ledger path runs under **tsx** (Hardhat CJS runner hits an ESM require-cycle in @ledgerhq). Pre-flight: enable **Blind signing** on the Ledger Ethereum app.

Next (tracked): extend `deploy-ledger.ts` to the full Phase-6 stack + config calls + library linking; ethers equivalent in rome-uniswap-v2 #72; rome-ops deploy-solidity.sh integration.