### PR TITLE
ops(oracle): redeploy OG-V2 on subura — metadata() + 3600 staleness

### DIFF
--- a/deployments/subura.json
+++ b/deployments/subura.json
@@ -32,45 +32,45 @@
     "deployedAt": 1781986758
   },
   "OracleGatewayV2": {
-    "deployedAt": "2026-06-20T20:19:57.027Z",
-    "defaultMaxStaleness": 60,
+    "deployedAt": "2026-06-29T16:57:14.773Z",
+    "defaultMaxStaleness": 3600,
     "pythReceiverProgramId": "0x0cb7fabb52f7a648bb5b317d9a018b9057cb024774fafe01e6c4df98cc385881",
     "switchboardProgramId": "0x068851c68c6832f02fa581b1bf491b77ca41776ba2b988b5a6faba8ee3a2ec90",
-    "PythPullAdapterImpl": "0x147cffca32d340adf338aaff2194633e20c7925f",
-    "SwitchboardV3AdapterImpl": "0x40e6e8f1aa0c6b752d65c934a5dbf7fbae958067",
-    "CachedPythAdapterImpl": "0xa90b0412e161d474b8d1ecc6ad6d96c96febb9c1",
-    "CachedFeedAdapterImpl": "0x2485d38d13fbbe6437c963c1f5733e6ac7495c49",
-    "OracleAdapterFactory": "0x64e9619b237843f04d6d51067aa896fec09873a4",
-    "BatchReader": "0x736fe375a2d201b72d47a12d0cc0f003702dd7b1",
+    "PythPullAdapterImpl": "0x6b40dc5f877ce90ccc1ef491cd5a6615bd7d4cb5",
+    "SwitchboardV3AdapterImpl": "0x579184c59db779d55389dba3e1b4b453c6aaad52",
+    "CachedPythAdapterImpl": "0x31f1fce999fe166da3b84cff16704d6a5748a542",
+    "CachedFeedAdapterImpl": "0xe285ea7459e8c694a3edf6a0031043ce9bb3f401",
+    "OracleAdapterFactory": "0x559cb6ab9287add4b84ded2f8e338aa20be4a241",
+    "BatchReader": "0x94282e37607cf159770b48412b814cce27e0fc82",
     "feeds": {
       "pyth": [
         {
           "pair": "SOL/USD",
-          "adapter": "0x0Fbb9527344f54C5038e83ac9C6e89D69dc3640b",
+          "adapter": "0xEdFA53e6966DD34e06068570A0a8373E5595129E",
           "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
           "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
         },
         {
           "pair": "BTC/USD",
-          "adapter": "0x909fB56eeAe10CCD3A0C18e521E3bf9A9Db52Fa8",
+          "adapter": "0x0523b950E44F3dA457298732Dd26f493EE1c7C44",
           "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
           "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
         },
         {
           "pair": "ETH/USD",
-          "adapter": "0xF2e9555319b0a1486D69e97B53f715784Ca02FCC",
+          "adapter": "0xc7467D88835A1F21501d149d934B1a7602220845",
           "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
           "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
         },
         {
           "pair": "USDC/USD",
-          "adapter": "0xDd2d922fE6A3CE99d9c2bcd18fD0228c47F86412",
+          "adapter": "0x35ab3Ac6953332C1a5dAD44E20f1d97201752c91",
           "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
           "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
         },
         {
           "pair": "USDT/USD",
-          "adapter": "0x4c4626477e95bdb081abAEfacbDF7F58236F2895",
+          "adapter": "0x6A785740F968198b9B3BB2FcC26197474196B2C9",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
         }
@@ -78,7 +78,7 @@
       "switchboard": [
         {
           "pair": "SOL/USD",
-          "adapter": "0x1ae8557F6F7Aea4e569253b39730B9E550eC3C58",
+          "adapter": "0xB744B7fd12Ea8623E6A57D06Ab373fa8884AF570",
           "pubkey": "GvDMxPzN1sCj7L26YDK2HnMRXEQmQ2aemov8YBtPS7vR",
           "pubkeyBytes32": "0xec81105112a257d61df4cf5f13ee0a1b019197c8c5343b4f2a7ec8846ae22c1a"
         }
@@ -86,31 +86,31 @@
       "cachedPyth": [
         {
           "pair": "SOL/USD",
-          "adapter": "0x4FA946EB15Ab6B791E0023728E722bf360dCe05E",
+          "adapter": "0xf7Fbd74F72D77B463B972Fca42F894f2884bFE6A",
           "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
           "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
         },
         {
           "pair": "BTC/USD",
-          "adapter": "0x3e2090a52E7477cfcc3bac974331CA4838B11F6d",
+          "adapter": "0xe57EE95E8545a20A7619E939093fE7568caAE69F",
           "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
           "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
         },
         {
           "pair": "ETH/USD",
-          "adapter": "0x70B3331650cd9f31bD64cEF6740DB4a7bad779e3",
+          "adapter": "0x166C50829a132Bbf88321543414Ff9D28D00f4e6",
           "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
           "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
         },
         {
           "pair": "USDC/USD",
-          "adapter": "0x781c63d26022e18c08613296aE53D2A70B593AC2",
+          "adapter": "0xd936Cd8d911F1C84C50E28A10A6BbeC1A9d3C375",
           "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
           "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
         },
         {
           "pair": "USDT/USD",
-          "adapter": "0xd2cDe57d45274eeDc318fD457ba2d8b6d4624C22",
+          "adapter": "0x09ba61FC6d887e72DEB7f886d5E754E0500C9B71",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
         }
@@ -118,31 +118,31 @@
       "cachedFeed": [
         {
           "pair": "SOL/USD",
-          "adapter": "0xb35c4C1171C81DDcC2e0e2BeA65e7Bbe2DdDF32D",
+          "adapter": "0x26EB90EB742ED4C4c17C0b346b005570dB04EdBD",
           "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
           "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243"
         },
         {
           "pair": "BTC/USD",
-          "adapter": "0xFE028745DA04d540488F641F7F3927BceA364A76",
+          "adapter": "0x15AAA3cB18B1E63b45059932DFEe6FD023116076",
           "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
           "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de"
         },
         {
           "pair": "ETH/USD",
-          "adapter": "0x0B645bD0fC9D87E40676aF6538Ff509ddf5319d9",
+          "adapter": "0xf3cf93dAB2Eb5e57f6Af647F5d16eB801406dF22",
           "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
           "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb"
         },
         {
           "pair": "USDC/USD",
-          "adapter": "0xFefC369a2d3B0c7E52F193D2d4832BC6189C500a",
+          "adapter": "0xc4ce7f3e7C64B323B1d30CB18d5Baf7419e17A85",
           "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
           "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2"
         },
         {
           "pair": "USDT/USD",
-          "adapter": "0x14E834e4aF2c2e2d6D28C07c63beEc12EA56BE5E",
+          "adapter": "0x9bA9C6A6f9E89ABaB10CC3177060B9593aD80BA5",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
         }


### PR DESCRIPTION
Redeploys the Oracle Gateway V2 stack on subura (121213, devnet).

**Why:** subura's cached adapters (CachedPyth/CachedFeed) were deployed 2026-06-20, before [#251](https://github.com/rome-protocol/rome-solidity/pull/251) added `metadata()` to cached adapters (2026-06-26). The oracle portal's `getFeedHealth` calls `metadata()` per adapter and marked the 10 cached feeds (of 16) Unavailable. Plain Pyth/Switchboard adapters were fine (got `metadata()` from earlier commits).

**What:** `deploy-v2-polish` (FORCE_REDEPLOY, new factory `0x559cb6ab…` + impls with `metadata()`) + `deploy-seed-feeds` (re-clone all feeds). `DEFAULT_MAX_STALENESS=3600` (was 60) per operator request to cut keeper SOL spend.

**Verified on-chain:** new cachedPyth/cachedFeed/plainPyth all return `metadata()` with staleness 3600; old cached adapter still reverts. Registry wiring: rome-protocol/registry#238. Receipt: `deployments/subura.json`.