### PR TITLE
fix(bridge): egress fail-closed guard parity — burnETH zero-recipient + burnUSDC domain-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2026-07-06 — RomeBridgeWithdraw: egress fail-closed guard parity (burnETH + burnUSDC)
+
+Uniform input-validation across all egress legs — two guards were missing, both
+now fail closed before any precompile touch. No happy-path behavior change.
+
+- `burnETH` now reverts `ZeroRecipient` when `ethereumRecipient == address(0)`,
+  before the amount/balance checks. It was the only egress leg missing this guard
+  (`_burnUSDC`, `burnToWormhole`, `bridgeOutToSolana`, `ensureRecipientAta` all
+  had it). A zero destination produced an unredeemable Wormhole VAA
+  (`targetAddress = 0`) → permanent loss of the burned wETH.
+- `_burnUSDC` now reverts `UnsupportedDestinationDomain` for the Solana domain
+  (`CCTPV2Lib.DOMAIN_SOLANA == 5`), even if a deployment maps it. The address-typed
+  `burnUSDC` API left-pads an EVM address into `mintRecipient`, which is not a valid
+  Solana token account — a domain-5 burn would carry an unredeemable recipient.
+  (A Solana CCTP recipient needs a `bytes32`-recipient entry point, out of scope.)
+- Test-pinned: `tests/bridge/RomeBridgeWithdraw.test.ts` — "burnETH reverts
+  ZeroRecipient when recipient is address(0)" + "burnUSDC reverts
+  UnsupportedDestinationDomain for Solana domain 5 even when it is allowlisted".
+
 ## 2026-07-05 — RomeBridgeWithdraw: generic Wormhole burn (asset-agnostic + per-call target chain)
 
 - `burnToWormhole(address assetWrapper, uint256 amount, bytes32 recipient, uint16 targetChain)`

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -347,6 +347,13 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
         if (remoteTokenMessenger == bytes32(0)) {
             revert UnsupportedDestinationDomain(destinationDomain);
         }
+        // Domain 5 (Solana) is structurally unsupported by this address-typed
+        // API: mintRecipient is a left-padded EVM address, not a valid Solana
+        // token account, so a burn to domain 5 would be unredeemable. Fail
+        // closed even if a deployment mistakenly maps domain 5.
+        if (destinationDomain == CCTPV2Lib.DOMAIN_SOLANA) {
+            revert UnsupportedDestinationDomain(destinationDomain);
+        }
         if (ethereumRecipient == address(0)) {
             revert ZeroRecipient();
         }
@@ -523,6 +530,12 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///      (2) then invokes `burnETH` which does only the transfer_wrapped
     ///          CPI (requires the delegation from step 1 to be in place).
     function burnETH(uint256 amount, address ethereumRecipient) external {
+        // Fail closed on a zero destination, before amount/balance — a
+        // bytes32(0) targetAddress produces an unredeemable Wormhole VAA
+        // (permanent loss). Mirrors _burnUSDC / burnToWormhole / bridgeOutToSolana.
+        if (ethereumRecipient == address(0)) {
+            revert ZeroRecipient();
+        }
         if (amount > type(uint64).max) {
             revert AmountExceedsUint64(amount);
         }

--- a/tests/bridge/RomeBridgeWithdraw.test.ts
+++ b/tests/bridge/RomeBridgeWithdraw.test.ts
@@ -209,6 +209,71 @@ describe("RomeBridgeWithdraw — error paths", () => {
     );
   });
 
+  it("burnETH reverts ZeroRecipient when recipient is address(0)", async () => {
+    // The guard must fire BEFORE the amount/balance checks (mirrors _burnUSDC /
+    // burnToWormhole), otherwise InsufficientBalance masks a zero-address burn
+    // whose Wormhole VAA (targetAddress = 0) would be permanently unredeemable.
+    await assert.rejects(
+      () => withdraw.write.burnETH([1n, "0x0000000000000000000000000000000000000000"]),
+      (err: any) => ((err?.message ?? "") as string).includes("ZeroRecipient")
+    );
+  });
+
+  it("burnUSDC reverts UnsupportedDestinationDomain for Solana domain 5 even when it is allowlisted", async () => {
+    // Domain 5 = Solana. burnUSDC's address-typed API left-pads an EVM address
+    // into mintRecipient, which is not a valid Solana token account — a burn to
+    // domain 5 would carry an unredeemable mintRecipient. Even a deployment that
+    // mistakenly maps domain 5 must fail closed. The default fixture maps only
+    // domain 0, so deploy a dedicated instance with domain 5 mapped to
+    // discriminate the new guard from the pre-existing unmapped-domain revert.
+    const mockUsdc = await viem.deployContract("MockSplErc20", [MOCK_MINT]);
+    const mockWeth = await viem.deployContract("MockSplErc20", [MOCK_MINT]);
+    const w: any = await viem.deployContract("RomeBridgeWithdraw", [
+      "0x0000000000000000000000000000000000000000",
+      mockUsdc.address,
+      mockWeth.address,
+      {
+        tokenMessengerProgram: DUMMY_PROGRAM,
+        messageTransmitterProgram: DUMMY_PROGRAM,
+        splTokenProgram: DUMMY_PROGRAM,
+        systemProgram: ZERO_BYTES32,
+        messageTransmitterConfig: ZERO_BYTES32,
+        tokenMessengerConfig: ZERO_BYTES32,
+        // Domain 5 (Solana) mapped ON PURPOSE — the guard must still reject it.
+        domains: [0, 5],
+        remoteTokenMessengers: ["0x" + "aa".repeat(32), "0x" + "bb".repeat(32)],
+        tokenMinter: ZERO_BYTES32,
+        localTokenUsdc: ZERO_BYTES32,
+        senderAuthorityPda: ZERO_BYTES32,
+        eventAuthority: ZERO_BYTES32,
+        messageTransmitterEventAuthority: ZERO_BYTES32,
+      },
+      {
+        tokenBridgeProgram: DUMMY_PROGRAM,
+        coreProgram: DUMMY_PROGRAM,
+        splTokenProgram: DUMMY_PROGRAM,
+        systemProgram: ZERO_BYTES32,
+        clockSysvar: DUMMY_PROGRAM,
+        rentSysvar: DUMMY_PROGRAM,
+        config: ZERO_BYTES32,
+        custody: ZERO_BYTES32,
+        authoritySigner: ZERO_BYTES32,
+        custodySigner: ZERO_BYTES32,
+        bridgeConfig: ZERO_BYTES32,
+        feeCollector: ZERO_BYTES32,
+        emitter: ZERO_BYTES32,
+        sequence: ZERO_BYTES32,
+        wrappedMeta: ZERO_BYTES32,
+        targetChain: 2,
+      },
+      { admin: "0x00000000000000000000000000000000000000a1", targetChains: [], assetWrappers: [] },
+    ]);
+    await assert.rejects(
+      () => w.write.burnUSDC([1n, user, 5]),
+      (err: any) => ((err?.message ?? "") as string).includes("UnsupportedDestinationDomain")
+    );
+  });
+
   it("ensureRecipientAta reverts ZeroRecipient when recipient is bytes32(0)", async () => {
     await assert.rejects(
       () => withdraw.write.ensureRecipientAta([ZERO_BYTES32, MOCK_MINT]),


### PR DESCRIPTION
Two egress legs in `RomeBridgeWithdraw` were missing input guards that every sibling enforces. Both now fail closed **before any precompile touch** — no happy-path behavior change.

### `burnETH` — `ZeroRecipient` guard
It was the only egress leg without it. `burnETH(amount, address(0))` burned wETH into an unredeemable Wormhole VAA (`targetAddress = 0`) → permanent loss. Now reverts `ZeroRecipient` first, matching `_burnUSDC` / `burnToWormhole` / `bridgeOutToSolana` / `ensureRecipientAta`.

### `_burnUSDC` — Solana-domain guard
The address-typed `burnUSDC` API left-pads an EVM address into `mintRecipient`, which is not a valid Solana token account — so a burn to domain 5 (`CCTPV2Lib.DOMAIN_SOLANA`) would carry an unredeemable recipient. Now reverts `UnsupportedDestinationDomain` even if a deployment maps domain 5. (A real Solana CCTP recipient needs a separate `bytes32`-recipient entry point — out of scope here.)

### Tests
Both guards are exact-revert-testable on the simulated EVM (no Rome stack). Test-pinned in `tests/bridge/RomeBridgeWithdraw.test.ts` — **13 passing**; adjacent bridge units (`rome_bridge_withdraw_v6`, `rome_bridge_withdraw_wormhole_generic`) **19 passing**, no regression.

Found during an audit pass on the unified v8 egress contract.
