### PR TITLE
chore(deploy): redeploy RomeBridgeWithdraw on Hadrian with SPL egress

### DIFF
--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -87,8 +87,8 @@
     "deployedAt": 1779081498
   },
   "RomeBridgeWithdraw": {
-    "address": "0x5dbe5e8b3697516637cc967b428b0d903c93bb43",
-    "deployedAt": 1779081505
+    "address": "0x99a8b0bda3ef1d829f28405eb9c69986333a50d6",
+    "deployedAt": 1782396258
   },
   "SimpleActivator": {
     "address": "0xc478604d116222190750fe9a52dd3d6ae9140212",


### PR DESCRIPTION
## What

The Hadrian `RomeBridgeWithdraw` at `0x5dbe5e8b…` (deployed **2026-05-18**) predated the Solana SPL-egress feature added in **#227** (merged **2026-06-01**). rome-ui **#559** then repointed `useOutboundSplBridge` from the wrapper's own method to `chain.contracts.bridgeWithdraw`, calling `bridgeOutToSolana(bytes32,uint256,bytes32)` / `ensureRecipientAta(bytes32,bytes32)`. Those selectors are **absent** from the deployed bytecode → every Rome→Solana bridge-out hit the fallback and reverted with empty `0x`. (Not a chain bug; not a track issue — purely a stale deploy.)

Redeployed from `ff84074` (egress methods at `RomeBridgeWithdraw.sol:471` / `:508`). This PR commits the deploy artifact.

## New address

`RomeBridgeWithdraw` → **`0x99a8b0bda3ef1d829f28405eb9c69986333a50d6`**

- CCTP / Wormhole wiring + mints reproduced **identically** — verified against the live contract's own immutables (CCTP `CCTPiPYP…`/`CCTPmbSD…`, Wormhole `wormDTUJ…`/`worm2ZoG…`, `targetChain=2`, mints `4zMM…`/`6F5Y…`).
- `usdcWrapper`/`wethWrapper` immutables reuse the existing wrappers — egress is mint-agnostic (mint is a call param; operates on `AUTHORITY_PDA`'s ATA), so they affect only the co-located `burnUSDC`/`burnETH` `balanceOf` reads.

## Verification (read-only, Hadrian)

| | OLD `0x5dbe5e8b` | NEW `0x99a8b0bd…` |
|---|---|---|
| bytecode | 9633 B | 10793 B |
| egress selectors `0x8efe5df8`/`0xeeaed29d` | ABSENT | **PRESENT** |
| `ensureRecipientAta` eth_call | empty-`0x` revert | **Ok `0x`** |
| `bridgeOutToSolana` eth_call | empty-`0x` revert | dispatches → inner `transfer_spl` reached (expected "create dest ATA first") |

## Follow-ups (separate)

- **registry** `chains/200010-hadrian/contracts.json` — point `RomeBridgeWithdraw` at the new address (companion PR).
- **funded E2E** — `ensureRecipientAta` → `bridgeOutToSolana` round-trip from a funded sender to prove end-to-end.
- *(optional)* refresh `usdcWrapper`/`wethWrapper` to the #240 wrappers in a later deploy.
