### PR TITLE
chore(ci): pre-whitelist v6 bridge test paths for GitGuardian

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -20,6 +20,16 @@ secret:
     # that false positive without disabling the Generic High Entropy
     # detector for the rest of the repo.
     - tests/cpi/SolanaConstants.test.ts
+    # v6 CCTP-v2 bridge tests + PDA-derivation script assert against the
+    # account list + instruction bytes of a LANDED public devnet CCTP v2
+    # deposit_for_burn. Every bs58 string is a public Solana pubkey (program
+    # id / config PDA / ATA / canonical devnet USDC mint) read straight
+    # off-chain — public identifiers, not secrets. Same false-positive class
+    # as SolanaConstants.test.ts ("Generic High Entropy Secret").
+    - tests/bridge/cctp_v2_lib.test.ts
+    - tests/bridge/rome_bridge_withdraw_v6.test.ts
+    - tests/bridge/derive.test.ts
+    - scripts/bridge/derive/cctp-accounts.ts
   ignored_matches:
     # Canonical public Solana program IDs. These are NOT secrets — they are
     # the globally-published program IDs every Solana client must recognize.


### PR DESCRIPTION
GitGuardian reads `ignored_paths` from the **base branch**, so the whitelist for the v6 bridge tests must land on master before #264 can clear its GG check. These files assert byte-for-byte against a **landed public devnet** CCTP v2 `deposit_for_burn` — every flagged bs58 string is a public Solana pubkey (program id / config PDA / ATA / canonical devnet USDC mint), the identical false-positive class already whitelisted for `tests/cpi/SolanaConstants.test.ts`. Config-only; no code. Unblocks https://github.com/rome-protocol/rome-solidity/pull/264.