### PR TITLE
feat(bridge): Wormhole transfer_native egress (v11) for Solana-native mints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 2026-07-06 — RomeBridgeWithdraw: Wormhole transfer_native egress (v11, Solana-native mints)
+
+`transferNativeToWormhole(address assetWrapper, uint256 amount, bytes32 recipient, uint16 targetChain)`
+— the Solana-native-mint counterpart of `burnToWormhole`. Where `burnToWormhole` uses
+Wormhole `transfer_wrapped` (Wormhole-origin assets like wETH), this uses `transfer_native`
+(solitaire tag 5) so a **Solana-native mint** (wSOL, mSOL, LSTs) egresses via Wormhole:
+tokens move into the Token Bridge's per-mint custody and a transfer VAA is posted for the
+recipient to redeem on the target chain.
+
+- **Per-mint custody (fund-critical):** the custody account is derived at runtime as
+  `find_program_address([mint], tokenBridge)` — matching
+  `@wormhole-foundation/sdk-solana-tokenbridge` `deriveCustodyKey`. v10's single stored
+  `wormholeCustody` serves ONE mint only; native egress across mints requires the per-mint
+  derivation. `custody_signer` is global (the stored deploy value is reused).
+- **Reuses `approveWormholeBurn`** for the separate-tx delegate approval — approving
+  `authority_signer` on the caller's ATA is asset-neutral and identical for the
+  from → custody move (no redundant approve function added).
+- **New event `WormholeNativeTransfer`** — native LOCKS in custody (does not burn), so a
+  distinct event lets indexers tell native-lock egress from wrapped-burn (`WormholeBurn`).
+- **Lib:** `WormholeTokenBridgeLib.encodeTransferNative` (tag 0x05; payload identical to
+  transfer_wrapped) + `buildTransferNativeAccounts` (canonical 17-account IDL layout — NO
+  `from_owner`; `custody`+`custody_signer` replace `wrapped_meta`; `tokenProgram` before
+  `wormholeProgram` — plus the #266 emulator trailing `token_bridge_program`). The dead,
+  never-wired `TransferAccounts`/`buildAccounts` scaffold (wrong account order) was removed.
+- **Contract change → requires a RomeBridgeWithdraw redeploy (v11).** Source-ready; deployed
+  v10 (`0xd2161cd5…`) is unaffected until the next redeploy. Deploy seeds the wSOL + mSOL
+  mints into the Wormhole allowlist (constructor or `set-wormhole-allowlist.ts`); the
+  `custody_signer` deploy param is already derived.
+- Test-pinned: `tests/bridge/wormhole_native_lib.test.ts` (tag-0x05 byte layout + 18-meta
+  native account order/flags, asserted against the Wormhole SDK IDL) +
+  `tests/bridge/wormhole_native_egress.test.ts` (asset / target-chain / zero-recipient /
+  amount-bound guards + mint-keyed allowlist on the native entry point).
+
 ## 2026-07-06 — RomeBridgeWithdraw: mint-keyed Wormhole allowlist (held for next redeploy / v10)
 
 The generic Wormhole allowlist is now keyed on the SPL **mint** (`wrapper.mint_id()`)

--- a/contracts/bridge/IWormholeTokenBridge.sol
+++ b/contracts/bridge/IWormholeTokenBridge.sol
@@ -16,6 +16,12 @@ library WormholeTokenBridgeLib {
     ///      Coincides numerically with TRANSFER_TOKENS_TAG; kept separate for clarity.
     uint8 internal constant TRANSFER_WRAPPED_TAG = 0x04;
 
+    /// @notice TransferNative instruction tag (solitaire enum index 5) — the
+    ///         Solana-native-mint egress (wSOL, mSOL, LSTs). Same payload as
+    ///         transfer_wrapped; distinct account layout (custody + custody_signer,
+    ///         no from_owner). See buildTransferNativeAccounts.
+    uint8 internal constant TRANSFER_NATIVE_TAG = 0x05;
+
     /// @notice Parameters for the transfer_tokens instruction.
     /// @dev amount and fee are u64 — Wormhole Token Bridge native format.
     ///      Callers accepting uint256 from the ERC-20 boundary must range-check
@@ -28,27 +34,24 @@ library WormholeTokenBridgeLib {
         uint32 nonce;
     }
 
-    /// @notice Aggregated account references for the transfer_tokens instruction.
-    /// @dev Passed as a single struct to avoid stack-too-deep in buildAccounts.
-    struct TransferAccounts {
-        bytes32 payer;
-        bytes32 config;
-        bytes32 from_owner;
-        bytes32 from;
-        bytes32 mint;
-        bytes32 custody;
-        bytes32 authority_signer;
-        bytes32 custody_signer;
-        bytes32 bridge_config;
-        bytes32 message;
-        bytes32 emitter;
-        bytes32 sequence;
-        bytes32 fee_collector;
-        bytes32 clock;
-        bytes32 rent;
-        bytes32 system;
-        bytes32 token;
-        bytes32 wormhole_core;
+    /// @notice Encodes a transfer_native instruction payload (solitaire tag 5).
+    /// @dev Byte-identical to encodeTransferTokens except the leading tag. The
+    ///      shared TransferParams struct (amount/fee u64, target 32B, chain u16,
+    ///      nonce u32) is reused.
+    ///      Layout: [tag:1=0x05][nonce:4 LE][amount:8 LE][fee:8 LE][target:32][chain:2 LE]
+    function encodeTransferNative(TransferParams memory p)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(
+            TRANSFER_NATIVE_TAG,
+            _u32le(p.nonce),
+            _u64le(p.amount),
+            _u64le(p.fee),
+            p.targetAddress,
+            _u16le(p.targetChain)
+        );
     }
 
     /// @notice Encodes a transfer_tokens instruction payload.
@@ -68,33 +71,82 @@ library WormholeTokenBridgeLib {
         );
     }
 
-    /// @notice Builds the ordered account list for the transfer_tokens instruction.
-    /// @dev Accepts a TransferAccounts struct to avoid stack-too-deep with 18 accounts.
-    function buildAccounts(TransferAccounts memory a)
+    // -------------------------------------------------------------------------
+    // TransferNative — account layout for Solana-native mints (wSOL, mSOL, LSTs)
+    // -------------------------------------------------------------------------
+
+    /// @notice Aggregated account references for the transfer_native instruction.
+    /// @dev Per the Wormhole SDK IDL (@wormhole-foundation/sdk-solana-tokenbridge
+    ///      tokenBridgeType.transferNative) — 17 accounts, NO `from_owner`
+    ///      (native is delegate-authorized via authority_signer). Order + flags:
+    ///      0  payer             signer, writable
+    ///      1  config            readonly (token bridge config)
+    ///      2  from              writable (user ATA)
+    ///      3  mint              writable (the native SPL mint)
+    ///      4  custody           writable  — PER-MINT: find_program_address([mint], tokenBridge)
+    ///      5  authority_signer  readonly
+    ///      6  custody_signer    readonly  — global
+    ///      7  bridge_config     writable (Core bridge config)
+    ///      8  message           signer, writable
+    ///      9  emitter           readonly
+    ///      10 sequence          writable
+    ///      11 fee_collector     writable
+    ///      12 clock             readonly
+    ///      13 rent              readonly
+    ///      14 system            readonly
+    ///      15 token             readonly (SPL Token program)  — native IDL puts token BEFORE core
+    ///      16 wormhole_core     readonly (Core program)       — (the REVERSE of the wrapped tail)
+    struct TransferNativeAccounts {
+        bytes32 payer;
+        bytes32 config;
+        bytes32 from;
+        bytes32 mint;
+        bytes32 custody;
+        bytes32 authority_signer;
+        bytes32 custody_signer;
+        bytes32 bridge_config;
+        bytes32 message;
+        bytes32 emitter;
+        bytes32 sequence;
+        bytes32 fee_collector;
+        bytes32 clock;
+        bytes32 rent;
+        bytes32 system;
+        bytes32 token;
+        bytes32 wormhole_core;
+        // POST-#266 EMULATOR WORKAROUND: the Wormhole Token Bridge program
+        // itself. Not in the 17-account IDL layout; solitaire ignores trailing
+        // accounts, but Rome's Mollusk emulator (ix_store filter) only loads
+        // accounts present in OUTER metas, so the inner CPI needs it here.
+        // Mirrors buildTransferWrappedAccounts.
+        bytes32 token_bridge_program;
+    }
+
+    function buildTransferNativeAccounts(TransferNativeAccounts memory a)
         internal
         pure
         returns (ICrossProgramInvocation.AccountMeta[] memory metas)
     {
         metas = new ICrossProgramInvocation.AccountMeta[](18);
-
         metas[0]  = ICrossProgramInvocation.AccountMeta(a.payer,            true,  true);   // payer
         metas[1]  = ICrossProgramInvocation.AccountMeta(a.config,           false, false);  // config
-        metas[2]  = ICrossProgramInvocation.AccountMeta(a.from_owner,       true,  false);  // from_owner
-        metas[3]  = ICrossProgramInvocation.AccountMeta(a.from,             false, true);   // from
-        metas[4]  = ICrossProgramInvocation.AccountMeta(a.mint,             false, true);   // mint
-        metas[5]  = ICrossProgramInvocation.AccountMeta(a.custody,          false, true);   // custody
-        metas[6]  = ICrossProgramInvocation.AccountMeta(a.authority_signer, false, false);  // authority_signer
-        metas[7]  = ICrossProgramInvocation.AccountMeta(a.custody_signer,   false, false);  // custody_signer
-        metas[8]  = ICrossProgramInvocation.AccountMeta(a.bridge_config,    false, true);   // bridge_config
-        metas[9]  = ICrossProgramInvocation.AccountMeta(a.message,          true,  true);   // message
-        metas[10] = ICrossProgramInvocation.AccountMeta(a.emitter,          false, false);  // emitter
-        metas[11] = ICrossProgramInvocation.AccountMeta(a.sequence,         false, true);   // sequence
-        metas[12] = ICrossProgramInvocation.AccountMeta(a.fee_collector,    false, true);   // fee_collector
-        metas[13] = ICrossProgramInvocation.AccountMeta(a.clock,            false, false);  // clock
-        metas[14] = ICrossProgramInvocation.AccountMeta(a.rent,             false, false);  // rent
-        metas[15] = ICrossProgramInvocation.AccountMeta(a.system,           false, false);  // system
-        metas[16] = ICrossProgramInvocation.AccountMeta(a.token,            false, false);  // token
-        metas[17] = ICrossProgramInvocation.AccountMeta(a.wormhole_core,    false, false);  // wormhole_core
+        metas[2]  = ICrossProgramInvocation.AccountMeta(a.from,             false, true);   // from
+        metas[3]  = ICrossProgramInvocation.AccountMeta(a.mint,             false, true);   // mint
+        metas[4]  = ICrossProgramInvocation.AccountMeta(a.custody,          false, true);   // custody (per-mint)
+        metas[5]  = ICrossProgramInvocation.AccountMeta(a.authority_signer, false, false);  // authority_signer
+        metas[6]  = ICrossProgramInvocation.AccountMeta(a.custody_signer,   false, false);  // custody_signer (global)
+        metas[7]  = ICrossProgramInvocation.AccountMeta(a.bridge_config,    false, true);   // wormhole core config
+        metas[8]  = ICrossProgramInvocation.AccountMeta(a.message,          true,  true);   // message
+        metas[9]  = ICrossProgramInvocation.AccountMeta(a.emitter,          false, false);  // emitter
+        metas[10] = ICrossProgramInvocation.AccountMeta(a.sequence,         false, true);   // sequence
+        metas[11] = ICrossProgramInvocation.AccountMeta(a.fee_collector,    false, true);   // fee_collector
+        metas[12] = ICrossProgramInvocation.AccountMeta(a.clock,            false, false);  // clock
+        metas[13] = ICrossProgramInvocation.AccountMeta(a.rent,             false, false);  // rent
+        metas[14] = ICrossProgramInvocation.AccountMeta(a.system,           false, false);  // system
+        metas[15] = ICrossProgramInvocation.AccountMeta(a.token,            false, false);  // SPL Token program
+        metas[16] = ICrossProgramInvocation.AccountMeta(a.wormhole_core,    false, false);  // Core program
+        // POST-#266 EMULATOR WORKAROUND — see struct comment above.
+        metas[17] = ICrossProgramInvocation.AccountMeta(a.token_bridge_program, false, false);
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/bridge/RomeBridgeEvents.sol
+++ b/contracts/bridge/RomeBridgeEvents.sol
@@ -69,6 +69,27 @@ interface RomeBridgeEvents {
         uint16 targetChain
     );
 
+    /// @notice Emitted on a Wormhole transfer_native egress via
+    ///         `transferNativeToWormhole` — the Solana-native-mint counterpart of
+    ///         `WormholeBurn`. transfer_native LOCKS the tokens in the Token
+    ///         Bridge's per-mint custody (it does NOT burn); the recipient
+    ///         redeems the VAA on the target chain. A distinct event lets indexers
+    ///         tell native-lock egress from wrapped-burn egress.
+    /// @param user         EVM address of the transferring user.
+    /// @param assetWrapper Registered SPL_ERC20 wrapper (over a Solana-native mint).
+    /// @param mint         SPL mint (bytes32 pubkey) of the native asset.
+    /// @param amount       Token amount (in SPL decimals).
+    /// @param recipient    32-byte recipient on the target chain.
+    /// @param targetChain  Wormhole chain id of the destination.
+    event WormholeNativeTransfer(
+        address indexed user,
+        address indexed assetWrapper,
+        bytes32 mint,
+        uint256 amount,
+        bytes32 recipient,
+        uint16 targetChain
+    );
+
     /// @notice Emitted when the paymaster sponsors a user transaction.
     /// @param user            EVM address of the sponsored user.
     /// @param remainingBudget Remaining sponsorship budget after this transaction.

--- a/contracts/bridge/RomeBridgeWithdraw.sol
+++ b/contracts/bridge/RomeBridgeWithdraw.sol
@@ -778,6 +778,127 @@ contract RomeBridgeWithdraw is ERC2771Context, RomeBridgeEvents {
     }
 
     // -------------------------------------------------------------------------
+    // Wormhole transfer_native — Solana-native mint egress (wSOL, mSOL, LSTs)
+    // -------------------------------------------------------------------------
+
+    /// @notice Solana-native counterpart of `burnToWormhole`. Where
+    ///         `burnToWormhole` uses transfer_wrapped (for Wormhole-origin assets
+    ///         like wETH), this uses **transfer_native** (solitaire tag 5) so a
+    ///         Solana-native mint (wSOL, mSOL, LSTs) egresses via Wormhole: the
+    ///         tokens move into the Token Bridge's per-mint custody and a transfer
+    ///         VAA is posted; the recipient redeems on the target chain.
+    /// @dev Must be preceded by `approveWormholeBurn(assetWrapper, amount)` in a
+    ///      SEPARATE tx (the same ~1.4M-CU split as burnToWormhole). That approval
+    ///      delegates `authority_signer` on the caller's ATA — the identical
+    ///      delegation transfer_native needs to move `from` → custody. The approve
+    ///      is asset-neutral (it is not specific to "burn"); it is reused as-is.
+    /// @param assetWrapper Registered SPL_ERC20 wrapper for a Solana-native mint.
+    /// @param amount       Token amount in the wrapper's SPL decimals (uint64-bounded).
+    /// @param recipient    32-byte recipient on the target chain (non-zero).
+    /// @param targetChain  Wormhole chain id, PER-CALL (must be allowlisted).
+    function transferNativeToWormhole(
+        address assetWrapper,
+        uint256 amount,
+        bytes32 recipient,
+        uint16 targetChain
+    ) external {
+        // Guards ordered BEFORE any Rome precompile touch (parity with burnToWormhole).
+        if (!wormholeMintAllowed[SPL_ERC20(assetWrapper).mint_id()]) {
+            revert UnsupportedAssetWrapper(assetWrapper);
+        }
+        if (!wormholeTargetChainAllowed[targetChain]) {
+            revert UnsupportedTargetChain(targetChain);
+        }
+        if (recipient == bytes32(0)) {
+            revert ZeroRecipient();
+        }
+        if (amount > type(uint64).max) {
+            revert AmountExceedsUint64(amount);
+        }
+
+        SPL_ERC20 wrapper = SPL_ERC20(assetWrapper);
+        bytes32 mint = wrapper.mint_id();
+        address user = _msgSender();
+        uint256 balance = wrapper.balanceOf(user);
+        if (balance < amount) {
+            revert InsufficientBalance(user, amount, balance);
+        }
+
+        bytes32 userPda = RomeEVMAccount.pda(user);
+        bytes32 userAta = HelperProgram.ata(user, mint);
+
+        // custody = ["<mint>"] PDA under the Token Bridge — PER-MINT, derived at
+        // runtime. THE crux: v10's single stored `wormholeCustody` serves ONE mint
+        // only; native egress of multiple mints requires per-mint custody. Matches
+        // @wormhole-foundation/sdk-solana-tokenbridge deriveCustodyKey =
+        // deriveAddress([mint], tokenBridge). custody_signer is global (stored).
+        ISystemProgram.Seed[] memory custodySeeds = new ISystemProgram.Seed[](1);
+        custodySeeds[0] = ISystemProgram.Seed(abi.encodePacked(mint));
+        (bytes32 custody, ) = PdaDeriver.derive(wormholeTokenBridgeProgram, custodySeeds);
+
+        // Per-tx Wormhole message account: salted PDA under the user (nonce, not
+        // block.number — unstable across emulation/execution on Rome).
+        uint64 nonce = burnNonce[user];
+        burnNonce[user] = nonce + 1;
+        bytes32 whSalt = keccak256(abi.encodePacked("WH_MSG", address(this), nonce));
+        bytes32 messageAccount = RomeEVMAccount.pda_with_salt(user, whSalt);
+
+        bytes memory ixData = WormholeTokenBridgeLib.encodeTransferNative(
+            WormholeTokenBridgeLib.TransferParams({
+                amount:        uint64(amount),
+                fee:           0,
+                targetAddress: recipient,
+                targetChain:   targetChain,
+                nonce:         uint32(block.timestamp)
+            })
+        );
+
+        ICrossProgramInvocation.AccountMeta[] memory metas =
+            WormholeTokenBridgeLib.buildTransferNativeAccounts(
+                WormholeTokenBridgeLib.TransferNativeAccounts({
+                    payer:            userPda,
+                    config:           wormholeConfig,
+                    from:             userAta,
+                    mint:             mint,
+                    custody:          custody,
+                    authority_signer: wormholeAuthoritySigner,
+                    custody_signer:   wormholeCustodySigner,
+                    bridge_config:    wormholeBridgeConfig,
+                    message:          messageAccount,
+                    emitter:          wormholeEmitter,
+                    sequence:         wormholeSequence,
+                    fee_collector:    wormholeFeeCollector,
+                    clock:            whClockSysvar,
+                    rent:             whRentSysvar,
+                    system:           whSystemProgram,
+                    token:            whSplTokenProgram,
+                    wormhole_core:    wormholeCoreProgram,
+                    token_bridge_program: wormholeTokenBridgeProgram
+                })
+            );
+
+        // Only the per-tx message PDA needs an explicit signing salt; the unified
+        // user PDA at `payer` (metas[0]) is auto-signed by the precompile from the
+        // tx-caller's EVM address. Native has no from_owner — the from→custody move
+        // is authorized by the authority_signer delegation from approveWormholeBurn.
+        bytes32[] memory salts = new bytes32[](1);
+        salts[0] = whSalt;
+
+        (bool ok, bytes memory result) = address(CpiProgram).delegatecall(
+            abi.encodeWithSignature(
+                "invoke_signed(bytes32,(bytes32,bool,bool)[],bytes,bytes32[])",
+                wormholeTokenBridgeProgram,
+                metas,
+                ixData,
+                salts
+            )
+        );
+        if (!ok) revert CpiFailed(result);
+
+        emit WormholeNativeTransfer(user, assetWrapper, mint, amount, recipient, targetChain);
+    }
+
+    // -------------------------------------------------------------------------
     // Rome → Solana SPL egress (any wrapper mint)
     //
     // Two atomic single-CPI txs — `ensureRecipientAta` (only when the recipient

--- a/contracts/bridge/test/WormholeLibHarness.sol
+++ b/contracts/bridge/test/WormholeLibHarness.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {WormholeTokenBridgeLib} from "../IWormholeTokenBridge.sol";
+import {ICrossProgramInvocation} from "../../interface.sol";
+
+/// @notice Test harness exposing WormholeTokenBridgeLib transfer_native internals
+///         for network-independent unit tests (mirrors CCTPV2LibHarness). Also
+///         exposes the proven transfer_wrapped encoder so the native encoding can
+///         be asserted equal-modulo-the-tag against it.
+contract WormholeLibHarness {
+    function encodeNative(
+        uint32 nonce,
+        uint64 amount,
+        uint64 fee,
+        bytes32 targetAddress,
+        uint16 targetChain
+    ) external pure returns (bytes memory) {
+        return WormholeTokenBridgeLib.encodeTransferNative(WormholeTokenBridgeLib.TransferParams({
+            amount: amount,
+            fee: fee,
+            targetAddress: targetAddress,
+            targetChain: targetChain,
+            nonce: nonce
+        }));
+    }
+
+    function encodeWrapped(
+        uint32 nonce,
+        uint64 amount,
+        uint64 fee,
+        bytes32 targetAddress,
+        uint16 targetChain
+    ) external pure returns (bytes memory) {
+        return WormholeTokenBridgeLib.encodeTransferTokens(WormholeTokenBridgeLib.TransferParams({
+            amount: amount,
+            fee: fee,
+            targetAddress: targetAddress,
+            targetChain: targetChain,
+            nonce: nonce
+        }));
+    }
+
+    function buildNative(WormholeTokenBridgeLib.TransferNativeAccounts memory a)
+        external
+        pure
+        returns (ICrossProgramInvocation.AccountMeta[] memory)
+    {
+        return WormholeTokenBridgeLib.buildTransferNativeAccounts(a);
+    }
+}

--- a/tests/bridge/wormhole_native_egress.test.ts
+++ b/tests/bridge/wormhole_native_egress.test.ts
@@ -1,0 +1,118 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * RomeBridgeWithdraw — Wormhole transfer_native egress (v11,
+ * transferNativeToWormhole). Mirrors rome_bridge_withdraw_wormhole_generic.test.ts.
+ *
+ * The asset + target-chain allowlist guards + zero-recipient + amount-bound
+ * checks fire BEFORE any Rome precompile touch (parity with burnToWormhole), so
+ * their exact reverts are assertable on the simulated EVM with MockSplErc20
+ * wrappers. The happy-path transfer_native CPI (and the balanceOf gate, which
+ * reads a precompile) need a live Rome node -> funded integration smoke.
+ *
+ * transferNativeToWormhole shares the wormholeMintAllowed / wormholeTargetChain
+ * allowlists with burnToWormhole: a wrapper/chain enabled for one is enabled for
+ * the other. These tests prove the guard wiring on the native entry point.
+ */
+
+const ZERO = "0x" + "00".repeat(32);
+const PK = (n: number) => ("0x" + n.toString(16).padStart(2, "0").repeat(32)) as `0x${string}`;
+const RECIPIENT = PK(0x99);
+
+const CCTP = {
+  tokenMessengerProgram: PK(1),
+  messageTransmitterProgram: PK(2),
+  splTokenProgram: PK(3),
+  systemProgram: ZERO,
+  messageTransmitterConfig: PK(4),
+  tokenMessengerConfig: PK(5),
+  tokenMinter: PK(6),
+  localTokenUsdc: PK(7),
+  domains: [0, 15],
+  remoteTokenMessengers: [PK(8), PK(9)],
+  senderAuthorityPda: PK(10),
+  eventAuthority: PK(11),
+  messageTransmitterEventAuthority: PK(12),
+};
+const WH = {
+  tokenBridgeProgram: PK(20), coreProgram: PK(21), splTokenProgram: PK(3),
+  systemProgram: ZERO, clockSysvar: PK(22), rentSysvar: PK(23),
+  config: PK(24), custody: PK(25), authoritySigner: PK(26), custodySigner: PK(27),
+  bridgeConfig: PK(28), feeCollector: PK(29), emitter: PK(30), sequence: PK(31),
+  wrappedMeta: PK(32), targetChain: 10002,
+};
+const FORWARDER = "0x0000000000000000000000000000000000000000";
+
+describe("RomeBridgeWithdraw — Wormhole transfer_native egress", function () {
+  let viem: any;
+  let bridge: any;
+  let wsol: any, msol: any, unregistered: any, weth: any;
+  let ownerAddr: `0x${string}`;
+
+  before(async function () {
+    ({ viem } = await hardhat.network.connect());
+    const wallets = await viem.getWalletClients();
+    ownerAddr = wallets[0].account.address;
+    const usdc = await viem.deployContract("MockSplErc20", [PK(40)]);
+    weth = await viem.deployContract("MockSplErc20", [PK(41)]);
+    wsol = await viem.deployContract("MockSplErc20", [PK(50)]); // native mint (e.g. So111..112)
+    msol = await viem.deployContract("MockSplErc20", [PK(51)]); // native LST mint
+    unregistered = await viem.deployContract("MockSplErc20", [PK(52)]);
+    // wSOL + mSOL registered as native-egress assets; Sepolia (10002) + ETH (2) allowed.
+    const WHG = {
+      admin: ownerAddr,
+      targetChains: [10002, 2],
+      assetWrappers: [wsol.address, msol.address],
+    };
+    bridge = await viem.deployContract("RomeBridgeWithdraw", [
+      FORWARDER, usdc.address, weth.address, CCTP, WH, WHG,
+    ]);
+  });
+
+  it("both native wrappers (wSOL + mSOL) are registered for native egress", async function () {
+    assert.equal(await bridge.read.wormholeAssetAllowed([wsol.address]), true);
+    assert.equal(await bridge.read.wormholeAssetAllowed([msol.address]), true);
+    assert.equal(await bridge.read.wormholeAssetAllowed([unregistered.address]), false);
+  });
+
+  it("transferNativeToWormhole with an unregistered asset reverts UnsupportedAssetWrapper", async function () {
+    await assert.rejects(
+      bridge.write.transferNativeToWormhole([unregistered.address, 1000n, RECIPIENT, 10002]),
+      /UnsupportedAssetWrapper/,
+    );
+  });
+
+  it("transferNativeToWormhole to an unlisted target chain reverts UnsupportedTargetChain", async function () {
+    await assert.rejects(
+      bridge.write.transferNativeToWormhole([wsol.address, 1000n, RECIPIENT, 5]),
+      /UnsupportedTargetChain/,
+    );
+  });
+
+  it("transferNativeToWormhole to the zero recipient reverts ZeroRecipient", async function () {
+    await assert.rejects(
+      bridge.write.transferNativeToWormhole([wsol.address, 1000n, ZERO, 10002]),
+      /ZeroRecipient/,
+    );
+  });
+
+  it("transferNativeToWormhole amount above uint64 max reverts AmountExceedsUint64", async function () {
+    await assert.rejects(
+      bridge.write.transferNativeToWormhole([wsol.address, 2n ** 64n, RECIPIENT, 10002]),
+      /AmountExceedsUint64/,
+    );
+  });
+
+  it("allowlist is mint-keyed: a second wrapper over an allowed native mint clears the asset guard", async function () {
+    const wsolAlt = await viem.deployContract("MockSplErc20", [PK(50)]); // SAME mint as wsol
+    assert.notEqual(wsolAlt.address.toLowerCase(), wsol.address.toLowerCase());
+    // Mint-keyed allowlist accepts the alt wrapper -> reverts on a LATER guard
+    // (ZeroRecipient), not UnsupportedAssetWrapper.
+    await assert.rejects(
+      bridge.write.transferNativeToWormhole([wsolAlt.address, 1000n, ZERO, 10002]),
+      /ZeroRecipient/,
+    );
+  });
+});

--- a/tests/bridge/wormhole_native_lib.test.ts
+++ b/tests/bridge/wormhole_native_lib.test.ts
@@ -1,0 +1,134 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+
+/**
+ * WormholeTokenBridgeLib — transfer_native (v11) unit tests.
+ * Network-independent (hardhat simulated EVM), mirroring cctp_v2_lib.test.ts.
+ *
+ * Ground truth is the Wormhole SDK IDL
+ * (@wormhole-foundation/sdk-solana-tokenbridge tokenBridgeType.transferNative) —
+ * the same authoritative source the deploy-side PDAs derive from. Its account
+ * order (idx 0-14) is byte-identical to the on-chain-PROVEN transfer_wrapped
+ * builder in this repo, which validates "IDL order == on-chain positional order".
+ *
+ * transfer_native differs from transfer_wrapped in three ways this test pins:
+ *   1. tag byte 0x05 (TransferNative=5) vs 0x04 (TransferWrapped=4); payload
+ *      otherwise identical.
+ *   2. NO from_owner account (delegate-authorized via authority_signer).
+ *   3. custody (idx4, per-mint) + custody_signer (idx6, global) replace
+ *      wrapped_meta; trailing programs are tokenProgram(15), wormholeProgram(16)
+ *      (native IDL order — the REVERSE of the wrapped builder's tail).
+ *
+ * idx17 token_bridge_program is the Rome-emulator #266 workaround (not in the
+ * IDL; harmless trailing account, required for Mollusk inner-CPI resolution),
+ * mirroring buildTransferWrappedAccounts.
+ */
+
+const PK = (n: number) => ("0x" + n.toString(16).padStart(2, "0").repeat(32)) as `0x${string}`;
+const TAG_NATIVE = 0x05;
+const TAG_WRAPPED = 0x04;
+
+// Distinct named pubkeys so any ordering mistake is caught.
+const A = {
+  payer: PK(1),
+  config: PK(2),
+  from: PK(3),
+  mint: PK(4),
+  custody: PK(5),
+  authority_signer: PK(6),
+  custody_signer: PK(7),
+  bridge_config: PK(8),
+  message: PK(9),
+  emitter: PK(10),
+  sequence: PK(11),
+  fee_collector: PK(12),
+  clock: PK(13),
+  rent: PK(14),
+  system: PK(15),
+  token: PK(16),
+  wormhole_core: PK(17),
+  token_bridge_program: PK(18),
+};
+
+// Canonical native layout: [name, is_signer, is_writable] per the SDK IDL
+// (transferNative) + the #266 trailing account.
+const EXPECTED: ReadonlyArray<readonly [keyof typeof A, boolean, boolean]> = [
+  ["payer", true, true],
+  ["config", false, false],
+  ["from", false, true],
+  ["mint", false, true],
+  ["custody", false, true],
+  ["authority_signer", false, false],
+  ["custody_signer", false, false],
+  ["bridge_config", false, true],
+  ["message", true, true],
+  ["emitter", false, false],
+  ["sequence", false, true],
+  ["fee_collector", false, true],
+  ["clock", false, false],
+  ["rent", false, false],
+  ["system", false, false],
+  ["token", false, false],
+  ["wormhole_core", false, false],
+  ["token_bridge_program", false, false],
+];
+
+describe("WormholeTokenBridgeLib — transfer_native", function () {
+  let h: any;
+
+  before(async function () {
+    const { viem } = await hardhat.network.connect();
+    h = await viem.deployContract("WormholeLibHarness", []);
+  });
+
+  it("encodeTransferNative emits tag 0x05 + [nonce4|amount8|fee8|target32|chain2] little-endian", async function () {
+    const nonce = 0x11223344;
+    const amount = 123456789n;
+    const fee = 7n;
+    const chain = 10002;
+    const target = ("0x" + "ab".repeat(32)) as `0x${string}`;
+
+    const out: string = await h.read.encodeNative([nonce, amount, fee, target, chain]);
+    const b = Buffer.from(out.slice(2), "hex");
+
+    assert.equal(b.length, 1 + 4 + 8 + 8 + 32 + 2, "encoded length");
+    assert.equal(b[0], TAG_NATIVE, "tag byte");
+    assert.equal(b.readUInt32LE(1), nonce, "nonce u32 LE");
+    assert.equal(b.readBigUInt64LE(5), amount, "amount u64 LE");
+    assert.equal(b.readBigUInt64LE(13), fee, "fee u64 LE");
+    assert.equal("0x" + b.subarray(21, 53).toString("hex"), target, "targetAddress 32B");
+    assert.equal(b.readUInt16LE(53), chain, "targetChain u16 LE");
+  });
+
+  it("encodeTransferNative == encodeTransferTokens with only the tag flipped 0x04->0x05", async function () {
+    const args = [0xdeadbeef, 42n, 0n, ("0x" + "cd".repeat(32)) as `0x${string}`, 2] as const;
+    const nat = Buffer.from(((await h.read.encodeNative(args)) as string).slice(2), "hex");
+    const wrp = Buffer.from(((await h.read.encodeWrapped(args)) as string).slice(2), "hex");
+    assert.equal(nat[0], TAG_NATIVE, "native tag");
+    assert.equal(wrp[0], TAG_WRAPPED, "wrapped tag");
+    assert.deepEqual(nat.subarray(1), wrp.subarray(1), "payload after tag is identical");
+  });
+
+  it("buildTransferNativeAccounts produces the canonical 18-meta native layout (order + flags)", async function () {
+    const metas = await h.read.buildNative([A]);
+    assert.equal(metas.length, EXPECTED.length, "meta count (17 IDL + #266 trailing)");
+
+    for (let i = 0; i < EXPECTED.length; i++) {
+      const [name, isSigner, isWritable] = EXPECTED[i];
+      assert.equal(metas[i].pubkey.toLowerCase(), A[name].toLowerCase(), `account[${i}] pubkey (${name})`);
+      assert.equal(metas[i].is_signer, isSigner, `account[${i}] is_signer (${name})`);
+      assert.equal(metas[i].is_writable, isWritable, `account[${i}] is_writable (${name})`);
+    }
+
+    // Crux: custody per-mint (idx4, writable), custody_signer global (idx6, ro),
+    // and there is NO from_owner (native is delegate-authorized).
+    assert.equal(metas[4].pubkey.toLowerCase(), A.custody.toLowerCase(), "custody at idx4");
+    assert.equal(metas[4].is_writable, true, "custody writable");
+    assert.equal(metas[6].pubkey.toLowerCase(), A.custody_signer.toLowerCase(), "custody_signer at idx6");
+    const signerIdxs = metas
+      .map((m: any, i: number) => (m.is_signer ? i : -1))
+      .filter((i: number) => i >= 0);
+    assert.deepEqual(signerIdxs, [0, 8], "only payer + message sign (no from_owner)");
+  });
+});


### PR DESCRIPTION
## What

`RomeBridgeWithdraw.transferNativeToWormhole` (v11) — the Solana-native-mint counterpart of `burnToWormhole`. Uses Wormhole `transfer_native` (solitaire tag 5) so **wSOL / mSOL / LSTs** egress via Wormhole: tokens lock in the Token Bridge's per-mint custody and a transfer VAA is posted for the recipient to redeem.

## Fund-critical crux

Custody is **per-mint** — derived at runtime as `find_program_address([mint], tokenBridge)`, matching `@wormhole-foundation/sdk-solana-tokenbridge` `deriveCustodyKey`. v10's single stored `wormholeCustody` serves one mint only; native egress across mints requires the per-mint derivation. `custody_signer` is global (stored deploy value reused).

## Layout verification

The `transfer_native` account order + flags were verified against the vendored Wormhole SDK IDL (`tokenBridgeType.transferNative`), cross-checked against the on-chain-proven `transfer_wrapped` builder (idx 0–14 byte-identical → IDL order == on-chain positional order). Native differs from wrapped: **no `from_owner`** (delegate-authorized), `custody` + `custody_signer` replace `wrapped_meta`, and `tokenProgram` precedes `wormholeProgram` (the reverse of wrapped's tail). The dead, never-wired `TransferAccounts`/`buildAccounts` scaffold (wrong order) was removed.

## Design notes

- **Reuses `approveWormholeBurn`** for the separate-tx delegate step — approving `authority_signer` is asset-neutral and identical for the from→custody move (same global PDA). No redundant approve function added.
- **New `WormholeNativeTransfer` event** — native *locks* in custody (does not burn), so a distinct event lets indexers tell native-lock from wrapped-burn egress.

## Tests

Full CI set green (209 passing). New:
- `tests/bridge/wormhole_native_lib.test.ts` — tag-`0x05` byte layout + the 18-meta native account order/flags asserted against the SDK IDL.
- `tests/bridge/wormhole_native_egress.test.ts` — asset / target-chain / zero-recipient / amount-bound guards + mint-keyed allowlist on the native entry point.
- Adjacent wrapped / v6 / CCTP-v2 lib tests regress green.

## Deploy

Requires a `RomeBridgeWithdraw` redeploy (v11); deployed v10 (`0xd2161cd5…`) is unaffected until then. Deploy seeds wSOL + mSOL into the Wormhole allowlist (`scripts/bridge/set-wormhole-allowlist.ts`); the `custody_signer` deploy param is already derived. Happy-path `transfer_native` CPI to be validated by a funded Hadrian smoke post-deploy.
