### PR TITLE
deploy(hadrian): RomeBridgeWithdraw v6 receipt (CCTP v2)

### DIFF
--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -87,8 +87,8 @@
     "deployedAt": 1779081498
   },
   "RomeBridgeWithdraw": {
-    "address": "0x99a8b0bda3ef1d829f28405eb9c69986333a50d6",
-    "deployedAt": 1782396258
+    "address": "0x9975fe4b721bf52f2a5bcc795fa2e29edc50de8b",
+    "deployedAt": 1783174480
   },
   "SimpleActivator": {
     "address": "0xc478604d116222190750fe9a52dd3d6ae9140212",


### PR DESCRIPTION
Deploy receipt for v6 (`0x9975fe4b721bf52f2a5bcc795fa2e29edc50de8b`) on Hadrian — rome-solidity #264. Wrappers reused. On-chain verified: v2 program ids wired (C1 fix), 6-domain allowlist, dust burn to Monad (domain 15) landed + Circle v2 attestation complete (950K CU). The prior receipt entry was a stale v4 address. Canonical address propagates via the registry separately; Hadrian's live registry entry stays on the current bridge until the worker's v2 outbound leg (C-CCTP-2) lands (auditor H1).