### PR TITLE
chore(ci): ignore public CCTP v2 program IDs + devnet config PDAs (GitGuardian)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -40,3 +40,19 @@ secret:
       match: ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
     - name: Token-2022 program ID (public)
       match: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+    # CCTP v2 public program IDs — deterministic, globally-published (same on
+    # devnet + mainnet). Recur across v6 bridge contract, constants, tests.
+    - name: CCTP v2 TokenMessengerMinter program ID (public)
+      match: CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe
+    - name: CCTP v2 MessageTransmitter program ID (public)
+      match: CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC
+    # Public CCTP v2 config PDAs on Solana devnet (token_messenger,
+    # token_minter, local_token for the canonical devnet USDC mint). Derived
+    # deterministically from the public program IDs; asserted in derive.test.ts
+    # as ground truth against a landed public deposit_for_burn. Not secrets.
+    - name: CCTP v2 token_messenger config PDA (devnet, public)
+      match: AawthJCGRmggpfv9MMWV6Jmo9cue4gL9wUZgRBShg58W
+    - name: CCTP v2 token_minter PDA (devnet, public)
+      match: E1bQJ8eMMn3zmeSewW3HQ8zmJr7KR75JonbwAtWx2bux
+    - name: CCTP v2 local_token USDC PDA (devnet, public)
+      match: 7MwmWTK2R9Na6rnoSAEt5gytFmSZj9WLVdazvxvru9AU


### PR DESCRIPTION
Value-based `ignored_matches` (the repo's existing mechanism for public Solana program IDs) clearing the v6 bridge false positives on #264: the two CCTP v2 program IDs + three devnet config PDAs — all public, globally-derivable on-chain identifiers, asserted as ground truth in `derive.test.ts`. Config-only. Base-branch config, so must land on master before #264 re-scans clean.