### PR TITLE
feat(scripts): Compound-collateral wrapper set + JitoSOL/mSOL/BONK oracle seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added — Compound-collateral wrapper set (`WRAPPER_SET=collateral`) + JitoSOL/mSOL/BONK oracle seeds
+
+[`scripts/bridge/bootstrap-bridged-wrappers.ts`](scripts/bridge/bootstrap-bridged-wrappers.ts) gains a second wrapper set: `WRAPPER_SET=collateral` registers the 6 exotic collaterals of Hadrian's canonical 9-asset Comet (wBTC, wJitoSOL, wmSOL, wJUP, wJTO, wBONK — mints in [`scripts/bridge/constants.ts`](scripts/bridge/constants.ts) `COMPOUND_COLLATERAL_MINTS_DEVNET`) on any devnet-substrate chain, so per-chain Comets can carry the full asset suite. Devnet-only (the test mints have no mainnet counterpart); mainnet-resolving networks throw. `martius` and `nerva` added to `DEVNET_NETWORKS` (Rome-testnet chains on the Solana devnet substrate — previously they silently resolved to mainnet mints unless `BRIDGED_SET=devnet` was passed).
+
+[`scripts/oracle/deploy-seed-feeds.ts`](scripts/oracle/deploy-seed-feeds.ts) — adds JITOSOL/MSOL/BONK PYTH_SEEDS and fixes JUP/JTO to the receiver PDAs the oracle-keeper actually refreshes (the previous JUP account doesn't exist on devnet; both were unusable). Accounts mirror Hadrian's live adapters, owner-verified on devnet.
+
 ### Added — `metadata()` on `CachedPythAdapter` / `CachedFeedAdapter`
 
 [`contracts/oracle/CachedPythAdapter.sol`](contracts/oracle/CachedPythAdapter.sol) and [`contracts/oracle/CachedFeedAdapter.sol`](contracts/oracle/CachedFeedAdapter.sol) now implement `IAdapterMetadata`, reaching parity with the raw `PythPullAdapter` / `SwitchboardV3Adapter`. `CachedPythAdapter` reports `Pyth` + its `pythAccount`; `CachedFeedAdapter` delegates `sourceType` / `solanaAccount` to its underlying via try/catch (fallback `Pyth` / `0x0`).

--- a/deployments/martius.json
+++ b/deployments/martius.json
@@ -73,6 +73,36 @@
           "adapter": "0x9a95d834B067B4b52423a1635E567B211246F72d",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
+        },
+        {
+          "pair": "JUP/USD",
+          "adapter": "0xAeB5EC137d0721CF6A1F80cE5D513F8db410C301",
+          "pubkey": "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
+          "pubkeyBytes32": "0x628661ff844a6d513411aa02952b8bf902e3b2fe282639f9c96d399e52d86468"
+        },
+        {
+          "pair": "JTO/USD",
+          "adapter": "0xf54A700F09c3E24E46118c134441C2a4c2270644",
+          "pubkey": "7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP",
+          "pubkeyBytes32": "0x61ca3f110915af36104573608c75b56a0758cbef2cb34551cf02cad9a63ed00c"
+        },
+        {
+          "pair": "JITOSOL/USD",
+          "adapter": "0xDBCb1E24a690CC3E2CB21fa4923C7C41e3480696",
+          "pubkey": "AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g",
+          "pubkeyBytes32": "0x93f6880418b35aad10f98e24e374d087058430512df03245e0ada7647385b53b"
+        },
+        {
+          "pair": "MSOL/USD",
+          "adapter": "0xA2Cd26dFe82727033442E74E2491c4c34A4269A2",
+          "pubkey": "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+          "pubkeyBytes32": "0x3e559ca93e1bf119b0e7c20adf557067caca210c2e1778cef652a1dd4dc84644"
+        },
+        {
+          "pair": "BONK/USD",
+          "adapter": "0x79b2aCC9AFC4B6207Faa53536bED2DfD92b483a0",
+          "pubkey": "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+          "pubkeyBytes32": "0xb4eacbe402ae9165c2ab7dfcdbe5044d27f284106f88a90bfddefa5fbff60ca0"
         }
       ],
       "switchboard": [
@@ -113,6 +143,36 @@
           "adapter": "0xD5315AB7488D0d5da402c70Ca808b68c23b8243F",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
+        },
+        {
+          "pair": "JUP/USD",
+          "adapter": "0x2F9A54aC49218a6771A329D18a5F3699ef228f5d",
+          "pubkey": "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
+          "pubkeyBytes32": "0x628661ff844a6d513411aa02952b8bf902e3b2fe282639f9c96d399e52d86468"
+        },
+        {
+          "pair": "JTO/USD",
+          "adapter": "0x11e4B2688140C29dd45354c841c355Babd4Cd2C5",
+          "pubkey": "7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP",
+          "pubkeyBytes32": "0x61ca3f110915af36104573608c75b56a0758cbef2cb34551cf02cad9a63ed00c"
+        },
+        {
+          "pair": "JITOSOL/USD",
+          "adapter": "0xF1C001d3bc2b981f563fd847c92aF0695D547771",
+          "pubkey": "AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g",
+          "pubkeyBytes32": "0x93f6880418b35aad10f98e24e374d087058430512df03245e0ada7647385b53b"
+        },
+        {
+          "pair": "MSOL/USD",
+          "adapter": "0x41Dbb3b23CE2596744b07576332891064509CD57",
+          "pubkey": "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+          "pubkeyBytes32": "0x3e559ca93e1bf119b0e7c20adf557067caca210c2e1778cef652a1dd4dc84644"
+        },
+        {
+          "pair": "BONK/USD",
+          "adapter": "0xad6456Bc42F456ECbAd542fab37D59f5e0eC25a7",
+          "pubkey": "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+          "pubkeyBytes32": "0xb4eacbe402ae9165c2ab7dfcdbe5044d27f284106f88a90bfddefa5fbff60ca0"
         }
       ],
       "cachedFeed": [
@@ -145,6 +205,36 @@
           "adapter": "0xbe7Ba706a3Ce74BaaB913000f0b77D0063A2A95B",
           "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
           "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748"
+        },
+        {
+          "pair": "JUP/USD",
+          "adapter": "0xd33F53163d076146A051a641329Bb75E567ec40E",
+          "pubkey": "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
+          "pubkeyBytes32": "0x628661ff844a6d513411aa02952b8bf902e3b2fe282639f9c96d399e52d86468"
+        },
+        {
+          "pair": "JTO/USD",
+          "adapter": "0xFA17DcD2e14D293F3EFC239F5e1Ccd904C917C6F",
+          "pubkey": "7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP",
+          "pubkeyBytes32": "0x61ca3f110915af36104573608c75b56a0758cbef2cb34551cf02cad9a63ed00c"
+        },
+        {
+          "pair": "JITOSOL/USD",
+          "adapter": "0x1824927C559707f5d9570b2a57a149d20c0f19A1",
+          "pubkey": "AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g",
+          "pubkeyBytes32": "0x93f6880418b35aad10f98e24e374d087058430512df03245e0ada7647385b53b"
+        },
+        {
+          "pair": "MSOL/USD",
+          "adapter": "0xDA5BB8eB07D4294361c25e1F03163bDd481f805d",
+          "pubkey": "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+          "pubkeyBytes32": "0x3e559ca93e1bf119b0e7c20adf557067caca210c2e1778cef652a1dd4dc84644"
+        },
+        {
+          "pair": "BONK/USD",
+          "adapter": "0x6b554C435Bae33dc18907Ab760b0E2e417b6429e",
+          "pubkey": "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+          "pubkeyBytes32": "0xb4eacbe402ae9165c2ab7dfcdbe5044d27f284106f88a90bfddefa5fbff60ca0"
         }
       ]
     }
@@ -159,5 +249,41 @@
     "wsolWrapper": "0xa4DbEcDcC812B9c933967a15fE5D9Af420084b2B",
     "users": "0xC9c4D11C53B8158dd0f6Cd85476957dA9c7AD34C",
     "deployedAt": 1782428918
+  },
+  "SPL_ERC20_WBTC": {
+    "address": "0x34AE37cFA1f41F5E69d8F042F7455A63a4F048B8",
+    "mintId": "2gsErzRCTA7T6hGnYo44EnpP7hP79CHQerDhtmggkZZF",
+    "name": "Rome Wrapped BTC",
+    "symbol": "wBTC"
+  },
+  "SPL_ERC20_WJITOSOL": {
+    "address": "0x8a27E495CEAd6EcBBe25B537DBF666FD6bfE01E3",
+    "mintId": "8Eou1ZHTULFvoaELa9Dnw29puHdckcsj7buQKNqfaZHH",
+    "name": "Rome Wrapped JitoSOL",
+    "symbol": "wJitoSOL"
+  },
+  "SPL_ERC20_WMSOL": {
+    "address": "0xe6fD55A93cAecF0F9cF60FBC4D2CbE0d71b54491",
+    "mintId": "jc65vCfDLKm9sW7auJMkNJZuE6jnsqfW9bHHvYp9oYE",
+    "name": "Rome Wrapped mSOL",
+    "symbol": "wmSOL"
+  },
+  "SPL_ERC20_WJUP": {
+    "address": "0x71dC1C088E17cCD67058c626A358E02F6EbAAc69",
+    "mintId": "Aa58JCN8MCDPSAPe6qZiL1ZWtqxVDRdSjH6EGjku5vFe",
+    "name": "Rome Wrapped JUP",
+    "symbol": "wJUP"
+  },
+  "SPL_ERC20_WJTO": {
+    "address": "0xCb1e4CD61704C9fcc196Ce98619E85A241383Fd8",
+    "mintId": "F2Vr2fWpi4quVQSc8SGk2XyVaxmDMLRTvoeDGEMbvUZq",
+    "name": "Rome Wrapped JTO",
+    "symbol": "wJTO"
+  },
+  "SPL_ERC20_WBONK": {
+    "address": "0x2c71373725C59B3F1D47a0D425B7050D02e014b4",
+    "mintId": "HWeLrJqWKK3yDfqkGucGq9RpgfU75W1UE5iVL23BSw4Y",
+    "name": "Rome Wrapped BONK",
+    "symbol": "wBONK"
   }
 }

--- a/scripts/bridge/bootstrap-bridged-wrappers.ts
+++ b/scripts/bridge/bootstrap-bridged-wrappers.ts
@@ -16,7 +16,7 @@ import fs from "node:fs";
 import hardhat from "hardhat";
 import { resolveERC20SPLFactoryAddress } from "../lib/deployments.js";
 import { base58ToBytes32 } from "../lib/pubkey.js";
-import { SPL_MINTS_DEVNET, SPL_MINTS_MAINNET } from "./constants.js";
+import { SPL_MINTS_DEVNET, SPL_MINTS_MAINNET, COMPOUND_COLLATERAL_MINTS_DEVNET } from "./constants.js";
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
@@ -44,14 +44,42 @@ const MAINNET_SET: WrapperSpec[] = [
   { key: "SPL_ERC20_WSOL", mintBase58: SPL_MINTS_MAINNET.WSOL_NATIVE,   name: "Rome SOL",  symbol: "wSOL"  },
 ];
 
+// Compound-collateral wrapper set (devnet-substrate chains only). Mirrors the
+// 6 exotic collaterals of Hadrian's canonical 9-asset Comet — same underlying
+// devnet mints, same on-chain names/symbols — so a Comet deployed on any
+// devnet-substrate chain can carry the full asset suite. Select with
+// `WRAPPER_SET=collateral`; the default run keeps the canonical bridged set.
+const COLLATERAL_SET_DEVNET: WrapperSpec[] = [
+  { key: "SPL_ERC20_WBTC",     mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.BTC_TEST,     name: "Rome Wrapped BTC",     symbol: "wBTC"     },
+  { key: "SPL_ERC20_WJITOSOL", mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.JITOSOL_TEST, name: "Rome Wrapped JitoSOL", symbol: "wJitoSOL" },
+  { key: "SPL_ERC20_WMSOL",    mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.MSOL_TEST,    name: "Rome Wrapped mSOL",    symbol: "wmSOL"    },
+  { key: "SPL_ERC20_WJUP",     mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.JUP_TEST,     name: "Rome Wrapped JUP",     symbol: "wJUP"     },
+  { key: "SPL_ERC20_WJTO",     mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.JTO_TEST,     name: "Rome Wrapped JTO",     symbol: "wJTO"     },
+  { key: "SPL_ERC20_WBONK",    mintBase58: COMPOUND_COLLATERAL_MINTS_DEVNET.BONK_TEST,    name: "Rome Wrapped BONK",    symbol: "wBONK"    },
+];
+
 // Networks targeting Solana DEVNET use SPL_MINTS_DEVNET; mainnet networks use
 // SPL_MINTS_MAINNET. Update this list whenever a new chain is brought up.
 // Override via `BRIDGED_SET=devnet|mainnet` env var for one-off cases.
+// NOTE: Rome-testnet chains (martius, nerva) also run on the Solana DEVNET
+// substrate — Rome network tier ≠ Solana cluster.
 const DEVNET_NETWORKS = new Set([
   "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "augustus", "hadrian", "local",
+  "martius", "nerva",
 ]);
 
 function resolveSet(networkName: string): WrapperSpec[] {
+  const wrapperSet = process.env.WRAPPER_SET?.toLowerCase();
+  if (wrapperSet === "collateral") {
+    // Collateral test mints exist only on Solana devnet — refuse a mainnet run.
+    const override = process.env.BRIDGED_SET?.toLowerCase();
+    if (override === "mainnet" || (override !== "devnet" && !DEVNET_NETWORKS.has(networkName))) {
+      throw new Error(
+        `WRAPPER_SET=collateral is devnet-substrate-only (network '${networkName}' resolves to mainnet mints)`,
+      );
+    }
+    return COLLATERAL_SET_DEVNET;
+  }
   const override = process.env.BRIDGED_SET?.toLowerCase();
   if (override === "devnet")  return DEVNET_SET;
   if (override === "mainnet") return MAINNET_SET;
@@ -80,7 +108,8 @@ async function main() {
 
   console.log(`[${networkName}] deployer: ${deployer.account.address}`);
   console.log(`[${networkName}] factory:  ${factoryAddress}`);
-  console.log(`[${networkName}] mint set: ${set === DEVNET_SET ? "devnet" : "mainnet"} (${set.length} entries)\n`);
+  const setLabel = set === COLLATERAL_SET_DEVNET ? "collateral (devnet)" : set === DEVNET_SET ? "devnet" : "mainnet";
+  console.log(`[${networkName}] mint set: ${setLabel} (${set.length} entries)\n`);
 
   const deploymentsPath = `deployments/${networkName}.json`;
   const deployments = loadJson(deploymentsPath);

--- a/scripts/bridge/constants.ts
+++ b/scripts/bridge/constants.ts
@@ -53,6 +53,21 @@ export const SPL_MINTS_DEVNET = {
   WSOL_NATIVE: "So11111111111111111111111111111111111111112",
 } as const;
 
+// Compound-collateral test mints (Solana devnet only — Rome-minted test
+// assets, no mainnet counterpart). These are the underlying mints of the
+// 6 exotic collaterals on Hadrian's canonical 9-asset Comet; wrapping the
+// SAME mints on any devnet-substrate chain keeps the asset set identical
+// across chains. Extracted from the live Hadrian wrappers' mint_id()
+// (2026-07-01); mint authority 3E7gp1p8CfZ8kXMUagqKQWYZijQm7hxkrE67eQZPLdfv.
+export const COMPOUND_COLLATERAL_MINTS_DEVNET = {
+  BTC_TEST: "2gsErzRCTA7T6hGnYo44EnpP7hP79CHQerDhtmggkZZF",
+  JITOSOL_TEST: "8Eou1ZHTULFvoaELa9Dnw29puHdckcsj7buQKNqfaZHH",
+  MSOL_TEST: "jc65vCfDLKm9sW7auJMkNJZuE6jnsqfW9bHHvYp9oYE",
+  JUP_TEST: "Aa58JCN8MCDPSAPe6qZiL1ZWtqxVDRdSjH6EGjku5vFe",
+  JTO_TEST: "F2Vr2fWpi4quVQSc8SGk2XyVaxmDMLRTvoeDGEMbvUZq",
+  BONK_TEST: "HWeLrJqWKK3yDfqkGucGq9RpgfU75W1UE5iVL23BSw4Y",
+} as const;
+
 // Default export — points at devnet for now since active deploys target
 // rome/rome. Switch to SPL_MINTS_MAINNET for mainnet.
 export const SPL_MINTS = SPL_MINTS_DEVNET;

--- a/scripts/oracle/deploy-seed-feeds.ts
+++ b/scripts/oracle/deploy-seed-feeds.ts
@@ -55,15 +55,37 @@ const PYTH_SEEDS: SeedFeed[] = [
         pubkeyBase58: "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
         description: "USDT / USD",
     },
+    // JUP/JTO corrected 2026-07-01: the previous entries (2F9M59…, D8UUgr…)
+    // don't exist on devnet (JUP) / aren't the accounts the oracle-keeper
+    // refreshes. These are the receiver PDAs Hadrian's live adapters read and
+    // the keeper keeps fresh (rome-ops testnet-oracle-portal keeper config).
     {
         pair: "JUP/USD",
-        pubkeyBase58: "2F9M59yYX6F4eHxWNCbvSGiZxRw6CcmpNqf9HsN7jC5o",
+        pubkeyBase58: "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
         description: "JUP / USD",
     },
     {
         pair: "JTO/USD",
-        pubkeyBase58: "D8UUgr8a3aR3yUeHLu7v8FWK7E1FADA92Hmj8CeuSrvs",
+        pubkeyBase58: "7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP",
         description: "JTO / USD",
+    },
+    // Solana-ecosystem collaterals for the canonical 9-asset cache-fed Comet
+    // (mirrors Hadrian; keeper-refreshed PDAs, verified owner rec5EKM… on
+    // devnet 2026-07-01).
+    {
+        pair: "JITOSOL/USD",
+        pubkeyBase58: "AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g",
+        description: "JitoSOL / USD",
+    },
+    {
+        pair: "MSOL/USD",
+        pubkeyBase58: "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+        description: "mSOL / USD",
+    },
+    {
+        pair: "BONK/USD",
+        pubkeyBase58: "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+        description: "BONK / USD",
     },
 ];
 


### PR DESCRIPTION
Enables per-chain Comets to carry Hadrian's full 9-asset suite (first consumer: martius, deployed with this branch — receipts in deployments/martius.json).

- \`bootstrap-bridged-wrappers.ts\`: \`WRAPPER_SET=collateral\` registers the 6 exotic collaterals (wBTC/wJitoSOL/wmSOL/wJUP/wJTO/wBONK) via \`add_spl_token_no_metadata\` — same underlying devnet mints + on-chain names as Hadrian's wrappers (mints pinned in \`constants.ts\` \`COMPOUND_COLLATERAL_MINTS_DEVNET\`). Devnet-substrate-only; mainnet-resolving networks throw. \`martius\`/\`nerva\` added to \`DEVNET_NETWORKS\` — they run on the Solana devnet substrate but previously resolved to MAINNET mints (a bare run on martius attempted mainnet-USDC registration and reverted on the wUSDC symbol collision).
- \`deploy-seed-feeds.ts\`: adds JITOSOL/MSOL/BONK PYTH_SEEDS; fixes JUP/JTO to the receiver PDAs the oracle-keeper actually refreshes (old JUP account doesn't exist on devnet — both entries were unusable). Accounts mirror Hadrian's live adapters; owner-verified (rec5EKM…) on devnet.
- Deployed on martius (121214): 6 cached wrappers + 5×3 oracle adapters (raw pyth / cached-pyth / cached-feed), first refresh() done, live prices verified (JitoSOL \$99.76, JUP \$0.234, BONK \$4.3e-6). Idempotent re-runs verified (6× already-registered / 15× skipping).

Tests: CI set green locally (141 passing).