### PR TITLE
fix(deploy): include hadrian in SOLANA_DEVNET_NETWORKS + Sepolia targetChain

### DIFF
--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -44,7 +44,7 @@ const CPI_PROGRAM_ADDRESS = "0xFF00000000000000000000000000000000000008" as cons
 // new chain — adding it here keeps the deploy + sub-PDA derivations consistent.
 const SOLANA_DEVNET_NETWORKS = new Set([
   "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "local",
-  "trajan",
+  "trajan", "hadrian",
 ]);
 
 function programIdsFor(networkName: string) {
@@ -206,7 +206,7 @@ export async function deployWithdraw(
     // the registry). The earlier `"<chain>"` placeholder was a leftover from
     // PR #97's marcus-sweep — it never matched any real network and silently
     // routed Marcus's outbound Wormhole to Ethereum mainnet.
-    targetChain:        ["marcus", "local", "trajan"].includes(networkName) ? 10002 : 2,
+    targetChain:        ["marcus", "local", "trajan", "hadrian"].includes(networkName) ? 10002 : 2,
   };
 
   // forwarder = address(0): the meta-tx paymaster was removed. ERC2771Context


### PR DESCRIPTION
`deploy.ts` omitted `hadrian` from `SOLANA_DEVNET_NETWORKS` + the Sepolia `targetChain` list, so `RomeBridgeWithdraw` on Hadrian (Solana devnet) was constructed with the **mainnet** Wormhole token-bridge program (`wormDTUJ6…`). Outbound `burnETH` then CPI'd to a program not deployed on the cluster → `Custom error: … is not SBF program`. CCTP was unaffected (CCTP program ids are cluster-identical, which is why USDC outbound worked).

Adds `hadrian` to both lists. Redeployed **v5 `0x8510803f89eda2e5ade77b27ded8a0fb96a3042f`** (devnet Wormhole `DZnkkTm…`, Sepolia targetChain 10002), reusing the live wrappers + mints. Verified end-to-end on Hadrian: `approveBurnETH` + `burnETH` both land (wETH −0.001). Registry address bump: rome-protocol/registry (companion PR).