### PR TITLE
feat(deploy): cold-ledger admin handover (hot-deploy + transfer to Ledger)

### DIFF
--- a/COLD_LEDGER_MAINNET_DEPLOY.md
+++ b/COLD_LEDGER_MAINNET_DEPLOY.md
@@ -3,7 +3,32 @@
 Scaffold for moving mainnet (`rubicon`, chain **7531**) Solidity deploys off the hot-key to a cold Ledger.
 Branch: `mainnet-cold-ledger-deploy-solidity`. **IMPLEMENTED + devnet-validated (2026-06-16):** viem Ledger adapter `scripts/lib/ledger.ts` + unified `getDeployer` `scripts/lib/deployer.ts` (Ledger or hot key, reads artifacts from FS) + entrypoint `scripts/deploy-ledger.ts`. ERC20SPLFactory was deployed via the Ledger on trajan (chain 121302) at `0x7659efa8898928b042ff6bbde2adb45c3a0c27cd`.
 
-**Run:** `npx hardhat compile && DEPLOY_VIA_LEDGER=1 ROME_RPC_URL=<rpc> ROME_CHAIN_ID=<id> npx tsx scripts/deploy-ledger.ts`. The Ledger path MUST run under **`tsx`**, not `hardhat run` (Hardhat's CJS script runner hits an ESM require-cycle in `@ledgerhq`). `scripts/deploy-ledger.ts` currently deploys ERC20SPLFactory; remaining Phase-6 contracts extend it with the same `deployer.deploy(<name>, [args])` pattern (library-linked contracts need link handling added to `getDeployer`).
+**Run:** `npx hardhat compile && DEPLOY_VIA_LEDGER=1 ROME_RPC_URL=<rpc> ROME_CHAIN_ID=<id> npx tsx scripts/deploy-ledger.ts`. The Ledger path MUST run under **`tsx`**, not `hardhat run` (Hardhat's CJS script runner hits an ESM require-cycle in `@ledgerhq`). `scripts/deploy-ledger.ts` is the **Ledger-as-deployer** path (the Ledger signs each `CREATE`). For the full stack, prefer the **hot-deploy + handover** flow below — far fewer device taps.
+
+## Recommended flow: hot-deploy + cold-Ledger admin handover (validated 2026-06-16)
+
+The Phase-6 stack has **only two transferable admin roles**; every other contract is permissionless or fully immutable (no owner to secure):
+
+| Contract | Role | Transfer (single-step) |
+|---|---|---|
+| `OracleAdapterFactory` | `owner` (ctor `msg.sender`) | `transferOwnership(address)` |
+| `UniswapV2Factory` (Romeswap) | `feeToSetter` (ctor param) | `setFeeToSetter(address)` |
+| *all others (ERC20SPLFactory, SPL_ERC20 wrappers, RomeBridgeWithdraw/Paymaster, SimpleActivator, MeteoraDAMMv1Factory, Router, WETH9, Multicall, ERC20Factory)* | **none** | — |
+
+So the cold-ledger mainnet deploy is:
+1. **Hot-deploy** the whole stack with a throwaway hot key (the existing `deploy-solidity.sh` / `scripts/*` flow) — fast, **tap-free**. Fund the hot key via `rome-apps cli deposit` (SOL→Rome gas).
+2. **Verify** the deployed bytecode matches the audited contracts.
+3. **Hand the two roles to the cold Ledger** with `scripts/transfer-admin-to-ledger.ts` — signed by the current (hot) owner, single-step → **also tap-free**; the Ledger only signs when it *later* exercises a role:
+   ```
+   DEPLOY_PRIVATE_KEY=0x<hot> LEDGER_ADDRESS=0x<cold> \
+   ORACLE_FACTORY=0x... ROMESWAP_FACTORY=0x... \
+   ROME_RPC_URL=<rpc> ROME_CHAIN_ID=<id> npx tsx scripts/transfer-admin-to-ledger.ts
+   ```
+4. **Discard the hot key.** The Ledger now controls the only two admin-bearing contracts; the rest have no admin at all.
+
+**Validated on devnet (trajan 121302):** hot deployer `0x8ec2…` deployed `OracleAdapterFactory` → `transferOwnership` → `owner() == Ledger 0x3D60…` (tap-free, `scripts/test-handover.ts`). Romeswap `feeToSetter` uses the identical single-step path. The risk window (hot key is the momentary owner) is closed by verify-then-handover before any value flows — the standard deploy-to-cold-wallet pattern.
+
+Because the bulk deploy is hot and the handover is two viem calls, **rome-uniswap-v2 needs no separate ethers Ledger adapter** — Romeswap deploys hot and its `feeToSetter` is handed over by this same script.
 
 ## Current mechanism (verified)
 - Stack: Hardhat 3 (`hardhat ^3.9.0`) + viem (`@nomicfoundation/hardhat-toolbox-viem ^5.0.7`) — `hardhat.config.ts:1,5`.

--- a/scripts/test-handover.ts
+++ b/scripts/test-handover.ts
@@ -1,0 +1,41 @@
+// Validates the hot-deploy + cold-Ledger admin-handover pattern end-to-end:
+//   1. deploy OracleAdapterFactory with a hot key (owner = hot key)
+//   2. transferOwnership(LEDGER) signed by the hot key (tap-free)
+//   3. assert owner() == LEDGER
+//
+//   DEPLOY_PRIVATE_KEY=0x<hot> LEDGER_ADDRESS=0x<ledger> npx tsx scripts/test-handover.ts
+//
+// Constructor placeholders are fine — only `defaultMaxStaleness` is validated;
+// impl addresses are merely stored (we exercise ownership, not feed creation).
+
+import { createPublicClient, createWalletClient, getAddress, http, type Address, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { getDeployer } from "./lib/deployer.js";
+import { handOverOwner } from "./transfer-admin-to-ledger.js";
+import { romeChain } from "./lib/ledger.js";
+
+const RPC = process.env.ROME_RPC_URL ?? "https://trajan.devnet.romeprotocol.xyz/";
+const CHAIN_ID = Number(process.env.ROME_CHAIN_ID ?? "121302");
+const LEDGER = getAddress(process.env.LEDGER_ADDRESS ?? "0x3D60F9B3E11CBe57516351F18FD9D6c3Fd4B8F96");
+const PH: Address = "0x0000000000000000000000000000000000000001";
+const Z32 = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+async function main() {
+    const deployer = await getDeployer(CHAIN_ID, RPC); // hot key (DEPLOY_PRIVATE_KEY)
+    console.log("Hot deployer:", deployer.address);
+
+    const factory = await deployer.deploy("OracleAdapterFactory", [PH, PH, Z32, Z32, 3600n, PH, PH]);
+    console.log("OracleAdapterFactory (hot-owned):", factory.address);
+
+    const pk = process.env.DEPLOY_PRIVATE_KEY as string;
+    const account = privateKeyToAccount((pk.startsWith("0x") ? pk : `0x${pk}`) as Hex);
+    const chain = romeChain(CHAIN_ID, RPC);
+    const wallet = createWalletClient({ account, chain, transport: http(RPC) });
+    const pub = createPublicClient({ chain, transport: http(RPC) });
+
+    console.log(`Handing owner -> cold Ledger ${LEDGER} (signed by hot key, tap-free)...`);
+    await handOverOwner(wallet, pub, factory.address, LEDGER);
+    console.log("✓ hot-deploy + cold-Ledger admin handover validated (owner == Ledger).");
+}
+
+main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/transfer-admin-to-ledger.ts
+++ b/scripts/transfer-admin-to-ledger.ts
@@ -1,0 +1,81 @@
+// Cold-Ledger admin handover for the Rome Phase-6 stack.
+//
+// Most Phase-6 contracts have NO transferable admin (factories/wrappers/bridge-
+// withdraw/activator/router/WETH are permissionless or fully immutable). Only
+// two carry a transferable privileged role, both single-step:
+//   - OracleAdapterFactory.owner          via transferOwnership(address)
+//   - UniswapV2Factory.feeToSetter (Romeswap) via setFeeToSetter(address)
+//
+// So the cold-ledger flow is: hot-deploy the stack (fast, tap-free), then run
+// this to hand those two roles to the cold Ledger address. The transfers are
+// signed by the CURRENT owner (the hot deployer) — the Ledger only receives, so
+// the handover itself is tap-free; the Ledger taps only when it later exercises
+// a role. Idempotent (skips a role already held by the target).
+//
+//   DEPLOY_PRIVATE_KEY=0x<hot owner>  LEDGER_ADDRESS=0x<cold ledger> \
+//   ORACLE_FACTORY=0x... [ROMESWAP_FACTORY=0x...] \
+//   ROME_RPC_URL=... ROME_CHAIN_ID=... npx tsx scripts/transfer-admin-to-ledger.ts
+
+import { createPublicClient, createWalletClient, getAddress, http, type Address, type Hex, type PublicClient, type WalletClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { romeChain } from "./lib/ledger.js";
+
+const OWNABLE_ABI = [
+    { type: "function", name: "owner", stateMutability: "view", inputs: [], outputs: [{ type: "address" }] },
+    { type: "function", name: "transferOwnership", stateMutability: "nonpayable", inputs: [{ type: "address", name: "newOwner" }], outputs: [] },
+] as const;
+
+const FEESETTER_ABI = [
+    { type: "function", name: "feeToSetter", stateMutability: "view", inputs: [], outputs: [{ type: "address" }] },
+    { type: "function", name: "setFeeToSetter", stateMutability: "nonpayable", inputs: [{ type: "address", name: "_feeToSetter" }], outputs: [] },
+] as const;
+
+/** Transfer an Ownable-style `owner` (OracleAdapterFactory) to `target`, signed by the current owner. */
+export async function handOverOwner(wallet: WalletClient, pub: PublicClient, contract: Address, target: Address): Promise<void> {
+    const current = getAddress((await pub.readContract({ address: contract, abi: OWNABLE_ABI, functionName: "owner" })) as Address);
+    if (current === target) { console.log(`  owner already ${target} — skip`); return; }
+    const hash = await wallet.writeContract({ address: contract, abi: OWNABLE_ABI, functionName: "transferOwnership", args: [target], account: wallet.account!, chain: wallet.chain });
+    await pub.waitForTransactionReceipt({ hash });
+    const after = getAddress((await pub.readContract({ address: contract, abi: OWNABLE_ABI, functionName: "owner" })) as Address);
+    if (after !== target) throw new Error(`transferOwnership failed: owner=${after}, expected ${target}`);
+    console.log(`  ✓ owner -> ${after}`);
+}
+
+/** Transfer a UniswapV2Factory `feeToSetter` (Romeswap) to `target`, signed by the current feeToSetter. */
+export async function handOverFeeToSetter(wallet: WalletClient, pub: PublicClient, contract: Address, target: Address): Promise<void> {
+    const current = getAddress((await pub.readContract({ address: contract, abi: FEESETTER_ABI, functionName: "feeToSetter" })) as Address);
+    if (current === target) { console.log(`  feeToSetter already ${target} — skip`); return; }
+    const hash = await wallet.writeContract({ address: contract, abi: FEESETTER_ABI, functionName: "setFeeToSetter", args: [target], account: wallet.account!, chain: wallet.chain });
+    await pub.waitForTransactionReceipt({ hash });
+    const after = getAddress((await pub.readContract({ address: contract, abi: FEESETTER_ABI, functionName: "feeToSetter" })) as Address);
+    if (after !== target) throw new Error(`setFeeToSetter failed: feeToSetter=${after}, expected ${target}`);
+    console.log(`  ✓ feeToSetter -> ${after}`);
+}
+
+async function main() {
+    const RPC = process.env.ROME_RPC_URL ?? "https://trajan.devnet.romeprotocol.xyz/";
+    const CHAIN_ID = Number(process.env.ROME_CHAIN_ID ?? "121302");
+    const TARGET = getAddress(process.env.LEDGER_ADDRESS as string);
+    const pk = process.env.DEPLOY_PRIVATE_KEY;
+    if (!pk) throw new Error("DEPLOY_PRIVATE_KEY (the current owner) is required to sign the handover");
+
+    const account = privateKeyToAccount((pk.startsWith("0x") ? pk : `0x${pk}`) as Hex);
+    const chain = romeChain(CHAIN_ID, RPC);
+    const wallet = createWalletClient({ account, chain, transport: http(RPC) });
+    const pub = createPublicClient({ chain, transport: http(RPC) });
+    console.log(`Signer (current owner): ${account.address}\nTarget (cold Ledger):  ${TARGET}`);
+
+    if (process.env.ORACLE_FACTORY) {
+        console.log("OracleAdapterFactory:");
+        await handOverOwner(wallet, pub, getAddress(process.env.ORACLE_FACTORY), TARGET);
+    }
+    if (process.env.ROMESWAP_FACTORY) {
+        console.log("UniswapV2Factory (Romeswap):");
+        await handOverFeeToSetter(wallet, pub, getAddress(process.env.ROMESWAP_FACTORY), TARGET);
+    }
+    console.log("Admin handover complete.");
+}
+
+if (process.argv[1]?.endsWith("transfer-admin-to-ledger.ts")) {
+    main().catch((error) => { console.error(error); process.exitCode = 1; });
+}


### PR DESCRIPTION
## Cold-ledger admin handover — completes the cold-ledger mainnet deploy

Phase-6 has **only two transferable admin roles** (`OracleAdapterFactory.owner`, `UniswapV2Factory.feeToSetter`); every other contract is permissionless or fully immutable. So the cold-ledger deploy is:

1. **Hot-deploy** the stack with a throwaway hot key (existing scripts) — tap-free.
2. **Hand the two roles to the cold Ledger** via `scripts/transfer-admin-to-ledger.ts` — single-step, signed by the hot owner -> also tap-free. The Ledger only signs when it later exercises a role.

**Validated on devnet (trajan 121302):** hot-deployed OracleAdapterFactory -> `transferOwnership` -> `owner() == Ledger` (`scripts/test-handover.ts`).

Builds on #241 (reuses `lib/ledger.ts` + `lib/deployer.ts`). rome-uniswap-v2 needs no ethers Ledger adapter — Romeswap deploys hot + its `feeToSetter` is handed over by this same script.