### PR TITLE
feat(bridge): mint-keyed Wormhole allowlist (v10, caller-transparent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2026-07-06 — RomeBridgeWithdraw: mint-keyed Wormhole allowlist (held for next redeploy / v10)
+
+The generic Wormhole allowlist is now keyed on the SPL **mint** (`wrapper.mint_id()`)
+instead of the wrapper-instance address. Any ERC20-SPL wrapper over an allowed mint is
+accepted — all wrappers over one mint are fungible views of the same on-chain ATA — which
+removes the multi-wrapper drift class (registry / deployments / v8 each holding a distinct
+wrapper over the same mint) with **no security change** (the mint is the real asset identity).
+
+- **Caller-transparent:** `burnToWormhole` / `approveWormholeBurn` / `setWormholeAssetAllowed`
+  keep the `address assetWrapper` parameter, and `wormholeAssetAllowed(address)` stays a
+  view (now mint-derived) — bridge-api / rome-ui need no changes. New storage getter
+  `wormholeMintAllowed(bytes32)`; constructor seed + setter + both burn-path guards derive
+  the mint internally.
+- **Contract change → requires a RomeBridgeWithdraw redeploy (v10).** Merging is source-ready;
+  the deployed v9 (`0xa5a010bc…`) is unaffected until the next redeploy picks this up.
+- Test-pinned: `tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts` — "allowlist is
+  mint-keyed: any wrapper over an allowed mint is accepted".
+
 ## 2026-07-06 — RomeBridgeWithdraw: egress fail-closed guard parity (burnETH + burnUSDC)
 
 Uniform input-validation across all egress legs — two guards were missing, both

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -108,9 +108,13 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///         mirrors `cctpRemoteTokenMessengers`' dual role (config + guard).
     mapping(uint16 => bool) public wormholeTargetChainAllowed;
 
-    /// @notice Generic-Wormhole asset allowlist: registered SPL_ERC20 wrapper
-    ///         address → allowed. Only registered wrappers can burn to Wormhole.
-    mapping(address => bool) public wormholeAssetAllowed;
+    /// @notice Generic-Wormhole asset allowlist, keyed on the SPL MINT (not the
+    ///         wrapper instance). All ERC20-SPL wrappers over one mint are fungible
+    ///         views of the same on-chain ATA, so keying on the mint accepts any
+    ///         wrapper over an allowed asset and kills the multi-wrapper drift
+    ///         class. The public API stays wrapper-typed via the
+    ///         `wormholeAssetAllowed(address)` view below — callers are unchanged.
+    mapping(bytes32 => bool) public wormholeMintAllowed;
 
     /// @notice Admin of the Wormhole allowlist setters. Seeded at construction
     ///         from `WormholeGenericConfig.admin`; transferable (cold-ledger
@@ -286,7 +290,7 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
             wormholeTargetChainAllowed[whg.targetChains[i]] = true;
         }
         for (uint256 i = 0; i < whg.assetWrappers.length; i++) {
-            wormholeAssetAllowed[whg.assetWrappers[i]] = true;
+            wormholeMintAllowed[SPL_ERC20(whg.assetWrappers[i]).mint_id()] = true;
         }
     }
 
@@ -298,8 +302,14 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ///         Lets the owner add wmSOL / arb / avax (etc.) on the LIVE contract
     ///         — the reason v8 exists (v7's allowlist was constructor-frozen).
     function setWormholeAssetAllowed(address assetWrapper, bool allowed) external onlyOwner {
-        wormholeAssetAllowed[assetWrapper] = allowed;
+        wormholeMintAllowed[SPL_ERC20(assetWrapper).mint_id()] = allowed;
         emit WormholeAssetAllowedSet(assetWrapper, allowed);
+    }
+
+    /// @notice Back-compat wrapper-typed view: is the mint behind `assetWrapper`
+    ///         allowed for burnToWormhole? True for ANY wrapper over an allowed mint.
+    function wormholeAssetAllowed(address assetWrapper) external view returns (bool) {
+        return wormholeMintAllowed[SPL_ERC20(assetWrapper).mint_id()];
     }
 
     /// @notice Enable/disable a Wormhole target chain for `burnToWormhole`
@@ -627,7 +637,7 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     /// @param assetWrapper Registered SPL_ERC20 wrapper for the asset.
     /// @param amount       Burn allowance to delegate (base units; uint64-bounded).
     function approveWormholeBurn(address assetWrapper, uint256 amount) external {
-        if (!wormholeAssetAllowed[assetWrapper]) {
+        if (!wormholeMintAllowed[SPL_ERC20(assetWrapper).mint_id()]) {
             revert UnsupportedAssetWrapper(assetWrapper);
         }
         if (amount > type(uint64).max) {
@@ -677,7 +687,7 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     ) external {
         // Guards ordered BEFORE any Rome precompile touch, so their exact
         // reverts are assertable on a simulated EVM (parity with _burnUSDC).
-        if (!wormholeAssetAllowed[assetWrapper]) {
+        if (!wormholeMintAllowed[SPL_ERC20(assetWrapper).mint_id()]) {
             revert UnsupportedAssetWrapper(assetWrapper);
         }
         if (!wormholeTargetChainAllowed[targetChain]) {

--- a/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
+++ b/tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts
@@ -83,6 +83,23 @@ describe("RomeBridgeWithdraw — generic Wormhole burn", function () {
     assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), false);
   });
 
+  it("allowlist is mint-keyed: any wrapper over an allowed mint is accepted", async function () {
+    // `weth` (mint PK(41)) is ctor-seeded. Deploy a SECOND, distinct wrapper
+    // CONTRACT over the SAME mint. Wrapper-instance-keyed (old) would reject it
+    // (different address); mint-keyed (new) accepts it, because all wrappers over
+    // one mint are fungible views of the same on-chain ATA. This is exactly the
+    // registry/deployments/v8 wrapper drift (3 wrappers, 1 mint) made harmless.
+    const wethAlt = await viem.deployContract("MockSplErc20", [PK(41)]);
+    assert.notEqual(wethAlt.address.toLowerCase(), weth.address.toLowerCase());
+    assert.equal(await bridge.read.wormholeAssetAllowed([wethAlt.address]), true);
+    // And it must clear the burnToWormhole asset guard — reverting on a LATER
+    // guard (ZeroRecipient), not UnsupportedAssetWrapper.
+    await assert.rejects(
+      bridge.write.burnToWormhole([wethAlt.address, 1000n, ZERO, 10002]),
+      /ZeroRecipient/,
+    );
+  });
+
   it("burnToWormhole to an unlisted target chain reverts UnsupportedTargetChain", async function () {
     await assert.rejects(
       bridge.write.burnToWormhole([weth.address, 1000n, RECIPIENT, 5]),


### PR DESCRIPTION
Keys the generic Wormhole allowlist on the SPL **mint** (`wrapper.mint_id()`) instead of the wrapper-instance address. Any ERC20-SPL wrapper over an allowed mint is accepted — all wrappers over one mint are fungible views of the same on-chain ATA — so this **removes the multi-wrapper drift class** (registry / deployments / live v8 each hold a *different* wrapper over the same wETH mint) with **no security change**: the mint is the real asset identity.

## Caller-transparent
`burnToWormhole` / `approveWormholeBurn` / `setWormholeAssetAllowed` keep the `address assetWrapper` param, and `wormholeAssetAllowed(address)` stays a view (now mint-derived) — **bridge-api / rome-ui need zero changes**. New storage getter `wormholeMintAllowed(bytes32)`; the ctor seed + setter + both burn-path guards derive the mint internally.

## Held for the next redeploy (v10)
This is a contract change, so it only takes effect on a **new** `RomeBridgeWithdraw` deploy. The live v9 (`0xa5a010bc…`) is unaffected until then — merge is source-ready; deploy is deferred to the next planned redeploy. Addresses the design point raised in the F1/F2 audit follow-ups (why allowlist a wrapper when the mint is the real thing).

## Tests
`tsc` clean; **16 passing** in `tests/bridge/rome_bridge_withdraw_wormhole_generic.test.ts` (new mint-keyed test + all existing allowlist tests unchanged, proving caller-transparency); **17** adjacent bridge units, no regression.