### PR TITLE
ci(dependabot): add npm-lockfile guard to auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,6 +27,29 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Lockfile guard for npm bumps. Dependabot sometimes drops still-required
+      # nested package-lock.json entries, leaving it out of sync with
+      # package.json; a strict `npm ci` then fails. Reproduce that install here
+      # so a drifted lockfile fails the job and the auto-merge step below — whose
+      # `if` has no status function, so it implies success() — is skipped. Gated
+      # on a root package-lock.json existing (the hashFiles check needs the
+      # checkout, hence checkout runs first).
+      - name: Checkout
+        if: steps.meta.outputs.package-ecosystem == 'npm_and_yarn'
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        if: steps.meta.outputs.package-ecosystem == 'npm_and_yarn' && hashFiles('package-lock.json') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Verify lockfile is in sync (npm ci)
+        if: steps.meta.outputs.package-ecosystem == 'npm_and_yarn' && hashFiles('package-lock.json') != ''
+        run: npm ci --no-audit --no-fund
+
       - name: Enable auto-merge for low-risk updates
         if: |
           (steps.meta.outputs.package-ecosystem == 'github_actions' ||


### PR DESCRIPTION
## Why

rome-solidity's dependabot npm patch/minor PRs auto-merge with no `npm ci` gate — `main`/`master` has no required check that catches lockfile drift (the repo's `ci.yml` uses `npm install`, which silently *fixes* drift rather than failing on it). A dependabot bump that leaves `package-lock.json` out of sync with `package.json` (dropped nested entries) would slip through unattended, then break any strict `npm ci` downstream. This is the same class of bug that broke a sibling repo's deploy build.

## What

Port the npm-lockfile guard from the rome-ops auto-merge template: run a strict `npm ci` before enabling auto-merge for npm bumps. On drift the job fails and the auto-merge step is skipped (its `if` has no status function → implies `success()`). `hashFiles('package-lock.json')`-gated so it only runs when a root lockfile exists; non-npm ecosystems skip it entirely. `actionlint` clean.