### PR TITLE
ops(bridge): backfill CCTP-V2 RomeBridgeWithdraw on martius/nerva/subura

### DIFF
--- a/deployments/martius.json
+++ b/deployments/martius.json
@@ -28,8 +28,8 @@
     "via": "ERC20SPLFactory.add_spl_token_no_metadata"
   },
   "RomeBridgeWithdraw": {
-    "address": "0xa79ec05a0ea7b3efeec6d802ee3dca423cbe122a",
-    "deployedAt": 1782428747
+    "address": "0x60e2b02c454be429b0047a237a57d21a68afb560",
+    "deployedAt": 1783560484
   },
   "OracleGatewayV2": {
     "deployedAt": "2026-06-26T18:17:48.917Z",

--- a/deployments/nerva.json
+++ b/deployments/nerva.json
@@ -32,8 +32,8 @@
     "via": "ERC20SPLFactory.add_spl_token_no_metadata"
   },
   "RomeBridgeWithdraw": {
-    "address": "0xf0abf2cd0bbdc3bcc060f7459e30911b0641d9b5",
-    "deployedAt": 1780022479
+    "address": "0x4440fc523d7bb7fef6702f578a2c18791a9a83ad",
+    "deployedAt": 1783560514
   },
   "OracleGatewayV2": {
     "deployedAt": "2026-07-01T03:18:01.488Z",

--- a/deployments/subura.json
+++ b/deployments/subura.json
@@ -28,8 +28,8 @@
     "via": "ERC20SPLFactory.add_spl_token_no_metadata"
   },
   "RomeBridgeWithdraw": {
-    "address": "0x9f65cfabd791bb5f87a1e659007836b517f027ff",
-    "deployedAt": 1781986758
+    "address": "0xd76bb26b93ae0b89e59263245620fd7cd97b9d78",
+    "deployedAt": 1783560537
   },
   "OracleGatewayV2": {
     "deployedAt": "2026-06-29T16:57:14.773Z",

--- a/scripts/bridge/deploy.ts
+++ b/scripts/bridge/deploy.ts
@@ -44,8 +44,7 @@ const CPI_PROGRAM_ADDRESS = "0xFF00000000000000000000000000000000000008" as cons
 // per cluster; CCTP's are the same on both. Update this set when bringing up a
 // new chain — adding it here keeps the deploy + sub-PDA derivations consistent.
 const SOLANA_DEVNET_NETWORKS = new Set([
-  "marcus", "cassius", "subura", "esquiline", "aventine", "maximus", "local",
-  "trajan", "hadrian",
+  "local", "subura", "esquiline", "hadrian", "martius", "nerva",
 ]);
 
 function programIdsFor(networkName: string) {


### PR DESCRIPTION
## What

Deploys the current CCTP-V2-capable `RomeBridgeWithdraw` to the three live chains still running bring-up-vintage v1.0.0, and fixes `scripts/bridge/deploy.ts`'s `SOLANA_DEVNET_NETWORKS` set (adds `martius`+`nerva`, drops retired `marcus`/`cassius`/`aventine`/`maximus`/`trajan`).

| Chain | New RomeBridgeWithdraw | Wrappers |
|---|---|---|
| martius (121214) | `0x60e2b02c454be429b0047a237a57d21a68afb560` | reused |
| nerva (210000) | `0x4440fc523d7bb7fef6702f578a2c18791a9a83ad` | reused |
| subura (121213) | `0xd76bb26b93ae0b89e59263245620fd7cd97b9d78` | reused |

## Why

The v6→v11 RomeBridgeWithdraw arc (CCTP v2 per-call destination, generic Wormhole burn) only ever shipped to Hadrian. On every other live chain, rome-bridge-api's outbound USDC quote targets the V2 burn selector `0x7ed19660`, which v1.0.0 doesn't implement — `eth_estimateGas` reverts, MetaMask falls back to a ~250M-gas limit (the "Max fee 5.2 USDC" symptom), and a signed burn would revert on-chain.

## Verification

- CI test set green locally (216/216: oracle + bridge + cpi).
- On-chain `eth_getCode` per chain: 18,857 bytes (byte-size-identical to Hadrian's current build), selector `7ed19660` present on all three.
- Deployer = each chain's bring-up deployer (also Wormhole allowlist admin).

## Follow-ups

- esquiline still on v1.0.0 — its deployer key isn't in this keystore (bring-up ran elsewhere).
- Registry `contracts.json` pointer updates + bridge-api pod snapshot refresh ship separately.