### PR TITLE
feat(oracle): implement metadata() on cached adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — `metadata()` on `CachedPythAdapter` / `CachedFeedAdapter`
+
+[`contracts/oracle/CachedPythAdapter.sol`](contracts/oracle/CachedPythAdapter.sol) and [`contracts/oracle/CachedFeedAdapter.sol`](contracts/oracle/CachedFeedAdapter.sol) now implement `IAdapterMetadata`, reaching parity with the raw `PythPullAdapter` / `SwitchboardV3Adapter`. `CachedPythAdapter` reports `Pyth` + its `pythAccount`; `CachedFeedAdapter` delegates `sourceType` / `solanaAccount` to its underlying via try/catch (fallback `Pyth` / `0x0`).
+
+Without it, `BatchReader.getFeedHealth` — which calls `metadata()` first and marks a feed unhealthy (skipping the price read) when that reverts — reported every cached adapter as unavailable in batch health reads, even when `latestRoundData()` returned a fresh price. Tests: [`tests/oracle/AdapterMetadata.test.ts`](tests/oracle/AdapterMetadata.test.ts) adds cases for both.
+
 ### Changed — `SPL_ERC20_cached` ATA-existence gate collapses two precompile round-trips into one
 
 [`contracts/erc20spl/erc20spl_cached.sol`](contracts/erc20spl/erc20spl_cached.sol) — `balanceOf`, `allowance`, `approve`, and `_transfer` previously derived the target ATA with a legacy `HelperProgram.ata(x, mint_id)` call (`0xff..09`) then read it with `SplCached.account(ata)`. Both now collapse into a single `SplCached.account(x, mint_id)` (selector `0xf9827227`) — the precompile derives `ATA(external_auth(x), mint)` internally, dropping one EVM→precompile round-trip per gate. Behaviour is unchanged: same overlay-aware existence check, same auto-create on the catch branch.

--- a/contracts/oracle/CachedFeedAdapter.sol
+++ b/contracts/oracle/CachedFeedAdapter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "./IAggregatorV3Interface.sol";
 import "./IAdapterFactory.sol";
+import "./IAdapterMetadata.sol";
 
 /// @title CachedFeedAdapter
 /// @notice A source-agnostic caching decorator over ANY AggregatorV3 price feed
@@ -25,7 +26,7 @@ import "./IAdapterFactory.sol";
 ///
 ///         AggregatorV3 drop-in. Deployed as an EIP-1167 clone (the
 ///         implementation is constructor-locked).
-contract CachedFeedAdapter is IAggregatorV3Interface {
+contract CachedFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
     address public underlying;
     string private _description;
     uint256 public maxStaleness;
@@ -83,6 +84,25 @@ contract CachedFeedAdapter is IAggregatorV3Interface {
 
     function version() external pure override returns (uint256) {
         return 2;
+    }
+
+    /// @notice Single-struct description so the portal / BatchReader can read
+    ///         this cached adapter the same way it reads the raw adapters.
+    ///         Source identity (type + Solana account) belongs to the wrapped
+    ///         feed, so delegate it when the underlying exposes metadata().
+    function metadata() external view override returns (AdapterMetadata memory m) {
+        m.description = _description;
+        m.maxStaleness = maxStaleness;
+        m.createdAt = createdAt;
+        m.factory = factory;
+        m.paused = factory != address(0) && IAdapterFactory(factory).isPaused(address(this));
+        try IAdapterMetadata(underlying).metadata() returns (AdapterMetadata memory u) {
+            m.sourceType = u.sourceType;
+            m.solanaAccount = u.solanaAccount;
+        } catch {
+            m.sourceType = OracleSource.Pyth;
+            m.solanaAccount = bytes32(0);
+        }
     }
 
     /// @notice Keeper-driven snapshot: read the underlying feed and store the

--- a/contracts/oracle/CachedPythAdapter.sol
+++ b/contracts/oracle/CachedPythAdapter.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "./IAggregatorV3Interface.sol";
 import "./IAdapterFactory.sol";
+import "./IAdapterMetadata.sol";
 import "./PythPullParser.sol";
 import "../interface.sol";
 import {AccountReader} from "../cpi/AccountReader.sol";
@@ -27,7 +28,7 @@ import {AccountReader} from "../cpi/AccountReader.sol";
 ///
 ///         AggregatorV3 drop-in. Deployed as EIP-1167 clone (storage from the
 ///         clone's init path; the implementation is constructor-locked).
-contract CachedPythAdapter is IAggregatorV3Interface {
+contract CachedPythAdapter is IAggregatorV3Interface, IAdapterMetadata {
     bytes32 public pythAccount;
     string private _description;
     uint256 public maxStaleness;
@@ -85,6 +86,20 @@ contract CachedPythAdapter is IAggregatorV3Interface {
 
     function version() external pure override returns (uint256) {
         return 2;
+    }
+
+    /// @notice Single-struct description so the portal / BatchReader can read
+    ///         this cached adapter the same way it reads the raw adapters.
+    function metadata() external view override returns (AdapterMetadata memory) {
+        return AdapterMetadata({
+            description: _description,
+            sourceType: OracleSource.Pyth,
+            solanaAccount: pythAccount,
+            maxStaleness: maxStaleness,
+            createdAt: createdAt,
+            factory: factory,
+            paused: factory != address(0) && IAdapterFactory(factory).isPaused(address(this))
+        });
     }
 
     /// @notice Keeper-driven snapshot: read + parse the Solana Pyth account and

--- a/tests/oracle/AdapterMetadata.test.ts
+++ b/tests/oracle/AdapterMetadata.test.ts
@@ -10,6 +10,8 @@ describe("AdapterMetadata", function () {
     let cloneHelper: any;
     let pythImplAddr: `0x${string}`;
     let sbImplAddr: `0x${string}`;
+    let cachedPythImplAddr: `0x${string}`;
+    let cachedFeedImplAddr: `0x${string}`;
     let factoryAddress: `0x${string}`;
 
     before(async function () {
@@ -28,6 +30,8 @@ describe("AdapterMetadata", function () {
         // just reads a mapping and returns false for any unpaused adapter.
         const cachedImpl = await viem.deployContract("CachedPythAdapter", []);
         const cachedFeedImpl = await viem.deployContract("CachedFeedAdapter", []);
+        cachedPythImplAddr = cachedImpl.address;
+        cachedFeedImplAddr = cachedFeedImpl.address;
         const factory = await viem.deployContract("OracleAdapterFactory", [
             pythImplAddr,
             sbImplAddr,
@@ -103,6 +107,58 @@ describe("AdapterMetadata", function () {
             assert.equal((m.factory as string).toLowerCase(), factoryAddress.toLowerCase());
             assert.equal(m.paused, false);
             assert.ok(m.createdAt > 0n);
+        });
+    });
+
+    describe("CachedPythAdapter.metadata()", function () {
+        it("returns the values passed at initialize", async function () {
+            const adapter = await cloneOf(cachedPythImplAddr, "CachedPythAdapter");
+
+            const account = ("0x" + "a1".repeat(32)) as `0x${string}`;
+            const description = "SOL / USD";
+            const maxStaleness = 3600n;
+
+            await adapter.write.initialize([account, description, maxStaleness, factoryAddress]);
+
+            const m: any = await adapter.read.metadata();
+            assert.equal(m.description, description);
+            assert.equal(Number(m.sourceType), SRC_PYTH);
+            assert.equal((m.solanaAccount as string).toLowerCase(), account.toLowerCase());
+            assert.equal(m.maxStaleness, maxStaleness);
+            assert.equal((m.factory as string).toLowerCase(), factoryAddress.toLowerCase());
+            assert.equal(m.paused, false);
+            assert.ok(m.createdAt > 0n);
+        });
+    });
+
+    describe("CachedFeedAdapter.metadata()", function () {
+        it("returns its own config and delegates source identity to the underlying", async function () {
+            // Underlying: an initialized PythPullAdapter clone, so the cached
+            // feed can delegate sourceType/solanaAccount to it.
+            const underlying = await cloneOf(pythImplAddr, "PythPullAdapter");
+            const pythAccount = ("0x" + "b2".repeat(32)) as `0x${string}`;
+            await underlying.write.initialize([
+                pythAccount,
+                "SOL / USD",
+                60n,
+                factoryAddress,
+                ("0x" + "77".repeat(32)) as `0x${string}`,
+            ]);
+
+            const adapter = await cloneOf(cachedFeedImplAddr, "CachedFeedAdapter");
+            const description = "SOL/USD (cached)";
+            const maxStaleness = 3600n;
+            await adapter.write.initialize([underlying.address, description, maxStaleness, factoryAddress]);
+
+            const m: any = await adapter.read.metadata();
+            assert.equal(m.description, description);
+            assert.equal(m.maxStaleness, maxStaleness);
+            assert.equal((m.factory as string).toLowerCase(), factoryAddress.toLowerCase());
+            assert.equal(m.paused, false);
+            assert.ok(m.createdAt > 0n);
+            // Source identity delegated from the wrapped Pyth adapter.
+            assert.equal(Number(m.sourceType), SRC_PYTH);
+            assert.equal((m.solanaAccount as string).toLowerCase(), pythAccount.toLowerCase());
         });
     });
 });


### PR DESCRIPTION
CachedPythAdapter and CachedFeedAdapter implemented only IAggregatorV3Interface, not IAdapterMetadata. BatchReader.getFeedHealth() calls metadata() first and marks a feed unhealthy (skipping the price read) when it reverts — so cached adapters read as unavailable in batch health checks even when latestRoundData() returns a fresh price.

Both now implement IAdapterMetadata:
- CachedPythAdapter reports Pyth + its pythAccount.
- CachedFeedAdapter delegates sourceType/solanaAccount to its underlying via try/catch (fallback Pyth/0x0).

Interface parity with the raw PythPullAdapter/SwitchboardV3Adapter. Tests: AdapterMetadata.test.ts adds cases for both cached adapters; full oracle suite (83) green.