### PR TITLE
bridge: RomeBridgeWithdraw v6 — CCTP v2 burns with per-call destination domain

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -20,6 +20,16 @@ secret:
     # that false positive without disabling the Generic High Entropy
     # detector for the rest of the repo.
     - tests/cpi/SolanaConstants.test.ts
+    # v6 CCTP-v2 bridge tests + PDA-derivation script: assert against the
+    # account list + instruction bytes of a LANDED public devnet CCTP v2
+    # deposit_for_burn. Every bs58 string is a public Solana pubkey (program
+    # id, config PDA, ATA, or the canonical devnet USDC mint) read straight
+    # off-chain — public identifiers, not secrets. Same false-positive class
+    # as SolanaConstants.test.ts (GitGuardian "Generic High Entropy Secret").
+    - tests/bridge/cctp_v2_lib.test.ts
+    - tests/bridge/rome_bridge_withdraw_v6.test.ts
+    - tests/bridge/derive.test.ts
+    - scripts/bridge/derive/cctp-accounts.ts
   ignored_matches:
     # Canonical public Solana program IDs. These are NOT secrets — they are
     # the globally-published program IDs every Solana client must recognize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2026-07-04 — RomeBridgeWithdraw v6: CCTP v2 + per-call destination domain
+
+- `burnUSDC(uint256, address, uint32 destinationDomain)` — outbound USDC to any
+  allowlisted Circle domain (Ethereum-family 0, Avalanche 1, Arbitrum 3, Base 6,
+  Polygon 7, Monad 15). The 2-arg overload remains ABI-compatible and routes to
+  domain 0. Burns now CPI Circle's CCTP **v2** Solana programs (required for
+  v2-only destinations like Monad; go-forward protocol everywhere).
+- `CctpParams` swaps the single `remoteTokenMessenger` for parallel
+  `domains[]`/`remoteTokenMessengers[]` arrays → constructor-populated
+  allowlist mapping (unlisted domains revert `UnsupportedDestinationDomain`).
+- New `CCTPV2Lib` (`contracts/bridge/ICCTPV2.sol`): v2 encode (destination_caller,
+  max_fee, min_finality_threshold) + 19-meta account build (adds the per-owner
+  `denylist_account` PDA, keeps the Mollusk trailing-meta workaround). Byte-for-byte
+  test-pinned against a landed devnet v2 burn.
+- New event `WithdrawnToDomain(user, mint, amount, recipient, path, destinationDomain)`
+  emitted alongside the legacy `Withdrawn`.
+- `deploy.ts`/`derive/cctp-accounts.ts` derive v2 config PDAs + per-domain remotes;
+  devnet domain list `[0,1,3,6,7,15]` in `constants.ts`.
+- Downstream: rome-ui gains a destination-network picker on outbound (follow-up);
+  existing 2-arg callers unaffected. `scripts/bridge/tests/portal-cctp-test.ts`
+  remains v1-era (do not use against v6).
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/contracts/bridge/ICCTPV2.sol
+++ b/contracts/bridge/ICCTPV2.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ICrossProgramInvocation} from "../interface.sol";
+
+/// @title CCTPV2Lib
+/// @notice Encodes deposit_for_burn instructions and account lists for the
+///         Circle CCTP **v2** Token Messenger Minter program
+///         (CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe on devnet+mainnet),
+///         invoked via Rome's CPI precompile. Sibling of the v1 CCTPLib —
+///         v2 is required for destinations that are v2-only (Monad = domain
+///         15) and is the go-forward protocol for every destination.
+///
+///         Ground truth: account ordering + instruction bytes reproduce a
+///         LANDED devnet v2 deposit_for_burn
+///         (4L4D7Qo7DNFfdGXY4AhYYiFfbdhxwSZruteaxVTUaSkXBpVrNBoyTmU47mZSuo6YUwNUWQNqneks9QWcyzNbLoPY)
+///         byte-for-byte — see tests/bridge/cctp_v2_lib.test.ts.
+library CCTPV2Lib {
+    uint32 internal constant DOMAIN_SOLANA = 5;
+
+    /// @dev Standard-finality tier (free per Circle's fee schedule; the
+    ///      fast tier 1000 costs bps). Matches the UI-side burn constants.
+    uint32 internal constant MIN_FINALITY_STANDARD = 2000;
+
+    /// @dev Anchor discriminator — same method name as v1, so the same
+    ///      sha256("global:deposit_for_burn")[0..8].
+    bytes8 internal constant DISCRIMINATOR_DEPOSIT_FOR_BURN = 0xd73c3d2e723780b0;
+
+    /// @notice v2 deposit_for_burn args. v2 adds destination_caller
+    ///         (bytes32(0) = permissionless relay), max_fee, and
+    ///         min_finality_threshold over v1.
+    struct DepositForBurnParams {
+        uint64 amount;
+        uint32 destinationDomain;
+        bytes32 mintRecipient;
+        bytes32 destinationCaller;
+        uint64 maxFee;
+        uint32 minFinalityThreshold;
+    }
+
+    /// @notice The 18 accounts of the landed v2 layout, plus the trailing
+    ///         MessageTransmitter __event_authority inherited from the v1
+    ///         Rome-emulator workaround (post-#266 Mollusk ix_store filter;
+    ///         trailing accounts are ignored by Anchor on-chain).
+    ///         v2 deltas vs v1: + denylist_account (per-owner PDA, index 4);
+    ///         remote_token_messenger remains PER DESTINATION DOMAIN.
+    struct DepositForBurnAccounts {
+        bytes32 owner;                       // 0  signer, writable — user's Rome PDA
+        bytes32 eventRentPayer;              // 1  signer, writable
+        bytes32 senderAuthorityPda;          // 2  readonly — ["sender_authority"] under TMM v2
+        bytes32 burnTokenAccount;            // 3  writable — user's USDC ATA
+        bytes32 denylistAccount;             // 4  readonly — ["denylist_account", owner] under TMM v2
+        bytes32 messageTransmitter;          // 5  writable — MT v2 config
+        bytes32 tokenMessenger;              // 6  readonly — TMM v2 config
+        bytes32 remoteTokenMessenger;        // 7  readonly — ["remote_token_messenger", dec(domain)]
+        bytes32 tokenMinter;                 // 8  writable
+        bytes32 localToken;                  // 9  writable
+        bytes32 burnTokenMint;               // 10 writable
+        bytes32 messageSentEventData;        // 11 signer, writable — per-tx salted PDA
+        bytes32 messageTransmitterProgram;   // 12 readonly
+        bytes32 tokenMessengerMinterProgram; // 13 readonly
+        bytes32 tokenProgram;                // 14 readonly
+        bytes32 systemProgram;               // 15 readonly
+        bytes32 eventAuthority;              // 16 readonly — TMM __event_authority
+        bytes32 program;                     // 17 readonly — TMM program (again)
+        bytes32 messageTransmitterEventAuthority; // 18 readonly — trailing emulator workaround
+    }
+
+    /// @notice Encodes the v2 deposit_for_burn payload.
+    /// @dev Layout (96 bytes): [disc:8][amount:8 LE][destination_domain:4 LE]
+    ///      [mint_recipient:32][destination_caller:32][max_fee:8 LE]
+    ///      [min_finality_threshold:4 LE]
+    function encodeDepositForBurn(DepositForBurnParams memory p)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(
+            DISCRIMINATOR_DEPOSIT_FOR_BURN,
+            _u64le(p.amount),
+            _u32le(p.destinationDomain),
+            p.mintRecipient,
+            p.destinationCaller,
+            _u64le(p.maxFee),
+            _u32le(p.minFinalityThreshold)
+        );
+    }
+
+    /// @notice Ordered account list per the landed v2 layout (+ trailing meta).
+    function buildDepositForBurnAccounts(DepositForBurnAccounts memory a)
+        internal
+        pure
+        returns (ICrossProgramInvocation.AccountMeta[] memory metas)
+    {
+        metas = new ICrossProgramInvocation.AccountMeta[](19);
+        metas[0]  = ICrossProgramInvocation.AccountMeta(a.owner,                       true,  true);
+        metas[1]  = ICrossProgramInvocation.AccountMeta(a.eventRentPayer,              true,  true);
+        metas[2]  = ICrossProgramInvocation.AccountMeta(a.senderAuthorityPda,          false, false);
+        metas[3]  = ICrossProgramInvocation.AccountMeta(a.burnTokenAccount,            false, true);
+        metas[4]  = ICrossProgramInvocation.AccountMeta(a.denylistAccount,             false, false);
+        metas[5]  = ICrossProgramInvocation.AccountMeta(a.messageTransmitter,          false, true);
+        metas[6]  = ICrossProgramInvocation.AccountMeta(a.tokenMessenger,              false, false);
+        metas[7]  = ICrossProgramInvocation.AccountMeta(a.remoteTokenMessenger,        false, false);
+        metas[8]  = ICrossProgramInvocation.AccountMeta(a.tokenMinter,                 false, true);
+        metas[9]  = ICrossProgramInvocation.AccountMeta(a.localToken,                  false, true);
+        metas[10] = ICrossProgramInvocation.AccountMeta(a.burnTokenMint,               false, true);
+        metas[11] = ICrossProgramInvocation.AccountMeta(a.messageSentEventData,        true,  true);
+        metas[12] = ICrossProgramInvocation.AccountMeta(a.messageTransmitterProgram,   false, false);
+        metas[13] = ICrossProgramInvocation.AccountMeta(a.tokenMessengerMinterProgram, false, false);
+        metas[14] = ICrossProgramInvocation.AccountMeta(a.tokenProgram,                false, false);
+        metas[15] = ICrossProgramInvocation.AccountMeta(a.systemProgram,               false, false);
+        metas[16] = ICrossProgramInvocation.AccountMeta(a.eventAuthority,              false, false);
+        metas[17] = ICrossProgramInvocation.AccountMeta(a.program,                     false, false);
+        // Trailing Rome-emulator workaround — see struct doc.
+        metas[18] = ICrossProgramInvocation.AccountMeta(a.messageTransmitterEventAuthority, false, false);
+    }
+
+    function _u32le(uint32 v) private pure returns (bytes memory) {
+        bytes memory b = new bytes(4);
+        b[0] = bytes1(uint8(v));
+        b[1] = bytes1(uint8(v >> 8));
+        b[2] = bytes1(uint8(v >> 16));
+        b[3] = bytes1(uint8(v >> 24));
+        return b;
+    }
+
+    function _u64le(uint64 v) private pure returns (bytes memory) {
+        bytes memory b = new bytes(8);
+        for (uint256 i = 0; i < 8; i++) {
+            b[i] = bytes1(uint8(v >> (8 * i)));
+        }
+        return b;
+    }
+}

--- a/contracts/bridge/RomeBridgeEvents.sol
+++ b/contracts/bridge/RomeBridgeEvents.sol
@@ -18,6 +18,20 @@ interface RomeBridgeEvents {
         uint8 path
     );
 
+    /// @notice Multi-destination variant of `Withdrawn` (v6): carries the
+    ///         Circle CCTP destination domain (or, for future Wormhole
+    ///         multi-destination, the Wormhole chain id) so indexers can
+    ///         attribute the egress chain without heuristics. Emitted
+    ///         ALONGSIDE the legacy `Withdrawn` for back-compat.
+    event WithdrawnToDomain(
+        address indexed user,
+        bytes32 indexed mint,
+        uint256 amount,
+        address recipient,
+        uint8 path,
+        uint32 destinationDomain
+    );
+
     /// @notice Emitted on a Rome → Solana SPL egress of a wrapper token to a
     ///         raw Solana recipient. Distinct from `Withdrawn` (EVM-chain
     ///         egress via CCTP/Wormhole, address recipient) — here the

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.28;
 
 import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import {SPL_ERC20} from "../erc20spl/erc20spl.sol";
-import {CCTPLib} from "./ICCTP.sol";
+import {CCTPV2Lib} from "./ICCTPV2.sol";
+import {PdaDeriver} from "../cpi/PdaDeriver.sol";
+import {ISystemProgram} from "../interface.sol";
 import {WormholeTokenBridgeLib} from "./IWormholeTokenBridge.sol";
 import {ICrossProgramInvocation, CpiProgram, HelperProgram} from "../interface.sol";
 import {RomeEVMAccount} from "../rome_evm_account.sol";
@@ -16,7 +18,10 @@ import {UserPda} from "../cpi/UserPda.sol";
 /// @title RomeBridgeWithdraw
 /// @notice Accepts rToken input on Rome EVM, emits outbound CCTP or Wormhole
 ///         message via CPI signed as the user's Rome-derived PDA.
-/// @dev CCTP path:     burnUSDC → depositForBurn CPI (path=0)
+/// @dev CCTP path:     burnUSDC → CCTP **v2** deposit_for_burn CPI (path=0),
+///                     per-call destination domain (v6). v2 is required for
+///                     v2-only destinations (Monad = 15) and is the
+///                     go-forward protocol for every destination.
 ///      Wormhole path: burnETH  → transfer_tokens CPI  (path=1)
 ///
 ///      All Solana program IDs, sysvars, and PDAs are supplied at construction
@@ -43,7 +48,6 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     bytes32 public immutable cctpSystemProgram;
     bytes32 public immutable cctpMessageTransmitterConfig;
     bytes32 public immutable cctpTokenMessengerConfig;
-    bytes32 public immutable cctpRemoteTokenMessenger;
     bytes32 public immutable cctpTokenMinter;
     bytes32 public immutable cctpLocalTokenUsdc;
     bytes32 public immutable cctpSenderAuthorityPda;
@@ -79,6 +83,14 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     // Per-user nonce for transient message PDAs
     // -------------------------------------------------------------------------
 
+    /// @notice CCTP destination allowlist: Circle domain → remote_token_messenger
+    ///         PDA (["remote_token_messenger", dec(domain)] under the v2 TMM).
+    ///         Populated once at construction from registry-fed deploy config —
+    ///         doubling as the per-destination account CCTP requires AND the
+    ///         fat-finger guard (unlisted domain burns revert instead of
+    ///         producing an unredeemable message).
+    mapping(uint32 => bytes32) public cctpRemoteTokenMessengers;
+
     /// @notice Per-user burn counter used to derive unique message PDAs per tx.
     /// @dev We can't use block.number in the salt — on Rome EVM, block.number
     ///      returns the Solana slot (rome-evm-private/program/src/state/handler.rs
@@ -96,6 +108,8 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     error AmountExceedsUint64(uint256 amount);
     error InsufficientBalance(address user, uint256 requested, uint256 available);
     error CpiFailed(bytes reason);
+    error UnsupportedDestinationDomain(uint32 domain);
+    error DomainConfigLengthMismatch();
     error ZeroRecipient();
 
     // -------------------------------------------------------------------------
@@ -105,11 +119,11 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     /// @notice CCTP-path Solana accounts. Includes all program IDs and PDAs needed
     ///         for the deposit_for_burn CPI. All fields come from the deploy script.
     struct CctpParams {
-        /// @dev CCTP Token Messenger Minter Solana program ID
-        ///      (CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3)
+        /// @dev CCTP **v2** Token Messenger Minter Solana program ID
+        ///      (CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe)
         bytes32 tokenMessengerProgram;
-        /// @dev CCTP Message Transmitter Solana program ID
-        ///      (CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd)
+        /// @dev CCTP **v2** Message Transmitter Solana program ID
+        ///      (CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC)
         bytes32 messageTransmitterProgram;
         /// @dev SPL Token program ID (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
         bytes32 splTokenProgram;
@@ -118,9 +132,13 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         // PDAs — derived per-deployment in Phase 1.5
         bytes32 messageTransmitterConfig;
         bytes32 tokenMessengerConfig;
-        bytes32 remoteTokenMessenger;
         bytes32 tokenMinter;
         bytes32 localTokenUsdc;
+        /// @dev Destination allowlist, parallel arrays: Circle domain ids and
+        ///      their ["remote_token_messenger", dec(domain)] PDAs under the
+        ///      v2 TMM. Derived by the deploy script per network.
+        uint32[] domains;
+        bytes32[] remoteTokenMessengers;
         /// @dev ["sender_authority"] PDA under Token Messenger Minter program
         bytes32 senderAuthorityPda;
         /// @dev TMM's __event_authority — for outer event_cpi
@@ -181,8 +199,13 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         cctpSystemProgram             = cctp.systemProgram;
         cctpMessageTransmitterConfig  = cctp.messageTransmitterConfig;
         cctpTokenMessengerConfig      = cctp.tokenMessengerConfig;
-        cctpRemoteTokenMessenger      = cctp.remoteTokenMessenger;
         cctpTokenMinter               = cctp.tokenMinter;
+        if (cctp.domains.length != cctp.remoteTokenMessengers.length) {
+            revert DomainConfigLengthMismatch();
+        }
+        for (uint256 i = 0; i < cctp.domains.length; i++) {
+            cctpRemoteTokenMessengers[cctp.domains[i]] = cctp.remoteTokenMessengers[i];
+        }
         cctpLocalTokenUsdc            = cctp.localTokenUsdc;
         cctpSenderAuthorityPda        = cctp.senderAuthorityPda;
         cctpEventAuthority            = cctp.eventAuthority;
@@ -210,11 +233,35 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     // CCTP path — path=0
     // -------------------------------------------------------------------------
 
-    /// @notice Burns wUSDC on the Rome EVM and initiates a CCTP deposit_for_burn
-    ///         CPI on Solana, bridging funds to `ethereumRecipient` on Ethereum.
-    /// @param amount           Token amount in SPL decimals (must fit uint64).
-    /// @param ethereumRecipient Destination address on Ethereum.
+    /// @notice Back-compat overload: burns to the Ethereum-family domain (0).
+    ///         Same ABI rome-ui's live hook calls today; routes through the
+    ///         v2 path like every other destination.
     function burnUSDC(uint256 amount, address ethereumRecipient) external {
+        _burnUSDC(amount, ethereumRecipient, 0);
+    }
+
+    /// @notice Burns wUSDC on the Rome EVM and initiates a CCTP **v2**
+    ///         deposit_for_burn CPI on Solana, bridging to `recipient` on the
+    ///         EVM chain identified by `destinationDomain` (Circle domain id:
+    ///         Ethereum/Sepolia 0, Avalanche 1, Arbitrum 3, Base 6, Polygon 7,
+    ///         Monad 15). The domain must be in the constructor allowlist.
+    /// @param amount            Token amount in SPL decimals (must fit uint64).
+    /// @param recipient         Destination address on the target EVM chain.
+    /// @param destinationDomain Circle CCTP domain of the destination chain.
+    function burnUSDC(uint256 amount, address recipient, uint32 destinationDomain) external {
+        _burnUSDC(amount, recipient, destinationDomain);
+    }
+
+    function _burnUSDC(uint256 amount, address ethereumRecipient, uint32 destinationDomain) internal {
+        // Ordered before any balance/precompile touch so both guards are
+        // exact-revert-testable on a simulated EVM (no Rome precompiles).
+        bytes32 remoteTokenMessenger = cctpRemoteTokenMessengers[destinationDomain];
+        if (remoteTokenMessenger == bytes32(0)) {
+            revert UnsupportedDestinationDomain(destinationDomain);
+        }
+        if (ethereumRecipient == address(0)) {
+            revert ZeroRecipient();
+        }
         if (amount > type(uint64).max) {
             revert AmountExceedsUint64(amount);
         }
@@ -255,22 +302,41 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         bytes32 cctpSalt = keccak256(abi.encodePacked("CCTP_MSG", address(this), nonce));
         bytes32 messageSentEventData = RomeEVMAccount.pda_with_salt(user, cctpSalt);
 
-        bytes memory ixData = CCTPLib.encodeDepositForBurn(CCTPLib.DepositForBurnParams({
-            amount:            uint64(amount),
-            destinationDomain: CCTPLib.DOMAIN_ETHEREUM,
-            mintRecipient:     bytes32(uint256(uint160(ethereumRecipient)))
+        bytes memory ixData = CCTPV2Lib.encodeDepositForBurn(CCTPV2Lib.DepositForBurnParams({
+            amount:              uint64(amount),
+            destinationDomain:   destinationDomain,
+            mintRecipient:       bytes32(uint256(uint160(ethereumRecipient))),
+            // bytes32(0) = permissionless delivery — anyone (incl. the user
+            // via Circle's portal) can submit the destination mint; matches
+            // the inbound leg's choice and keeps stuck-transfer rescue open.
+            destinationCaller:   bytes32(0),
+            // Standard finality is free per Circle's fee schedule; the fast
+            // tier (1000) costs bps. maxFee=0 makes any fee-charging path
+            // revert rather than silently shave the user's amount.
+            maxFee:              0,
+            minFinalityThreshold: CCTPV2Lib.MIN_FINALITY_STANDARD
         }));
 
+        // v2-only account: per-owner denylist PDA
+        // (["denylist_account", owner] under the v2 TMM). Derived at runtime
+        // — one find_program_address round-trip (~115K CU); can't be a
+        // constructor param because it's per-user.
+        ISystemProgram.Seed[] memory denylistSeeds = new ISystemProgram.Seed[](2);
+        denylistSeeds[0] = ISystemProgram.Seed(bytes("denylist_account"));
+        denylistSeeds[1] = ISystemProgram.Seed(abi.encodePacked(userPda));
+        (bytes32 denylistAccount, ) = PdaDeriver.derive(cctpTokenMessengerProgram, denylistSeeds);
+
         ICrossProgramInvocation.AccountMeta[] memory metas =
-            CCTPLib.buildDepositForBurnAccounts(
-                CCTPLib.DepositForBurnAccounts({
+            CCTPV2Lib.buildDepositForBurnAccounts(
+                CCTPV2Lib.DepositForBurnAccounts({
                     owner:                       userPda,
                     eventRentPayer:              userPda,  // unified PDA — replaces PAYER_PDA
                     senderAuthorityPda:          cctpSenderAuthorityPda,
                     burnTokenAccount:            userAta,
+                    denylistAccount:             denylistAccount,
                     messageTransmitter:          cctpMessageTransmitterConfig,
                     tokenMessenger:              cctpTokenMessengerConfig,
-                    remoteTokenMessenger:        cctpRemoteTokenMessenger,
+                    remoteTokenMessenger:        remoteTokenMessenger,
                     tokenMinter:                 cctpTokenMinter,
                     localToken:                  cctpLocalTokenUsdc,
                     burnTokenMint:               usdcMint,
@@ -306,7 +372,10 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         );
         if (!ok) revert CpiFailed(result);
 
+        // Legacy event kept byte-compatible for existing indexers; the
+        // domain-carrying variant is the multi-destination source of truth.
         emit Withdrawn(user, usdcMint, amount, ethereumRecipient, 0);
+        emit WithdrawnToDomain(user, usdcMint, amount, ethereumRecipient, 0, destinationDomain);
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/bridge/test/CCTPV2LibHarness.sol
+++ b/contracts/bridge/test/CCTPV2LibHarness.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {CCTPV2Lib} from "../ICCTPV2.sol";
+import {ICrossProgramInvocation} from "../../interface.sol";
+
+/// @notice Test harness exposing CCTPV2Lib internals for network-independent
+///         unit tests (same pattern as contracts/oracle/test harnesses).
+contract CCTPV2LibHarness {
+    function encode(
+        uint64 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        bytes32 destinationCaller,
+        uint64 maxFee,
+        uint32 minFinalityThreshold
+    ) external pure returns (bytes memory) {
+        return CCTPV2Lib.encodeDepositForBurn(CCTPV2Lib.DepositForBurnParams({
+            amount: amount,
+            destinationDomain: destinationDomain,
+            mintRecipient: mintRecipient,
+            destinationCaller: destinationCaller,
+            maxFee: maxFee,
+            minFinalityThreshold: minFinalityThreshold
+        }));
+    }
+
+    function build(CCTPV2Lib.DepositForBurnAccounts memory a)
+        external
+        pure
+        returns (ICrossProgramInvocation.AccountMeta[] memory)
+    {
+        return CCTPV2Lib.buildDepositForBurnAccounts(a);
+    }
+}

--- a/scripts/bridge/constants.ts
+++ b/scripts/bridge/constants.ts
@@ -8,6 +8,11 @@ export const SOLANA_PROGRAM_IDS = {
   WORMHOLE_TOKEN_BRIDGE: "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb",
   // CCTP Message Transmitter (burns/mints USDC cross-chain messages)
   CCTP_MESSAGE_TRANSMITTER: "CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd",
+  /** CCTP **v2** Token Messenger Minter — deterministic, SAME id on devnet
+   *  and mainnet (unlike most Circle v1 ids). v6 bridge burns route here. */
+  CCTP_V2_TOKEN_MESSENGER: "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe",
+  /** CCTP **v2** Message Transmitter — deterministic, same both clusters. */
+  CCTP_V2_MESSAGE_TRANSMITTER: "CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC",
   // CCTP Token Messenger (initiates depositForBurn and receiveMessage flows)
   CCTP_TOKEN_MESSENGER: "CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3",
   // CCTP Token Minter (mints/burns USDC under Token Messenger authority)
@@ -88,3 +93,15 @@ export const WORMHOLE_DISCRIMINATORS = {
 } as const;
 
 export type SolanaProgramKey = keyof typeof SOLANA_PROGRAM_IDS;
+
+
+/**
+ * CCTP v2 destination-domain allowlist per Solana cluster, deployed into
+ * RomeBridgeWithdraw v6's constructor (domain -> remote_token_messenger).
+ * Devnet (testnet destinations): Ethereum-family/Sepolia 0, Avalanche Fuji 1,
+ * Arbitrum Sepolia 3, Base Sepolia 6, Polygon Amoy 7, Monad Testnet 15 —
+ * all six verified live on Circle's sandbox attester (2026-07-04).
+ * Mainnet list stays conservative until a mainnet bridge chain exists.
+ */
+export const CCTP_V2_DOMAINS_DEVNET: number[] = [0, 1, 3, 6, 7, 15];
+export const CCTP_V2_DOMAINS_MAINNET: number[] = [0];

--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -57,14 +57,19 @@ function programIdsFor(networkName: string) {
 // Cluster-aware UNIVERSAL block. Wormhole Token Bridge / Core program IDs
 // vary per cluster; CCTP and SPL Token / System Program are identical
 // across clusters.
-function universalFor(networkName: string) {
+export function universalFor(networkName: string) {
   const ids = programIdsFor(networkName);
   return {
     splTokenProgram:             base58ToBytes32(ids.SPL_TOKEN),
     systemProgram:               base58ToBytes32(ids.SYSTEM_PROGRAM),
     wormholeTokenBridgeProgram:  base58ToBytes32(ids.WORMHOLE_TOKEN_BRIDGE),
-    cctpTokenMessengerProgram:   base58ToBytes32(ids.CCTP_TOKEN_MESSENGER),
-    cctpMessageTransmitterProgram: base58ToBytes32(ids.CCTP_MESSAGE_TRANSMITTER),
+    // v6: the CPI target MUST be the CCTP v2 programs — the constructor's
+    // config PDAs, the instruction data, and the account list are all v2
+    // (derive/cctp-accounts.ts). Wiring the v1 ids here (the pre-v6 default)
+    // makes every burnUSDC revert at the v2 program's owner/seed validation
+    // — fund-safe but 100% non-functional (audit C1, rome-solidity #264).
+    cctpTokenMessengerProgram:     base58ToBytes32(ids.CCTP_V2_TOKEN_MESSENGER),
+    cctpMessageTransmitterProgram: base58ToBytes32(ids.CCTP_V2_MESSAGE_TRANSMITTER),
     wormholeCoreProgram:         base58ToBytes32(ids.WORMHOLE_CORE),
     clockSysvar: base58ToBytes32("SysvarC1ock11111111111111111111111111111111"),
     rentSysvar:  base58ToBytes32("SysvarRent111111111111111111111111111111111"),
@@ -79,9 +84,12 @@ interface SolanaPdaAccounts {
   // CCTP PDAs
   cctpMessageTransmitterConfig: `0x${string}`;
   cctpTokenMessengerConfig:     `0x${string}`;
-  cctpRemoteTokenMessenger:     `0x${string}`;
   cctpTokenMinter:              `0x${string}`;
   cctpLocalTokenUsdc:           `0x${string}`;
+  // v6 multi-destination allowlist (parallel arrays) — replaces the singular
+  // v1 cctpRemoteTokenMessenger.
+  cctpDomains:                  number[];
+  cctpRemoteTokenMessengers:    `0x${string}`[];
   cctpSenderAuthorityPda:       `0x${string}`;
   cctpEventAuthority:           `0x${string}`;
   cctpMessageTransmitterEventAuthority: `0x${string}`;

--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -33,6 +33,7 @@ import { readDeployments, writeDeployments } from "../lib/deployments.js";
 import { base58ToBytes32 } from "../lib/pubkey.js";
 import { SOLANA_PROGRAM_IDS, SOLANA_PROGRAM_IDS_DEVNET } from "./constants.js";
 import { deriveCctpAccounts } from "./derive/cctp-accounts.js";
+import { CCTP_V2_DOMAINS_DEVNET, CCTP_V2_DOMAINS_MAINNET } from "./constants.js";
 import { deriveWormholeAccounts } from "./derive/wormhole-accounts.js";
 
 // CPI precompile at 0xff..08 as defined in contracts/interface.sol.
@@ -106,7 +107,10 @@ function loadSolanaPdas(usdcMintBase58: string, wethMintBase58: string, networkN
   const wethMint = new PublicKey(wethMintBase58);
   const ids = programIdsFor(networkName);
   return {
-    ...deriveCctpAccounts(usdcMint),
+    ...deriveCctpAccounts(
+      usdcMint,
+      SOLANA_DEVNET_NETWORKS.has(networkName) ? CCTP_V2_DOMAINS_DEVNET : CCTP_V2_DOMAINS_MAINNET,
+    ),
     ...deriveWormholeAccounts(wethMint, {
       tokenBridgeProgramId: ids.WORMHOLE_TOKEN_BRIDGE,
       coreProgramId:        ids.WORMHOLE_CORE,
@@ -175,9 +179,10 @@ export async function deployWithdraw(
     systemProgram:             UNIVERSAL.systemProgram,
     messageTransmitterConfig:  pdas.cctpMessageTransmitterConfig,
     tokenMessengerConfig:      pdas.cctpTokenMessengerConfig,
-    remoteTokenMessenger:      pdas.cctpRemoteTokenMessenger,
     tokenMinter:               pdas.cctpTokenMinter,
     localTokenUsdc:            pdas.cctpLocalTokenUsdc,
+    domains:                   pdas.cctpDomains,
+    remoteTokenMessengers:     pdas.cctpRemoteTokenMessengers,
     senderAuthorityPda:        pdas.cctpSenderAuthorityPda,
     eventAuthority:            pdas.cctpEventAuthority,
     messageTransmitterEventAuthority: pdas.cctpMessageTransmitterEventAuthority,

--- a/scripts/bridge/derive/cctp-accounts.ts
+++ b/scripts/bridge/derive/cctp-accounts.ts
@@ -23,8 +23,11 @@ import { PublicKey } from "@solana/web3.js";
 import { base58ToBytes32 } from "../../lib/pubkey.js";
 import { SOLANA_PROGRAM_IDS } from "../constants.js";
 
-const CCTP_TOKEN_MESSENGER_ID = new PublicKey(SOLANA_PROGRAM_IDS.CCTP_TOKEN_MESSENGER);
-const CCTP_MESSAGE_TRANSMITTER_ID = new PublicKey(SOLANA_PROGRAM_IDS.CCTP_MESSAGE_TRANSMITTER);
+// v6: CCTP **v2** programs. Seeds are IDENTICAL to v1 (validated 20/20
+// against a landed v2 receive by rome-ui's probe template-check); only the
+// program ids differ. v2 is required for v2-only destinations (Monad = 15).
+const CCTP_TOKEN_MESSENGER_ID = new PublicKey(SOLANA_PROGRAM_IDS.CCTP_V2_TOKEN_MESSENGER);
+const CCTP_MESSAGE_TRANSMITTER_ID = new PublicKey(SOLANA_PROGRAM_IDS.CCTP_V2_MESSAGE_TRANSMITTER);
 
 function pda(seeds: (Buffer | Uint8Array)[], programId: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(seeds, programId)[0];
@@ -39,7 +42,9 @@ function u32Le(n: number): Buffer {
 export interface CctpPdas {
   cctpMessageTransmitterConfig: `0x${string}`;
   cctpTokenMessengerConfig: `0x${string}`;
-  cctpRemoteTokenMessenger: `0x${string}`;
+  /** Destination allowlist, parallel arrays (v6 multi-destination). */
+  cctpDomains: number[];
+  cctpRemoteTokenMessengers: `0x${string}`[];
   cctpTokenMinter: `0x${string}`;
   cctpLocalTokenUsdc: `0x${string}`;
   cctpSenderAuthorityPda: `0x${string}`;
@@ -47,7 +52,7 @@ export interface CctpPdas {
   cctpMessageTransmitterEventAuthority: `0x${string}`;
 }
 
-export function deriveCctpAccounts(usdcMint: PublicKey): CctpPdas {
+export function deriveCctpAccounts(usdcMint: PublicKey, domains: number[]): CctpPdas {
   const messageTransmitterConfig = pda(
     [Buffer.from("message_transmitter")],
     CCTP_MESSAGE_TRANSMITTER_ID
@@ -57,12 +62,14 @@ export function deriveCctpAccounts(usdcMint: PublicKey): CctpPdas {
     CCTP_TOKEN_MESSENGER_ID
   );
   // NB: Circle CCTP seed encoding — domain is the ASCII STRING form of the
-  // destination domain number, not a LE u32. "0" for Ethereum. Verified against
-  // the circlefin/solana-cctp-contracts source:
+  // destination domain number, not a LE u32 ("0", "15", …). Verified against
+  // the circlefin/solana-cctp-contracts source AND a landed v2 burn:
   //   seeds = [b"remote_token_messenger", destination_domain.to_string().as_bytes()]
-  const remoteTokenMessenger = pda(
-    [Buffer.from("remote_token_messenger"), Buffer.from("0")],
-    CCTP_TOKEN_MESSENGER_ID
+  const remoteTokenMessengers = domains.map((d) =>
+    pda(
+      [Buffer.from("remote_token_messenger"), Buffer.from(String(d))],
+      CCTP_TOKEN_MESSENGER_ID
+    )
   );
   const tokenMinter = pda([Buffer.from("token_minter")], CCTP_TOKEN_MESSENGER_ID);
   const localTokenUsdc = pda(
@@ -88,7 +95,8 @@ export function deriveCctpAccounts(usdcMint: PublicKey): CctpPdas {
   return {
     cctpMessageTransmitterConfig: base58ToBytes32(messageTransmitterConfig.toBase58()),
     cctpTokenMessengerConfig: base58ToBytes32(tokenMessengerConfig.toBase58()),
-    cctpRemoteTokenMessenger: base58ToBytes32(remoteTokenMessenger.toBase58()),
+    cctpDomains: domains,
+    cctpRemoteTokenMessengers: remoteTokenMessengers.map((r) => base58ToBytes32(r.toBase58())),
     cctpTokenMinter: base58ToBytes32(tokenMinter.toBase58()),
     cctpLocalTokenUsdc: base58ToBytes32(localTokenUsdc.toBase58()),
     cctpSenderAuthorityPda: base58ToBytes32(senderAuthorityPda.toBase58()),

--- a/tests/bridge/RomeBridgeWithdraw.test.ts
+++ b/tests/bridge/RomeBridgeWithdraw.test.ts
@@ -67,7 +67,11 @@ describe("RomeBridgeWithdraw — error paths", () => {
         systemProgram: ZERO_BYTES32,
         messageTransmitterConfig: ZERO_BYTES32,
         tokenMessengerConfig: ZERO_BYTES32,
-        remoteTokenMessenger: ZERO_BYTES32,
+        // v6: per-destination allowlist replaces the single remote. Domain 0
+        // listed so the legacy 2-arg burnUSDC path (routes to domain 0)
+        // reaches the amount/balance guards these tests exercise.
+        domains: [0],
+        remoteTokenMessengers: ["0x" + "aa".repeat(32)],
         tokenMinter: ZERO_BYTES32,
         localTokenUsdc: ZERO_BYTES32,
         senderAuthorityPda: ZERO_BYTES32,

--- a/tests/bridge/cctp_v2_lib.test.ts
+++ b/tests/bridge/cctp_v2_lib.test.ts
@@ -1,0 +1,122 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import bs58 from "bs58";
+
+/**
+ * CCTPV2Lib unit tests — network-independent (hardhat simulated EVM).
+ *
+ * Ground truth is a LANDED Solana-devnet CCTP v2 deposit_for_burn
+ * (tx 4L4D7Qo7DNFfdGXY4AhYYiFfbdhxwSZruteaxVTUaSkXBpVrNBoyTmU47mZSuo6YUwNUWQNqneks9QWcyzNbLoPY,
+ * inner ix on CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe): the encode test
+ * asserts byte-for-byte against that tx's instruction data, and the account
+ * test against its account ordering — not against offsets we derived.
+ */
+
+// The landed instruction data (base58, 96 bytes decoded).
+const LANDED_IX_DATA_B58 =
+  "2H9Ja8XuEQY8ycNjJZ4xK1QjEjiR9QzTodq9C2WbB282pgdjxpiiMi7cj1BimHrQfdeUw2ywFgkZhNxFKZV4Xs8WMPu6KFRuUrCVoaFMikqntxjXrPZkNWGsp3Tr9ZbazEE3";
+// Its decoded fields (verified 2026-07-04): amount=9002533, destDomain=0,
+// mintRecipient=EVM 0x6fb09783940b0e9a313531bd5c7e81810a70f919 (left-padded),
+// destCaller=0, maxFee=0, minFinality=2000.
+const LANDED = {
+  amount: 9002533n,
+  destDomain: 0,
+  mintRecipient:
+    "0x0000000000000000000000006fb09783940b0e9a313531bd5c7e81810a70f919",
+  destCaller: "0x" + "00".repeat(32),
+  maxFee: 0n,
+  minFinality: 2000,
+};
+
+const b58ToHex = (s: string) => ("0x" + Buffer.from(bs58.decode(s)).toString("hex")) as `0x${string}`;
+
+// Landed outer account list for the same instruction, in order.
+const LANDED_ACCOUNTS = [
+  "HMHYnCqtHDztNDfSX2EXi4aU1sqX2b4iRdBF3ZBUShmX", // 0 owner (signer, writable)
+  "HMHYnCqtHDztNDfSX2EXi4aU1sqX2b4iRdBF3ZBUShmX", // 1 event_rent_payer (signer, writable)
+  "45hzrGLQ2EGo1Ln7QpXjDwb589GDQ9H2aEXXw6ds6BFE", // 2 sender_authority_pda
+  "4KMJDFRjjfn1tdLtAEsYMMM43EAQyTHodvzBk6JaXBtS", // 3 burn_token_account (writable)
+  "8HSsasTtHT3zwjmwU8HcnFhgPm8KoLA4UmF98RLo1wQv", // 4 denylist_account (v2-only, per-owner PDA)
+  "W1k5ijkaSTo5iA5zChNpfzcy796fLhkBxfmJuR8W8HU",  // 5 message_transmitter (writable)
+  "AawthJCGRmggpfv9MMWV6Jmo9cue4gL9wUZgRBShg58W", // 6 token_messenger
+  "3EzN2mcmdfSNGXRCAixSpTteK6ywdmFDZZWvkMnznFt9", // 7 remote_token_messenger (PER destination domain)
+  "E1bQJ8eMMn3zmeSewW3HQ8zmJr7KR75JonbwAtWx2bux", // 8 token_minter (writable)
+  "7MwmWTK2R9Na6rnoSAEt5gytFmSZj9WLVdazvxvru9AU", // 9 local_token (writable)
+  "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", // 10 burn_token_mint (writable)
+  "Gx45kV7rcvCYXaFqmUwVca2aaxFcZat3TuMn4fGmrbgp", // 11 message_sent_event_data (signer, writable)
+  "CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC", // 12 message_transmitter_program
+  "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe", // 13 token_messenger_minter_program
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",  // 14 token_program
+  "11111111111111111111111111111111",             // 15 system_program
+  "6TCCnJ9R1m1RXFzyoH7GYH2J6NJDtZaUvfipPuLWxHNd", // 16 event_authority (TMM __event_authority)
+  "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe", // 17 program
+];
+// 18 (trailing, NOT in the landed native tx): MessageTransmitter v2's
+// __event_authority — the Rome-emulator ix_store workaround inherited from
+// v1 (see CCTPLib struct comment). Harmless on-chain (trailing accounts
+// ignored by Anchor), required for Mollusk inner-CPI account resolution.
+const MT_V2_EVENT_AUTHORITY = "2PcXTomVAbX5Es1NUZUkxwuCm8tvV4NmRk3fmQWFCWoV";
+
+const pk = (b58: string) => ("0x" + Buffer.from(bs58.decode(b58)).toString("hex")) as `0x${string}`;
+
+describe("CCTPV2Lib", function () {
+  let harness: any;
+
+  before(async function () {
+    const { viem } = await hardhat.network.connect();
+    harness = await viem.deployContract("CCTPV2LibHarness", []);
+  });
+
+  it("encodeDepositForBurn reproduces the landed devnet v2 instruction byte-for-byte", async function () {
+    const out = await harness.read.encode([
+      LANDED.amount,
+      LANDED.destDomain,
+      LANDED.mintRecipient,
+      LANDED.destCaller,
+      LANDED.maxFee,
+      LANDED.minFinality,
+    ]);
+    assert.equal(out.toLowerCase(), b58ToHex(LANDED_IX_DATA_B58).toLowerCase());
+  });
+
+  it("buildDepositForBurnAccounts reproduces the landed ordering + the emulator trailing meta", async function () {
+    const a = {
+      owner: pk(LANDED_ACCOUNTS[0]),
+      eventRentPayer: pk(LANDED_ACCOUNTS[1]),
+      senderAuthorityPda: pk(LANDED_ACCOUNTS[2]),
+      burnTokenAccount: pk(LANDED_ACCOUNTS[3]),
+      denylistAccount: pk(LANDED_ACCOUNTS[4]),
+      messageTransmitter: pk(LANDED_ACCOUNTS[5]),
+      tokenMessenger: pk(LANDED_ACCOUNTS[6]),
+      remoteTokenMessenger: pk(LANDED_ACCOUNTS[7]),
+      tokenMinter: pk(LANDED_ACCOUNTS[8]),
+      localToken: pk(LANDED_ACCOUNTS[9]),
+      burnTokenMint: pk(LANDED_ACCOUNTS[10]),
+      messageSentEventData: pk(LANDED_ACCOUNTS[11]),
+      messageTransmitterProgram: pk(LANDED_ACCOUNTS[12]),
+      tokenMessengerMinterProgram: pk(LANDED_ACCOUNTS[13]),
+      tokenProgram: pk(LANDED_ACCOUNTS[14]),
+      systemProgram: pk(LANDED_ACCOUNTS[15]),
+      eventAuthority: pk(LANDED_ACCOUNTS[16]),
+      program: pk(LANDED_ACCOUNTS[17]),
+      messageTransmitterEventAuthority: pk(MT_V2_EVENT_AUTHORITY),
+    };
+    const metas = await harness.read.build([a]);
+    assert.equal(metas.length, 19);
+    for (let i = 0; i < 18; i++) {
+      assert.equal(
+        metas[i].pubkey.toLowerCase(),
+        pk(LANDED_ACCOUNTS[i]).toLowerCase(),
+        `account[${i}] mismatch`,
+      );
+    }
+    assert.equal(metas[18].pubkey.toLowerCase(), pk(MT_V2_EVENT_AUTHORITY).toLowerCase());
+    // Flag spot-checks: signers are owner, event_rent_payer, message_sent_event_data.
+    const signers = metas.map((m: any, i: number) => (m.is_signer ? i : -1)).filter((i: number) => i >= 0);
+    assert.deepEqual(signers, [0, 1, 11]);
+    // denylist is read-only; message_transmitter config is writable (v2 keeps v1's flag).
+    assert.equal(metas[4].is_writable, false);
+    assert.equal(metas[5].is_writable, true);
+  });
+});

--- a/tests/bridge/derive.test.ts
+++ b/tests/bridge/derive.test.ts
@@ -92,3 +92,22 @@ describe("Bridge PDA derivations", () => {
     assert.strictEqual(unique.size, values.length, "Wormhole PDAs must all be distinct");
   });
 });
+
+describe("deploy wiring — CPI target must be the v2 programs (audit C1)", () => {
+  it("universalFor returns the CCTP v2 program ids for the constructor fields", async () => {
+    const { universalFor } = await import("../../scripts/bridge/deploy.js");
+    const { SOLANA_PROGRAM_IDS } = await import("../../scripts/bridge/constants.js");
+    for (const net of ["hadrian", "nerva"]) {
+      const u = universalFor(net);
+      assert.strictEqual(
+        u.cctpTokenMessengerProgram,
+        base58ToBytes32(SOLANA_PROGRAM_IDS.CCTP_V2_TOKEN_MESSENGER),
+        `${net}: constructor must target the v2 TMM (v1 target = every burn reverts)`,
+      );
+      assert.strictEqual(
+        u.cctpMessageTransmitterProgram,
+        base58ToBytes32(SOLANA_PROGRAM_IDS.CCTP_V2_MESSAGE_TRANSMITTER),
+      );
+    }
+  });
+});

--- a/tests/bridge/derive.test.ts
+++ b/tests/bridge/derive.test.ts
@@ -16,24 +16,39 @@ import { PublicKey } from "@solana/web3.js";
 import { deriveCctpAccounts } from "../../scripts/bridge/derive/cctp-accounts.js";
 import { deriveWormholeAccounts } from "../../scripts/bridge/derive/wormhole-accounts.js";
 import { SPL_MINTS } from "../../scripts/bridge/constants.js";
+import { base58ToBytes32 } from "../../scripts/lib/pubkey.js";
 
 const BYTES32_RE = /^0x[0-9a-fA-F]{64}$/;
 
 describe("Bridge PDA derivations", () => {
-  it("deriveCctpAccounts returns 8 well-formed bytes32 values", () => {
-    // 7 original CCTP PDAs (messageTransmitterConfig, tokenMessengerConfig,
-    // remoteTokenMessenger, tokenMinter, localTokenUsdc, senderAuthorityPda,
-    // eventAuthority) + the 18th-meta workaround
-    // (cctpMessageTransmitterEventAuthority — MessageTransmitter's own
-    // __event_authority PDA, required by post-#266 Mollusk emulator's
-    // ix_store filter for the inner send_message_with_caller CPI).
+  it("deriveCctpAccounts (v2) reproduces the LANDED devnet v2 config accounts", () => {
+    // Ground truth = the account list of a landed devnet v2 deposit_for_burn
+    // (4L4D7Qo7…) + a landed v2 receive (3KsdvCJr…). Not derived offsets —
+    // real on-chain pubkeys.
     const usdcMint = new PublicKey(SPL_MINTS.USDC_NATIVE);
-    const pdas = deriveCctpAccounts(usdcMint);
-    const keys = Object.keys(pdas);
-    assert.strictEqual(keys.length, 8);
-    for (const [, value] of Object.entries(pdas)) {
-      assert.match(value, BYTES32_RE, `Expected bytes32 hex, got: ${value}`);
+    const pdas = deriveCctpAccounts(usdcMint, [0, 15]);
+    const expect58 = {
+      cctpMessageTransmitterConfig: "W1k5ijkaSTo5iA5zChNpfzcy796fLhkBxfmJuR8W8HU",
+      cctpTokenMessengerConfig: "AawthJCGRmggpfv9MMWV6Jmo9cue4gL9wUZgRBShg58W",
+      cctpTokenMinter: "E1bQJ8eMMn3zmeSewW3HQ8zmJr7KR75JonbwAtWx2bux",
+      cctpLocalTokenUsdc: "7MwmWTK2R9Na6rnoSAEt5gytFmSZj9WLVdazvxvru9AU",
+      cctpSenderAuthorityPda: "45hzrGLQ2EGo1Ln7QpXjDwb589GDQ9H2aEXXw6ds6BFE",
+      cctpEventAuthority: "6TCCnJ9R1m1RXFzyoH7GYH2J6NJDtZaUvfipPuLWxHNd",
+      cctpMessageTransmitterEventAuthority: "2PcXTomVAbX5Es1NUZUkxwuCm8tvV4NmRk3fmQWFCWoV",
+    } as const;
+    for (const [k, v] of Object.entries(expect58)) {
+      assert.strictEqual((pdas as any)[k], base58ToBytes32(v), k);
     }
+    assert.deepStrictEqual(pdas.cctpDomains, [0, 15]);
+    assert.strictEqual(pdas.cctpRemoteTokenMessengers.length, 2);
+    // Domain 0's remote_token_messenger from the landed burn:
+    assert.strictEqual(
+      pdas.cctpRemoteTokenMessengers[0],
+      base58ToBytes32("3EzN2mcmdfSNGXRCAixSpTteK6ywdmFDZZWvkMnznFt9"),
+    );
+    // Domain 15 (Monad) derives to a distinct, well-formed PDA.
+    assert.match(pdas.cctpRemoteTokenMessengers[1], BYTES32_RE);
+    assert.notStrictEqual(pdas.cctpRemoteTokenMessengers[1], pdas.cctpRemoteTokenMessengers[0]);
   });
 
   it("deriveWormholeAccounts returns 9 well-formed bytes32 values", () => {
@@ -48,8 +63,8 @@ describe("Bridge PDA derivations", () => {
 
   it("CCTP derivations are deterministic", () => {
     const usdcMint = new PublicKey(SPL_MINTS.USDC_NATIVE);
-    const a = deriveCctpAccounts(usdcMint);
-    const b = deriveCctpAccounts(usdcMint);
+    const a = deriveCctpAccounts(usdcMint, [0, 1, 3, 6, 7, 15]);
+    const b = deriveCctpAccounts(usdcMint, [0, 1, 3, 6, 7, 15]);
     assert.deepStrictEqual(a, b);
   });
 
@@ -62,8 +77,9 @@ describe("Bridge PDA derivations", () => {
 
   it("CCTP accounts use distinct PDA addresses", () => {
     const usdcMint = new PublicKey(SPL_MINTS.USDC_NATIVE);
-    const pdas = deriveCctpAccounts(usdcMint);
-    const values = Object.values(pdas);
+    const pdas = deriveCctpAccounts(usdcMint, [0, 1, 3, 6, 7, 15]);
+    const { cctpDomains, cctpRemoteTokenMessengers, ...configs } = pdas;
+    const values = [...Object.values(configs), ...cctpRemoteTokenMessengers];
     const unique = new Set(values);
     assert.strictEqual(unique.size, values.length, "CCTP PDAs must all be distinct");
   });

--- a/tests/bridge/rome_bridge_withdraw_v6.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_v6.test.ts
@@ -1,0 +1,80 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * RomeBridgeWithdraw v6 constructor + guard tests — network-independent.
+ * The domain allowlist and zero-recipient guards fire BEFORE any Rome
+ * precompile touch (deliberately, see _burnUSDC), so their exact reverts
+ * are assertable on the simulated EVM with MockSplErc20 wrappers.
+ */
+
+const ZERO = "0x" + "00".repeat(32);
+const PK = (n: number) => ("0x" + n.toString(16).padStart(2, "0").repeat(32)) as `0x${string}`;
+
+const CCTP = {
+  tokenMessengerProgram: PK(1),
+  messageTransmitterProgram: PK(2),
+  splTokenProgram: PK(3),
+  systemProgram: ZERO,
+  messageTransmitterConfig: PK(4),
+  tokenMessengerConfig: PK(5),
+  tokenMinter: PK(6),
+  localTokenUsdc: PK(7),
+  domains: [0, 15],
+  remoteTokenMessengers: [PK(8), PK(9)],
+  senderAuthorityPda: PK(10),
+  eventAuthority: PK(11),
+  messageTransmitterEventAuthority: PK(12),
+};
+const WH = {
+  tokenBridgeProgram: PK(20), coreProgram: PK(21), splTokenProgram: PK(3),
+  systemProgram: ZERO, clockSysvar: PK(22), rentSysvar: PK(23),
+  config: PK(24), custody: PK(25), authoritySigner: PK(26), custodySigner: PK(27),
+  bridgeConfig: PK(28), feeCollector: PK(29), emitter: PK(30), sequence: PK(31),
+  wrappedMeta: PK(32), targetChain: 10002,
+};
+const FORWARDER = "0x0000000000000000000000000000000000000000";
+
+describe("RomeBridgeWithdraw v6 — domain allowlist", function () {
+  let viem: any;
+  let bridge: any;
+
+  before(async function () {
+    ({ viem } = await hardhat.network.connect());
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    const weth = await viem.deployContract("MockSplErc20", [PK(41)]);
+    bridge = await viem.deployContract("RomeBridgeWithdraw", [
+      FORWARDER, usdc.address, weth.address, CCTP, WH,
+    ]);
+  });
+
+  it("constructor populates the domain → remote_token_messenger allowlist", async function () {
+    assert.equal((await bridge.read.cctpRemoteTokenMessengers([0])).toLowerCase(), PK(8));
+    assert.equal((await bridge.read.cctpRemoteTokenMessengers([15])).toLowerCase(), PK(9));
+    assert.equal(await bridge.read.cctpRemoteTokenMessengers([3]), ZERO);
+  });
+
+  it("burnUSDC to an unlisted domain reverts UnsupportedDestinationDomain", async function () {
+    await assert.rejects(
+      bridge.write.burnUSDC([1000n, "0x1111111111111111111111111111111111111111", 3]),
+      /UnsupportedDestinationDomain/,
+    );
+  });
+
+  it("burnUSDC to the zero recipient reverts ZeroRecipient", async function () {
+    await assert.rejects(
+      bridge.write.burnUSDC([1000n, "0x0000000000000000000000000000000000000000", 15]),
+      /ZeroRecipient/,
+    );
+  });
+
+  it("constructor rejects mismatched allowlist arrays", async function () {
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    const badCctp = { ...CCTP, domains: [0], remoteTokenMessengers: [PK(8), PK(9)] };
+    await assert.rejects(
+      viem.deployContract("RomeBridgeWithdraw", [FORWARDER, usdc.address, usdc.address, badCctp, WH]),
+      /DomainConfigLengthMismatch/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Outbound USDC moves to Circle's **CCTP v2** Solana programs with the **destination domain as a per-call parameter**, gated by a constructor allowlist — one deployed contract serves every destination instead of one per chain.

- `burnUSDC(uint256 amount, address recipient, uint32 destinationDomain)` + ABI-compatible 2-arg overload (→ domain 0, so the live rome-ui hook keeps working unchanged)
- Allowlist = `domains[]/remoteTokenMessengers[]` ctor arrays → mapping; unlisted domain reverts `UnsupportedDestinationDomain` (fat-finger guard doubling as the per-destination account CCTP needs)
- `CCTPV2Lib` (new): v2 encode + 19-meta build — per-owner `denylist_account` PDA derived at runtime, `destination_caller=0` (permissionless delivery/rescue), `max_fee=0` (fee paths revert, never shave), `min_finality=2000` (free tier)
- `WithdrawnToDomain` event alongside legacy `Withdrawn`
- deploy script derives v2 config PDAs + per-domain remotes; devnet domains `[0,1,3,6,7,15]` (Sepolia, Fuji, ArbSep, BaseSep, Amoy, Monad — all six live-verified on Circle's sandbox 2026-07-04)

## Why v2 / why now

Monad (domain 15) is v2-only — v5 is structurally unable to reach it (v1 program has no domain-15 remote registered). This completes the CCTP-v2 migration outbound-side (inbound shipped in rome-ui #697/#698) per the CCTP-first roadmap.

## Ground truth + tests

Encode and account layout are **test-pinned byte-for-byte against a landed devnet v2 deposit_for_burn** (`4L4D7Qo7…`), and the deploy-side PDA derivations against the same landed accounts (`3EzN2mcm…` = remote(0), etc.) — not doc-derived offsets. CI-equivalent suite: **169 passing** (12 new; legacy fixtures updated for the ctor ABI change).

## Before deploy (blocking)

- [ ] Quaestor audit pass (moves user funds)
- [ ] Live simulate + dust burn on Hadrian (validates the two judgment calls: token_minter writable flag; trailing Mollusk meta)
- [ ] `SOLANA_DEVNET_NETWORKS` includes the target network (the v4 lesson)
- [ ] Registry `contracts.json` v6 propagation per the v5 playbook after deploy