### PR TITLE
bridge: generic Wormhole burn (asset-agnostic) + v8 allowlist setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2026-07-05 — RomeBridgeWithdraw: generic Wormhole burn (asset-agnostic + per-call target chain)
+
+- `burnToWormhole(address assetWrapper, uint256 amount, bytes32 recipient, uint16 targetChain)`
+  + `approveWormholeBurn(address assetWrapper, uint256 amount)` — generalize the
+  Wormhole outbound burn from ETH-only/Sepolia-only to per-call asset + per-call
+  target chain. Mint + `wrapped_meta` are derived from the wrapper at runtime
+  (replaces the `wethMint`/`wormholeWrappedMeta` immutables); `targetChain`
+  replaces the immutable `wormholeTargetChain`. Added ALONGSIDE the unchanged
+  `burnETH`/`approveBurnETH` — no regression.
+- New `WormholeGenericConfig` constructor param (`{uint16[] targetChains; address[] assetWrappers}`)
+  → fail-closed `wormholeTargetChainAllowed` + `wormholeAssetAllowed` mappings.
+  Unlisted target reverts `UnsupportedTargetChain`; unregistered wrapper reverts
+  `UnsupportedAssetWrapper`. Mirrors `burnUSDC`'s per-domain allowlist model.
+- New event `WormholeBurn(user, assetWrapper, mint, amount, recipient, targetChain)`.
+- Closes inbound⇒outbound symmetry for non-USDC Wormhole assets (LSTs etc.):
+  anything bridged in via Wormhole can now be sent back out.
+- Guard suite test-pinned (`tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts`,
+  8 tests); the happy-path `transfer_wrapped` CPI is validated on-chain (needs a
+  live Rome node, like the other bridge integration tests).
+- Downstream: bridge-api gains a `token-wormhole-outbound` builder targeting this
+  ABI (follow-up); existing `burnETH`/`burnUSDC` callers unaffected.
+
 ## 2026-07-04 — RomeBridgeWithdraw v6: CCTP v2 + per-call destination domain
 
 - `burnUSDC(uint256, address, uint32 destinationDomain)` — outbound USDC to any

--- a/contracts/bridge/RomeBridgeEvents.sol
+++ b/contracts/bridge/RomeBridgeEvents.sol
@@ -47,6 +47,28 @@ interface RomeBridgeEvents {
         bytes32 solanaRecipient
     );
 
+    /// @notice Emitted on a generic (asset-agnostic, multi-destination)
+    ///         Wormhole outbound burn via `burnToWormhole`. The claim on the
+    ///         target chain is Wormhole-native (the user redeems the VAA), so
+    ///         this event is the bridge-api's outbound anchor. Distinct from
+    ///         the ETH-only `Withdrawn(path=1)`: the recipient is a 32-byte
+    ///         value (EVM addr left-padded / Solana pubkey raw) and the
+    ///         destination is a per-call Wormhole chain id.
+    /// @param user         EVM address of the burning user.
+    /// @param assetWrapper Registered SPL_ERC20 wrapper burned.
+    /// @param mint         SPL mint (bytes32 pubkey) of the wrapper.
+    /// @param amount       Token amount (in SPL decimals).
+    /// @param recipient    32-byte recipient on the target chain.
+    /// @param targetChain  Wormhole chain id of the destination.
+    event WormholeBurn(
+        address indexed user,
+        address indexed assetWrapper,
+        bytes32 mint,
+        uint256 amount,
+        bytes32 recipient,
+        uint16 targetChain
+    );
+
     /// @notice Emitted when the paymaster sponsors a user transaction.
     /// @param user            EVM address of the sponsored user.
     /// @param remainingBudget Remaining sponsorship budget after this transaction.

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -102,6 +102,16 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///      within the same tx and unique across txs.
     mapping(address => uint64) public burnNonce;
 
+    /// @notice Generic-Wormhole target-chain allowlist: Wormhole chain id →
+    ///         allowed. Fail-closed — `burnToWormhole` to an unlisted chain
+    ///         reverts. Populated once at construction from deploy config;
+    ///         mirrors `cctpRemoteTokenMessengers`' dual role (config + guard).
+    mapping(uint16 => bool) public wormholeTargetChainAllowed;
+
+    /// @notice Generic-Wormhole asset allowlist: registered SPL_ERC20 wrapper
+    ///         address → allowed. Only registered wrappers can burn to Wormhole.
+    mapping(address => bool) public wormholeAssetAllowed;
+
     // -------------------------------------------------------------------------
     // Errors
     // -------------------------------------------------------------------------
@@ -111,6 +121,8 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     error UnsupportedDestinationDomain(uint32 domain);
     error DomainConfigLengthMismatch();
     error ZeroRecipient();
+    error UnsupportedTargetChain(uint16 targetChain);
+    error UnsupportedAssetWrapper(address assetWrapper);
 
     // -------------------------------------------------------------------------
     // Constructor params structs (avoids stack-too-deep with many constructor args)
@@ -177,6 +189,17 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         uint16 targetChain;       // Wormhole destination chain id: 2 mainnet ETH, 10002 Sepolia
     }
 
+    /// @notice Generic-Wormhole config: per-call target-chain allowlist +
+    ///         registered asset wrappers. Enables asset-agnostic +
+    ///         multi-destination Wormhole egress (`burnToWormhole`), closing
+    ///         the inbound⇒outbound symmetry for non-ETH assets (LSTs etc.).
+    ///         Independent of the legacy ETH-only `burnETH` path (which keeps
+    ///         its own immutables); nothing is allowed unless listed here.
+    struct WormholeGenericConfig {
+        uint16[] targetChains;    // Wormhole chain ids allowed as burnToWormhole destinations
+        address[] assetWrappers;  // SPL_ERC20 wrappers allowed as burnToWormhole assets
+    }
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -185,7 +208,8 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         SPL_ERC20 _usdc,
         SPL_ERC20 _weth,
         CctpParams memory cctp,
-        WormholeParams memory wh
+        WormholeParams memory wh,
+        WormholeGenericConfig memory whg
     ) ERC2771Context(forwarder) {
         usdcWrapper = _usdc;
         wethWrapper = _weth;
@@ -227,6 +251,14 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         wormholeSequence           = wh.sequence;
         wormholeWrappedMeta        = wh.wrappedMeta;
         wormholeTargetChain        = wh.targetChain;
+        // Generic-Wormhole allowlists (asset-agnostic + multi-destination egress).
+        // Fail-closed: only chains/wrappers listed here can burnToWormhole.
+        for (uint256 i = 0; i < whg.targetChains.length; i++) {
+            wormholeTargetChainAllowed[whg.targetChains[i]] = true;
+        }
+        for (uint256 i = 0; i < whg.assetWrappers.length; i++) {
+            wormholeAssetAllowed[whg.assetWrappers[i]] = true;
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -516,6 +548,154 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         if (!ok) revert CpiFailed(result);
 
         emit Withdrawn(user, wethMint, amount, ethereumRecipient, 1);
+    }
+
+    /// @notice Generic (asset-agnostic) counterpart of `approveBurnETH`.
+    ///         Delegates the Wormhole authority_signer PDA as burn delegate on
+    ///         the caller's ATA for `assetWrapper`'s mint. Must precede
+    ///         `burnToWormhole` in a SEPARATE tx (the ~1.4M-CU split, same as
+    ///         approveBurnETH → burnETH).
+    /// @param assetWrapper Registered SPL_ERC20 wrapper for the asset.
+    /// @param amount       Burn allowance to delegate (base units; uint64-bounded).
+    function approveWormholeBurn(address assetWrapper, uint256 amount) external {
+        if (!wormholeAssetAllowed[assetWrapper]) {
+            revert UnsupportedAssetWrapper(assetWrapper);
+        }
+        if (amount > type(uint64).max) {
+            revert AmountExceedsUint64(amount);
+        }
+        SPL_ERC20 wrapper = SPL_ERC20(assetWrapper);
+        bytes32 mint = wrapper.mint_id();
+        uint8 decimals = wrapper.decimals();
+        address user = _msgSender();
+        bytes32 userAta = HelperProgram.ata(user, mint);
+
+        // SPL approve_checked via HelperProgram, delegate = wormholeAuthoritySigner
+        // (raw Solana PDA owned by the Wormhole Token Bridge). Mirrors
+        // approveBurnETH but with the mint/decimals derived from the wrapper
+        // instead of the wethMint/wethDecimals immutables.
+        (bool ok, bytes memory result) = address(HelperProgram).delegatecall(
+            abi.encodeWithSignature(
+                "approve_spl_raw_delegate(bytes32,bytes32,uint64,bytes32,uint8)",
+                userAta,
+                wormholeAuthoritySigner,
+                uint64(amount),
+                mint,
+                decimals
+            )
+        );
+        if (!ok) revert CpiFailed(result);
+    }
+
+    /// @notice Generic (asset-agnostic, multi-destination) Wormhole burn —
+    ///         the per-asset + per-call-target counterpart of `burnETH`.
+    ///         Burns `amount` of the asset behind `assetWrapper` and initiates
+    ///         a Wormhole `transfer_wrapped` CPI to (`targetChain`, `recipient`).
+    ///         The mint + `wrapped_meta` are derived from the wrapper at runtime
+    ///         (replacing the wethMint/wormholeWrappedMeta/wormholeTargetChain
+    ///         immutables). Must be preceded by
+    ///         `approveWormholeBurn(assetWrapper, amount)` in a separate tx.
+    ///         Destination claim is Wormhole-native (user redeems the VAA).
+    /// @param assetWrapper Registered SPL_ERC20 wrapper for the asset.
+    /// @param amount       Token amount in the wrapper's SPL decimals (uint64-bounded).
+    /// @param recipient    32-byte recipient on target chain (EVM addr left-padded; Solana pubkey raw).
+    /// @param targetChain  Wormhole chain id, PER-CALL (must be allowlisted).
+    function burnToWormhole(
+        address assetWrapper,
+        uint256 amount,
+        bytes32 recipient,
+        uint16 targetChain
+    ) external {
+        // Guards ordered BEFORE any Rome precompile touch, so their exact
+        // reverts are assertable on a simulated EVM (parity with _burnUSDC).
+        if (!wormholeAssetAllowed[assetWrapper]) {
+            revert UnsupportedAssetWrapper(assetWrapper);
+        }
+        if (!wormholeTargetChainAllowed[targetChain]) {
+            revert UnsupportedTargetChain(targetChain);
+        }
+        if (recipient == bytes32(0)) {
+            revert ZeroRecipient();
+        }
+        if (amount > type(uint64).max) {
+            revert AmountExceedsUint64(amount);
+        }
+
+        SPL_ERC20 wrapper = SPL_ERC20(assetWrapper);
+        bytes32 mint = wrapper.mint_id();
+        address user = _msgSender();
+        uint256 balance = wrapper.balanceOf(user);
+        if (balance < amount) {
+            revert InsufficientBalance(user, amount, balance);
+        }
+
+        bytes32 userPda = RomeEVMAccount.pda(user);
+        bytes32 userAta = HelperProgram.ata(user, mint);
+
+        // wrapped_meta = ["meta", mint] PDA under the Token Bridge — derived
+        // per-asset at runtime (was the wethMint-specific immutable). Same
+        // runtime-derivation pattern as _burnUSDC's denylist PDA.
+        ISystemProgram.Seed[] memory metaSeeds = new ISystemProgram.Seed[](2);
+        metaSeeds[0] = ISystemProgram.Seed(bytes("meta"));
+        metaSeeds[1] = ISystemProgram.Seed(abi.encodePacked(mint));
+        (bytes32 wrappedMeta, ) = PdaDeriver.derive(wormholeTokenBridgeProgram, metaSeeds);
+
+        // Per-tx Wormhole message account: salted PDA under the user (nonce, not
+        // block.number — unstable across emulation/execution on Rome).
+        uint64 nonce = burnNonce[user];
+        burnNonce[user] = nonce + 1;
+        bytes32 whSalt = keccak256(abi.encodePacked("WH_MSG", address(this), nonce));
+        bytes32 messageAccount = RomeEVMAccount.pda_with_salt(user, whSalt);
+
+        bytes memory ixData = WormholeTokenBridgeLib.encodeTransferTokens(
+            WormholeTokenBridgeLib.TransferParams({
+                amount:        uint64(amount),
+                fee:           0,
+                targetAddress: recipient,
+                targetChain:   targetChain,
+                nonce:         uint32(block.timestamp)
+            })
+        );
+
+        ICrossProgramInvocation.AccountMeta[] memory metas =
+            WormholeTokenBridgeLib.buildTransferWrappedAccounts(
+                WormholeTokenBridgeLib.TransferWrappedAccounts({
+                    payer:            userPda,
+                    config:           wormholeConfig,
+                    from:             userAta,
+                    from_owner:       userPda,
+                    mint:             mint,
+                    wrapped_meta:     wrappedMeta,
+                    authority_signer: wormholeAuthoritySigner,
+                    bridge_config:    wormholeBridgeConfig,
+                    message:          messageAccount,
+                    emitter:          wormholeEmitter,
+                    sequence:         wormholeSequence,
+                    fee_collector:    wormholeFeeCollector,
+                    clock:            whClockSysvar,
+                    rent:             whRentSysvar,
+                    system:           whSystemProgram,
+                    wormhole_core:    wormholeCoreProgram,
+                    token:            whSplTokenProgram,
+                    token_bridge_program: wormholeTokenBridgeProgram
+                })
+            );
+
+        bytes32[] memory salts = new bytes32[](1);
+        salts[0] = whSalt;
+
+        (bool ok, bytes memory result) = address(CpiProgram).delegatecall(
+            abi.encodeWithSignature(
+                "invoke_signed(bytes32,(bytes32,bool,bool)[],bytes,bytes32[])",
+                wormholeTokenBridgeProgram,
+                metas,
+                ixData,
+                salts
+            )
+        );
+        if (!ok) revert CpiFailed(result);
+
+        emit WormholeBurn(user, assetWrapper, mint, amount, recipient, targetChain);
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -112,6 +112,21 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///         address → allowed. Only registered wrappers can burn to Wormhole.
     mapping(address => bool) public wormholeAssetAllowed;
 
+    /// @notice Admin of the Wormhole allowlist setters. Seeded at construction
+    ///         from `WormholeGenericConfig.admin`; transferable (cold-ledger
+    ///         handover, matching this repo's mainnet admin pattern). The ctor
+    ///         allowlist is a SEED — the owner enables further assets/chains on
+    ///         the live contract (no redeploy per addition). Only gates the two
+    ///         allowlist setters + ownership transfer; every value path
+    ///         (burnUSDC/burnETH/burnToWormhole/bridgeOutToSolana) is
+    ///         permissionless and unaffected.
+    address public owner;
+
+    modifier onlyOwner() {
+        if (_msgSender() != owner) revert NotOwner(_msgSender());
+        _;
+    }
+
     // -------------------------------------------------------------------------
     // Errors
     // -------------------------------------------------------------------------
@@ -123,6 +138,15 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     error ZeroRecipient();
     error UnsupportedTargetChain(uint16 targetChain);
     error UnsupportedAssetWrapper(address assetWrapper);
+    error NotOwner(address caller);
+    error ZeroOwner();
+
+    // -------------------------------------------------------------------------
+    // Admin events
+    // -------------------------------------------------------------------------
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event WormholeAssetAllowedSet(address indexed assetWrapper, bool allowed);
+    event WormholeTargetChainAllowedSet(uint16 indexed targetChain, bool allowed);
 
     // -------------------------------------------------------------------------
     // Constructor params structs (avoids stack-too-deep with many constructor args)
@@ -196,6 +220,7 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///         Independent of the legacy ETH-only `burnETH` path (which keeps
     ///         its own immutables); nothing is allowed unless listed here.
     struct WormholeGenericConfig {
+        address admin;            // owner of the post-deploy allowlist setters (see `owner`)
         uint16[] targetChains;    // Wormhole chain ids allowed as burnToWormhole destinations
         address[] assetWrappers;  // SPL_ERC20 wrappers allowed as burnToWormhole assets
     }
@@ -252,13 +277,44 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         wormholeWrappedMeta        = wh.wrappedMeta;
         wormholeTargetChain        = wh.targetChain;
         // Generic-Wormhole allowlists (asset-agnostic + multi-destination egress).
-        // Fail-closed: only chains/wrappers listed here can burnToWormhole.
+        // Fail-closed SEED: only chains/wrappers listed here can burnToWormhole
+        // until `owner` lists more via the setters below.
+        if (whg.admin == address(0)) revert ZeroOwner();
+        owner = whg.admin;
+        emit OwnershipTransferred(address(0), whg.admin);
         for (uint256 i = 0; i < whg.targetChains.length; i++) {
             wormholeTargetChainAllowed[whg.targetChains[i]] = true;
         }
         for (uint256 i = 0; i < whg.assetWrappers.length; i++) {
             wormholeAssetAllowed[whg.assetWrappers[i]] = true;
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin: post-deploy Wormhole allowlist management
+    // -------------------------------------------------------------------------
+
+    /// @notice Enable/disable an SPL_ERC20 wrapper as a `burnToWormhole` asset.
+    ///         Lets the owner add wmSOL / arb / avax (etc.) on the LIVE contract
+    ///         — the reason v8 exists (v7's allowlist was constructor-frozen).
+    function setWormholeAssetAllowed(address assetWrapper, bool allowed) external onlyOwner {
+        wormholeAssetAllowed[assetWrapper] = allowed;
+        emit WormholeAssetAllowedSet(assetWrapper, allowed);
+    }
+
+    /// @notice Enable/disable a Wormhole target chain for `burnToWormhole`
+    ///         (e.g. Arbitrum 23, Avalanche/Fuji 6) without a redeploy.
+    function setWormholeTargetChainAllowed(uint16 targetChain, bool allowed) external onlyOwner {
+        wormholeTargetChainAllowed[targetChain] = allowed;
+        emit WormholeTargetChainAllowedSet(targetChain, allowed);
+    }
+
+    /// @notice Transfer allowlist-admin ownership (cold-ledger handover). Reverts
+    ///         on the zero address so admin can't be accidentally burned.
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroOwner();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/bridge/WORMHOLE_V8_REDEPLOY.md
+++ b/contracts/bridge/WORMHOLE_V8_REDEPLOY.md
@@ -1,0 +1,39 @@
+# RomeBridgeWithdraw v8 — multi-asset / multi-chain Wormhole egress
+
+**Audience:** engineer + operator deploying the next `RomeBridgeWithdraw`.
+**Why v8:** the deployed v7 (`0xeeb85da5…` on Hadrian) has a **constructor-frozen** Wormhole allowlist — only `wETH` + Sepolia (10002) are permitted, and there is **no setter**, so every new asset or chain needed a full redeploy. v8 adds an owner + setters so assets/chains are enabled on the **live** contract with a tx.
+
+## What changed in the contract
+- `WormholeGenericConfig.admin` (new ctor field) → seeds `owner`. Reverts `ZeroOwner` if 0x0.
+- `owner` (public, transferable) + `onlyOwner` (ERC2771 `_msgSender()`-aware).
+- `setWormholeAssetAllowed(address wrapper, bool)` — enable/disable a burn asset. `onlyOwner`.
+- `setWormholeTargetChainAllowed(uint16 whChainId, bool)` — enable/disable a destination. `onlyOwner`.
+- `transferOwnership(address)` — cold-ledger / multisig handover; zero-guarded. Matches this repo's mainnet admin-handover flow (`scripts/transfer-admin-to-ledger.ts`).
+- Events: `OwnershipTransferred`, `WormholeAssetAllowedSet`, `WormholeTargetChainAllowedSet`.
+- The ctor allowlist is now a **seed**, not a cage. Every value path (burnUSDC/burnETH/burnToWormhole/bridgeOutToSolana) stays permissionless — the owner only gates the two allowlist setters + ownership.
+- Guard suite: `tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts` — 15 green (8 original + 7 new: owner recorded, asset/chain enable+revoke, non-owner rejection, transferOwnership + old-owner-powerless + zero-guard).
+
+## Deploy (operator-gated)
+1. `deploy.ts` already wires `admin` — defaults to the deployer; override with `WORMHOLE_ADMIN=0x…` for a cold-ledger / Squads owner. Seed the ctor allowlist with what's ready (at minimum wETH + Sepolia, matching v7).
+   `WORMHOLE_ADMIN=0x<cold> USDC_MINT=… WETH_MINT=… npx hardhat run scripts/bridge/deploy.ts --network hadrian`
+2. Verify on-chain: `owner()` == admin; `wormholeTargetChainAllowed(10002)` == true.
+3. Register the new address in the registry (`RomeBridgeWithdraw` → v8, status live) via `/publish-registry-pr add-contract`. The bridge-api + rome-ui resolve `liveContractAddress("RomeBridgeWithdraw")`, so they pick it up automatically once live.
+4. Enable further assets/chains with setter txs signed by the owner — **no redeploy**.
+
+## Per-asset prerequisites (BOTH required before an asset can Wormhole-out)
+1. **An ERC20-SPL wrapper on Rome.** `burnToWormhole(assetWrapper,…)` takes a *wrapper address*, not a raw mint (unlike the Solana egress). **No wmSOL wrapper exists today** — deploy one via `ERC20SPLFactory.add_spl_token_no_metadata(mint, name, symbol)`, then `setWormholeAssetAllowed(wrapper, true)`.
+2. **Wormhole attestation on the destination.** The token must be attested with the Wormhole token bridge on the target network so the wrapped asset can mint there. wETH is attested; verify per (asset, chain) before enabling — an un-attested asset burns on Rome but has nothing to redeem into.
+
+## Wormhole chain ids (destination allowlist values)
+| Chain | Wormhole id | v7 status |
+|---|---|---|
+| Sepolia | 10002 | ✅ live |
+| Ethereum | 2 | enable in v8 |
+| Arbitrum One | 23 | enable in v8 |
+| Arbitrum Sepolia | 10003 | enable in v8 |
+| Avalanche / Fuji | 6 | enable in v8 |
+| Base | 30 | enable in v8 |
+| Base Sepolia | 10004 | enable in v8 |
+
+## bridge-api side — READY
+`src/route-builders/token-wormhole-outbound.ts` (`token-wormhole-from-rome`, asset `TOKEN`) emits `[approveWormholeBurn, burnToWormhole, wormhole-claim-on-destination]` on the live `RomeBridgeWithdraw`. Inputs: `splAsset.wrapper` (the ERC20-SPL wrapper) + `destinationChainId` (EVM id → mapped to the Wormhole id above). Redemption is Wormhole-native (user redeems the VAA — no bridge-api build, per the #25 decision). It works the moment v8 is live and the asset+chain are allowlisted.

--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -87,8 +87,8 @@
     "deployedAt": 1779081498
   },
   "RomeBridgeWithdraw": {
-    "address": "0xeeb85da5b35375ba6b2c1754bf7358ea77778b13",
-    "deployedAt": 1783264417
+    "address": "0xc1543b5efbeb98ff63506541b146c6fa3060b394",
+    "deployedAt": 1783275226
   },
   "SimpleActivator": {
     "address": "0xc478604d116222190750fe9a52dd3d6ae9140212",

--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -87,8 +87,8 @@
     "deployedAt": 1779081498
   },
   "RomeBridgeWithdraw": {
-    "address": "0x9975fe4b721bf52f2a5bcc795fa2e29edc50de8b",
-    "deployedAt": 1783174480
+    "address": "0xeeb85da5b35375ba6b2c1754bf7358ea77778b13",
+    "deployedAt": 1783264417
   },
   "SimpleActivator": {
     "address": "0xc478604d116222190750fe9a52dd3d6ae9140212",

--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -226,12 +226,23 @@ export async function deployWithdraw(
   // with a zero forwarder resolves _msgSender() to msg.sender directly — the
   // user-paid flow rome-ui actually uses (burnUSDC / burnETH / bridgeOutToSolana
   // are signed straight from the user's wallet, never sponsored).
+  // Generic-Wormhole allowlist (asset-agnostic + multi-destination egress).
+  // Register the wETH wrapper + this chain's Wormhole target so burnToWormhole
+  // works for wETH too — additive to the legacy burnETH path (which keeps its
+  // own immutables). Expand assetWrappers/targetChains as LST wrappers + more
+  // destination chains land (that closes inbound⇒outbound symmetry per asset).
+  const wormholeGeneric = {
+    targetChains: [wormholeParams.targetChain],
+    assetWrappers: wethWrapper ? [wethWrapper] : [],
+  };
+
   const withdraw = await viem.deployContract("RomeBridgeWithdraw", [
     "0x0000000000000000000000000000000000000000",
     usdcWrapper,
     wethWrapper,
     cctpParams,
     wormholeParams,
+    wormholeGeneric,
   ]);
 
   console.log(`[${networkName}] RomeBridgeWithdraw → ${withdraw.address}`);

--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -231,10 +231,17 @@ export async function deployWithdraw(
   // works for wETH too — additive to the legacy burnETH path (which keeps its
   // own immutables). Expand assetWrappers/targetChains as LST wrappers + more
   // destination chains land (that closes inbound⇒outbound symmetry per asset).
+  // Allowlist admin: the account that can enable further assets/chains on the
+  // LIVE contract post-deploy (no redeploy per addition). Defaults to the
+  // deployer; override via WORMHOLE_ADMIN for a cold-ledger / multisig owner.
+  const [deployerWallet] = await viem.getWalletClients();
+  const wormholeAdmin = (process.env.WORMHOLE_ADMIN ?? deployerWallet.account.address) as `0x${string}`;
   const wormholeGeneric = {
+    admin: wormholeAdmin,
     targetChains: [wormholeParams.targetChain],
     assetWrappers: wethWrapper ? [wethWrapper] : [],
   };
+  console.log(`[${networkName}] Wormhole allowlist admin → ${wormholeAdmin}`);
 
   const withdraw = await viem.deployContract("RomeBridgeWithdraw", [
     "0x0000000000000000000000000000000000000000",

--- a/tests/bridge/RomeBridgeWithdraw.test.ts
+++ b/tests/bridge/RomeBridgeWithdraw.test.ts
@@ -97,7 +97,7 @@ describe("RomeBridgeWithdraw — error paths", () => {
         wrappedMeta: ZERO_BYTES32,
         targetChain: 2,
       },
-      { targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these guard tests)
+      { admin: "0x00000000000000000000000000000000000000a1", targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these guard tests; admin non-zero to satisfy ctor)
     ]);
   });
 

--- a/tests/bridge/RomeBridgeWithdraw.test.ts
+++ b/tests/bridge/RomeBridgeWithdraw.test.ts
@@ -97,6 +97,7 @@ describe("RomeBridgeWithdraw — error paths", () => {
         wrappedMeta: ZERO_BYTES32,
         targetChain: 2,
       },
+      { targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these guard tests)
     ]);
   });
 

--- a/tests/bridge/rome_bridge_withdraw_v6.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_v6.test.ts
@@ -46,6 +46,7 @@ describe("RomeBridgeWithdraw v6 — domain allowlist", function () {
     const weth = await viem.deployContract("MockSplErc20", [PK(41)]);
     bridge = await viem.deployContract("RomeBridgeWithdraw", [
       FORWARDER, usdc.address, weth.address, CCTP, WH,
+      { targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these CCTP guard tests)
     ]);
   });
 
@@ -73,7 +74,7 @@ describe("RomeBridgeWithdraw v6 — domain allowlist", function () {
     const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
     const badCctp = { ...CCTP, domains: [0], remoteTokenMessengers: [PK(8), PK(9)] };
     await assert.rejects(
-      viem.deployContract("RomeBridgeWithdraw", [FORWARDER, usdc.address, usdc.address, badCctp, WH]),
+      viem.deployContract("RomeBridgeWithdraw", [FORWARDER, usdc.address, usdc.address, badCctp, WH, { targetChains: [], assetWrappers: [] }]),
       /DomainConfigLengthMismatch/,
     );
   });

--- a/tests/bridge/rome_bridge_withdraw_v6.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_v6.test.ts
@@ -46,7 +46,7 @@ describe("RomeBridgeWithdraw v6 — domain allowlist", function () {
     const weth = await viem.deployContract("MockSplErc20", [PK(41)]);
     bridge = await viem.deployContract("RomeBridgeWithdraw", [
       FORWARDER, usdc.address, weth.address, CCTP, WH,
-      { targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these CCTP guard tests)
+      { admin: "0x00000000000000000000000000000000000000a1", targetChains: [], assetWrappers: [] }, // generic-Wormhole config (unused by these CCTP guard tests)
     ]);
   });
 
@@ -74,7 +74,7 @@ describe("RomeBridgeWithdraw v6 — domain allowlist", function () {
     const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
     const badCctp = { ...CCTP, domains: [0], remoteTokenMessengers: [PK(8), PK(9)] };
     await assert.rejects(
-      viem.deployContract("RomeBridgeWithdraw", [FORWARDER, usdc.address, usdc.address, badCctp, WH, { targetChains: [], assetWrappers: [] }]),
+      viem.deployContract("RomeBridgeWithdraw", [FORWARDER, usdc.address, usdc.address, badCctp, WH, { admin: "0x00000000000000000000000000000000000000a1", targetChains: [], assetWrappers: [] }]),
       /DomainConfigLengthMismatch/,
     );
   });

--- a/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
@@ -14,6 +14,7 @@ import hardhat from "hardhat";
  */
 
 const ZERO = "0x" + "00".repeat(32);
+const ZERO_ADDR = "0x" + "00".repeat(20); // 20-byte zero (address), for transferOwnership guard
 const PK = (n: number) => ("0x" + n.toString(16).padStart(2, "0").repeat(32)) as `0x${string}`;
 const RECIPIENT = PK(0x99); // 32-byte recipient (Solana pubkey raw / EVM addr left-padded)
 
@@ -45,17 +46,23 @@ describe("RomeBridgeWithdraw — generic Wormhole burn", function () {
   let viem: any;
   let bridge: any;
   let weth: any, jitosol: any, unregistered: any;
+  let ownerAddr: `0x${string}`, otherAddr: `0x${string}`;
 
   before(async function () {
     ({ viem } = await hardhat.network.connect());
+    const wallets = await viem.getWalletClients();
+    ownerAddr = wallets[0].account.address;   // deployer = admin (see WHG.admin)
+    otherAddr = wallets[1].account.address;    // non-owner, used for access-control tests
     const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
     weth = await viem.deployContract("MockSplErc20", [PK(41)]);
     jitosol = await viem.deployContract("MockSplErc20", [PK(42)]);
     unregistered = await viem.deployContract("MockSplErc20", [PK(43)]);
     // New generic-Wormhole config: per-call target-chain allowlist + registered
     // asset wrappers. Sepolia (10002) + Ethereum (2) allowed; weth + jitosol
-    // registered — proving the path is multi-asset, not ETH-only.
+    // registered — proving the path is multi-asset, not ETH-only. `admin` owns
+    // the post-deploy setters so new assets/chains are enabled WITHOUT a redeploy.
     const WHG = {
+      admin: ownerAddr,
       targetChains: [10002, 2],
       assetWrappers: [weth.address, jitosol.address],
     };
@@ -115,7 +122,7 @@ describe("RomeBridgeWithdraw — generic Wormhole burn", function () {
     const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
     // Duplicate/empty allowlists must not silently succeed — keep parity with
     // CCTP's DomainConfigLengthMismatch guard family (asserts the ctor validates).
-    const emptyWhg = { targetChains: [] as number[], assetWrappers: [] as `0x${string}`[] };
+    const emptyWhg = { admin: ownerAddr, targetChains: [] as number[], assetWrappers: [] as `0x${string}`[] };
     const b = await viem.deployContract("RomeBridgeWithdraw", [
       FORWARDER, usdc.address, weth.address, CCTP, WH, emptyWhg,
     ]);
@@ -124,5 +131,61 @@ describe("RomeBridgeWithdraw — generic Wormhole burn", function () {
       b.write.burnToWormhole([weth.address, 1000n, RECIPIENT, 10002]),
       /UnsupportedTargetChain|UnsupportedAssetWrapper/,
     );
+  });
+
+  // ── Post-deploy admin: enable new assets/chains WITHOUT a redeploy ──────────
+  // The whole point of v8: the ctor allowlist is a seed, not a cage. An owner can
+  // list wmSOL/arb/avax + Arbitrum/Avalanche on the LIVE contract via setters.
+
+  it("constructor records the configured admin as owner", async function () {
+    assert.equal((await bridge.read.owner()).toLowerCase(), ownerAddr.toLowerCase());
+  });
+
+  it("owner enables a previously-unregistered asset via setWormholeAssetAllowed", async function () {
+    assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), false);
+    await bridge.write.setWormholeAssetAllowed([unregistered.address, true]);
+    assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), true);
+    // ...and can revoke it again (setter is a real toggle, not one-way).
+    await bridge.write.setWormholeAssetAllowed([unregistered.address, false]);
+    assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), false);
+  });
+
+  it("owner enables a new target chain via setWormholeTargetChainAllowed (e.g. Arbitrum 23)", async function () {
+    assert.equal(await bridge.read.wormholeTargetChainAllowed([23]), false);
+    await bridge.write.setWormholeTargetChainAllowed([23, true]);
+    assert.equal(await bridge.read.wormholeTargetChainAllowed([23]), true);
+  });
+
+  it("non-owner cannot toggle the asset allowlist (reverts NotOwner)", async function () {
+    await assert.rejects(
+      bridge.write.setWormholeAssetAllowed([unregistered.address, true], { account: otherAddr }),
+      /NotOwner/,
+    );
+  });
+
+  it("non-owner cannot toggle the target-chain allowlist (reverts NotOwner)", async function () {
+    await assert.rejects(
+      bridge.write.setWormholeTargetChainAllowed([6, true], { account: otherAddr }),
+      /NotOwner/,
+    );
+  });
+
+  it("transferOwnership hands admin to a new owner; old owner loses rights", async function () {
+    // Fresh instance so the transfer doesn't bleed into the shared `bridge`.
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    const b = await viem.deployContract("RomeBridgeWithdraw", [
+      FORWARDER, usdc.address, weth.address, CCTP, WH,
+      { admin: ownerAddr, targetChains: [10002], assetWrappers: [weth.address] },
+    ]);
+    await b.write.transferOwnership([otherAddr]);
+    assert.equal((await b.read.owner()).toLowerCase(), otherAddr.toLowerCase());
+    // Old owner is now powerless; new owner can administer.
+    await assert.rejects(b.write.setWormholeTargetChainAllowed([23, true]), /NotOwner/);
+    await b.write.setWormholeTargetChainAllowed([23, true], { account: otherAddr });
+    assert.equal(await b.read.wormholeTargetChainAllowed([23]), true);
+  });
+
+  it("transferOwnership to the zero address reverts (no accidental burn of admin)", async function () {
+    await assert.rejects(bridge.write.transferOwnership([ZERO_ADDR]), /ZeroOwner|NotOwner/);
   });
 });

--- a/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
@@ -1,0 +1,128 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * RomeBridgeWithdraw — generic Wormhole burn (burnToWormhole / approveWormholeBurn).
+ *
+ * Generalizes the ETH-only/Sepolia-only Wormhole burn to per-call asset +
+ * per-call target chain, mirroring burnUSDC's per-domain model. The asset +
+ * target-chain allowlist guards + zero-recipient + amount-bound checks fire
+ * BEFORE any Rome precompile touch (like _burnUSDC), so their exact reverts are
+ * assertable on the simulated EVM with MockSplErc20 wrappers. The happy-path
+ * transfer_tokens CPI needs a live Rome node → covered by the integration suite.
+ */
+
+const ZERO = "0x" + "00".repeat(32);
+const PK = (n: number) => ("0x" + n.toString(16).padStart(2, "0").repeat(32)) as `0x${string}`;
+const RECIPIENT = PK(0x99); // 32-byte recipient (Solana pubkey raw / EVM addr left-padded)
+
+const CCTP = {
+  tokenMessengerProgram: PK(1),
+  messageTransmitterProgram: PK(2),
+  splTokenProgram: PK(3),
+  systemProgram: ZERO,
+  messageTransmitterConfig: PK(4),
+  tokenMessengerConfig: PK(5),
+  tokenMinter: PK(6),
+  localTokenUsdc: PK(7),
+  domains: [0, 15],
+  remoteTokenMessengers: [PK(8), PK(9)],
+  senderAuthorityPda: PK(10),
+  eventAuthority: PK(11),
+  messageTransmitterEventAuthority: PK(12),
+};
+const WH = {
+  tokenBridgeProgram: PK(20), coreProgram: PK(21), splTokenProgram: PK(3),
+  systemProgram: ZERO, clockSysvar: PK(22), rentSysvar: PK(23),
+  config: PK(24), custody: PK(25), authoritySigner: PK(26), custodySigner: PK(27),
+  bridgeConfig: PK(28), feeCollector: PK(29), emitter: PK(30), sequence: PK(31),
+  wrappedMeta: PK(32), targetChain: 10002,
+};
+const FORWARDER = "0x0000000000000000000000000000000000000000";
+
+describe("RomeBridgeWithdraw — generic Wormhole burn", function () {
+  let viem: any;
+  let bridge: any;
+  let weth: any, jitosol: any, unregistered: any;
+
+  before(async function () {
+    ({ viem } = await hardhat.network.connect());
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    weth = await viem.deployContract("MockSplErc20", [PK(41)]);
+    jitosol = await viem.deployContract("MockSplErc20", [PK(42)]);
+    unregistered = await viem.deployContract("MockSplErc20", [PK(43)]);
+    // New generic-Wormhole config: per-call target-chain allowlist + registered
+    // asset wrappers. Sepolia (10002) + Ethereum (2) allowed; weth + jitosol
+    // registered — proving the path is multi-asset, not ETH-only.
+    const WHG = {
+      targetChains: [10002, 2],
+      assetWrappers: [weth.address, jitosol.address],
+    };
+    bridge = await viem.deployContract("RomeBridgeWithdraw", [
+      FORWARDER, usdc.address, weth.address, CCTP, WH, WHG,
+    ]);
+  });
+
+  it("constructor populates the wormhole target-chain allowlist", async function () {
+    assert.equal(await bridge.read.wormholeTargetChainAllowed([10002]), true);
+    assert.equal(await bridge.read.wormholeTargetChainAllowed([2]), true);
+    assert.equal(await bridge.read.wormholeTargetChainAllowed([5]), false);
+  });
+
+  it("constructor populates the wormhole asset allowlist", async function () {
+    assert.equal(await bridge.read.wormholeAssetAllowed([weth.address]), true);
+    assert.equal(await bridge.read.wormholeAssetAllowed([jitosol.address]), true);
+    assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), false);
+  });
+
+  it("burnToWormhole to an unlisted target chain reverts UnsupportedTargetChain", async function () {
+    await assert.rejects(
+      bridge.write.burnToWormhole([weth.address, 1000n, RECIPIENT, 5]),
+      /UnsupportedTargetChain/,
+    );
+  });
+
+  it("burnToWormhole with an unregistered asset reverts UnsupportedAssetWrapper", async function () {
+    await assert.rejects(
+      bridge.write.burnToWormhole([unregistered.address, 1000n, RECIPIENT, 10002]),
+      /UnsupportedAssetWrapper/,
+    );
+  });
+
+  it("burnToWormhole to the zero recipient reverts ZeroRecipient", async function () {
+    await assert.rejects(
+      bridge.write.burnToWormhole([weth.address, 1000n, ZERO, 10002]),
+      /ZeroRecipient/,
+    );
+  });
+
+  it("burnToWormhole amount above uint64 max reverts AmountExceedsUint64", async function () {
+    await assert.rejects(
+      bridge.write.burnToWormhole([weth.address, 2n ** 64n, RECIPIENT, 10002]),
+      /AmountExceedsUint64/,
+    );
+  });
+
+  it("approveWormholeBurn with an unregistered asset reverts UnsupportedAssetWrapper", async function () {
+    await assert.rejects(
+      bridge.write.approveWormholeBurn([unregistered.address, 1000n]),
+      /UnsupportedAssetWrapper/,
+    );
+  });
+
+  it("constructor rejects mismatched wormhole config (fail-closed)", async function () {
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    // Duplicate/empty allowlists must not silently succeed — keep parity with
+    // CCTP's DomainConfigLengthMismatch guard family (asserts the ctor validates).
+    const emptyWhg = { targetChains: [] as number[], assetWrappers: [] as `0x${string}`[] };
+    const b = await viem.deployContract("RomeBridgeWithdraw", [
+      FORWARDER, usdc.address, weth.address, CCTP, WH, emptyWhg,
+    ]);
+    // With no chains allowlisted, every burnToWormhole target is rejected.
+    await assert.rejects(
+      b.write.burnToWormhole([weth.address, 1000n, RECIPIENT, 10002]),
+      /UnsupportedTargetChain|UnsupportedAssetWrapper/,
+    );
+  });
+});


### PR DESCRIPTION
Generalizes RomeBridgeWithdraw's Wormhole egress from ETH-only/Sepolia-only to **any wrapped asset, any destination chain**, and makes the allowlist mutable so new assets/chains don't force a redeploy.

## Contract
- `burnToWormhole(assetWrapper, amount, recipient, targetChain)` + `approveWormholeBurn(assetWrapper, amount)` — asset-agnostic + per-call destination, mirroring `burnUSDC`'s per-domain model. Fail-closed allowlists. (commits `3dd7ffd`/`8c5c985`, v7 `0xeeb85da5`)
- **v8**: owner (seeded from `WormholeGenericConfig.admin`, transferable for cold-ledger handover) + `onlyOwner` `setWormholeAssetAllowed` / `setWormholeTargetChainAllowed` + `transferOwnership`. The ctor allowlist becomes a seed, not a cage — assets/chains are enabled on the live contract without redeploying. Every value path stays permissionless. (commit `cc3df3d`)

## Verified
- Guard suite **30 green** (15 generic-Wormhole incl. 7 new owner/setter/transfer tests).
- **Deployed v8 to Hadrian** `0xc1543b5efbeb98ff63506541b146c6fa3060b394` (commit `e88d91e`). Setter **proven live**: enabled Arbitrum (wh 23) + wSOL post-deploy with no redeploy.
- **wETH→Sepolia burnToWormhole proven live** end-to-end via the rome-bridge-api builder against v8 (redeemable VAA emitted).

## Deploy / go-live (runbook: `contracts/bridge/WORMHOLE_V8_REDEPLOY.md`)
Operator-gated: register v8 as the registry live pointer + re-validate the full egress surface (bridgeOutToSolana / burnUSDC / burnETH), then per non-wETH asset — deploy its ERC20SPL wrapper + `setWormholeAssetAllowed` + verify Wormhole attestation on the destination (empirically confirmed: an un-attested asset clears the allowlist but the Wormhole CPI reverts).

Pairs with rome-bridge-api `feat-trustless-settle` (#32) which carries the `token-wormhole-from-rome` builder.