### PR TITLE
WrappedGasFacade: WETH9-shaped wrap/unwrap with canonical events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2026-07-09 — WrappedGasFacade: WETH9-shaped wrap/unwrap with canonical events
+
+`contracts/wrap/WrappedGasFacade.sol` — `deposit()` payable (+ `receive()`) wraps native
+gas into the chain's gas-mint wrapper; `withdraw(uint256)` unwraps back (requires prior
+ERC-20 `approve`). Emits canonical WETH9 `Deposit`/`Withdrawal` events, closing the
+explorer/indexer blindness of the raw precompile legs (`Withdraw.withdraw_to_ata` /
+`HelperProgram.deposit_from_ata`), which carry no logs and no value. Cached track only
+(`WithdrawCached` 0xff..0b + the cached wrapper's ERC-20 surface); custody pools under
+the facade's authority exactly as WETH9 pools ETH; sub-token dust refunds on deposit;
+`Granularity` guard on both legs.
+
+- **Deploy runbook:** constructor takes the gas-mint wrapper address; call the idempotent
+  `ensureAta()` once post-deploy. The wrap precompile's internal auto-create-ATA branch is
+  NOT relied on — it fails in emulation ("instruction is not supported by ASplProgram");
+  flagged upstream separately.
+- Integration test `tests/wrapped_gas_facade.integration.ts` (Hadrian, funded): wrap with
+  dust refund, `receive()` wrap, unwrap with exact native/wrapper balance deltas, zero
+  facade residue, granularity revert. 4/4 passing on Hadrian 2026-07-09.
+
 ## 2026-07-06 — RomeBridgeWithdraw: Wormhole transfer_native egress (v11, Solana-native mints)
 
 `transferNativeToWormhole(address assetWrapper, uint256 amount, bytes32 recipient, uint16 targetChain)`

--- a/contracts/wrap/WrappedGasFacade.sol
+++ b/contracts/wrap/WrappedGasFacade.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../interface.sol";
+
+interface IERC20Minimal {
+    function transfer(address to, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    function decimals() external view returns (uint8);
+}
+
+/// @title WrappedGasFacade — WETH9-shaped surface over the gas-wrapper precompiles
+/// @notice `deposit()` wraps native gas into the chain's gas-mint wrapper token;
+///         `withdraw(uint256)` unwraps back to native gas. Both emit the canonical
+///         WETH9 `Deposit`/`Withdrawal` events, so explorers, indexers and
+///         eth_getLogs consumers see gas-wrapper movements without special-casing —
+///         the raw precompile legs (`withdraw_to_ata` / `deposit`) leave no EVM
+///         footprint (no logs, no value).
+///
+///         Custody pools under the facade's own authority, exactly as WETH9 pools
+///         ETH: the wrap leg lands wrapper tokens in the facade's PDA-owned ATA
+///         (auto-created by the precompile on first use), which the facade then
+///         transfers out to the caller; the unwrap leg pulls the caller's wrapper
+///         tokens in (ERC-20 `approve` required — the wrapper is an external token,
+///         not an internal ledger) and converts them to native credit forwarded on.
+///
+///         Cached track only (one-track rule): `WithdrawCached` (0xff..0b) plus the
+///         cached wrapper's ERC-20 surface.
+contract WrappedGasFacade {
+    IERC20Minimal public immutable wrapper;
+    /// @notice Native wei per one raw wrapper token unit: 10^(18 - wrapper.decimals()).
+    ///         Amounts below this granularity cannot be represented in the wrapper.
+    uint256 public immutable weiPerToken;
+
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
+
+    error Granularity();
+    error NativeSendFailed();
+
+    constructor(IERC20Minimal _wrapper) {
+        uint8 decimals = _wrapper.decimals();
+        require(decimals <= 18, "decimals");
+        wrapper = _wrapper;
+        weiPerToken = 10 ** (18 - decimals);
+    }
+
+    /// @notice Idempotent one-time bootstrap: create the facade's gas-mint ATA.
+    ///         Run once after deploy, before the first `deposit()`. The wrap
+    ///         precompile's internal auto-create path cannot be relied on
+    ///         (unsupported in emulation), and `withdraw()`'s pull leg only
+    ///         creates the ATA as a side effect of the wrapper transfer —
+    ///         explicit creation makes the facade order-independent.
+    function ensureAta() external {
+        AssociatedSplCached.create_ata();
+    }
+
+    /// @notice Wrap native gas into wrapper tokens. Sub-token dust is refunded.
+    function deposit() external payable {
+        _deposit();
+    }
+
+    /// @notice WETH9 equivalence: a plain native transfer wraps.
+    receive() external payable {
+        _deposit();
+    }
+
+    function _deposit() private {
+        uint256 wad = msg.value - (msg.value % weiPerToken);
+        if (wad == 0) revert Granularity();
+
+        // Wrap leg: facade's native wei -> wrapper SPL in the facade's PDA-owned
+        // ATA (precompile auto-creates the ATA if missing), then hand the tokens
+        // to the caller through the wrapper's standard ERC-20 surface.
+        WithdrawCached.withdraw_to_ata(wad);
+        require(wrapper.transfer(msg.sender, wad / weiPerToken), "transfer");
+
+        uint256 dust = msg.value - wad;
+        if (dust > 0) {
+            (bool refunded, ) = payable(msg.sender).call{value: dust}("");
+            if (!refunded) revert NativeSendFailed();
+        }
+        emit Deposit(msg.sender, wad);
+    }
+
+    /// @notice Unwrap wrapper tokens back to native gas. Requires prior ERC-20
+    ///         `approve` of `wad / weiPerToken` raw tokens to this contract.
+    /// @param wad Native-wei amount; must be a whole multiple of `weiPerToken`.
+    function withdraw(uint256 wad) external {
+        if (wad == 0 || wad % weiPerToken != 0) revert Granularity();
+
+        require(wrapper.transferFrom(msg.sender, address(this), wad / weiPerToken), "pull");
+        // Unwrap leg: wrapper SPL in the facade's ATA -> native credit to the
+        // facade, forwarded to the caller.
+        WithdrawCached.deposit(wad);
+        (bool sent, ) = payable(msg.sender).call{value: wad}("");
+        if (!sent) revert NativeSendFailed();
+
+        emit Withdrawal(msg.sender, wad);
+    }
+}

--- a/tests/wrapped_gas_facade.integration.ts
+++ b/tests/wrapped_gas_facade.integration.ts
@@ -1,0 +1,149 @@
+// Integration test for WrappedGasFacade against Hadrian.
+//
+// The facade is the WETH9-shaped surface over the gas-wrapper precompile legs
+// (cached track): `deposit()` wraps native gas into the chain's gas-mint
+// wrapper token, `withdraw(uint256)` unwraps it back, and both emit the
+// canonical WETH9 `Deposit` / `Withdrawal` events so explorers, indexers and
+// eth_getLogs consumers see the movement without special-casing.
+//
+// Cases:
+//   1. deposit() with sub-token dust → wrapper balance credited, dust
+//      refunded, Deposit event emitted
+//   2. plain native send (receive()) → wraps, WETH9-equivalent
+//   3. approve + withdraw() → native credited, Withdrawal event emitted
+//   4. withdraw() with sub-token granularity → reverts
+//
+// Hadrian network only (live precompiles behind 0xff…0b are required).
+// Run: npx hardhat test tests/wrapped_gas_facade.integration.ts --network hadrian
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { getAddress, parseAbi, parseEventLogs } from "viem";
+import { readDeployments } from "../scripts/lib/deployments";
+
+const erc20Abi = parseAbi([
+    "function balanceOf(address) external view returns (uint256)",
+    "function approve(address spender, uint256 value) external returns (bool)",
+    "function decimals() external view returns (uint8)",
+]);
+
+const facadeEventsAbi = parseAbi([
+    "event Deposit(address indexed dst, uint256 wad)",
+    "event Withdrawal(address indexed src, uint256 wad)",
+]);
+
+describe("WrappedGasFacade (Hadrian)", function () {
+    let facade: any;
+    let pc: any;
+    let me: `0x${string}`;
+    let deployerAccount: any;
+    let viem: any;
+    let wrapperAddr: `0x${string}`;
+    let weiPerToken: bigint;
+
+    // 0.002 gas tokens — 2 000 raw at 6 decimals. Small on purpose.
+    const WRAP_WEI = 2_000_000_000_000_000n;
+    const DUST_WEI = 123_456_789n; // below weiPerToken; must be refunded
+
+    before(async function () {
+        const conn = (await hardhat.network.connect()) as any;
+        viem = conn.viem;
+        if (conn.networkName !== "hadrian") {
+            throw new Error(`This integration test must run against hadrian; got ${conn.networkName}`);
+        }
+        const [deployer] = await viem.getWalletClients();
+        deployerAccount = deployer.account;
+        me = deployer.account.address;
+        pc = await viem.getPublicClient();
+
+        const wrapper = (readDeployments("hadrian") as any).SPL_ERC20_USDC?.address;
+        if (!wrapper) throw new Error("SPL_ERC20_USDC missing from deployments/hadrian.json");
+        wrapperAddr = getAddress(wrapper);
+
+        facade = await viem.deployContract("WrappedGasFacade", [wrapperAddr]);
+        const ensureHash = await facade.write.ensureAta([], { account: deployerAccount });
+        await pc.waitForTransactionReceipt({ hash: ensureHash });
+        const decimals = await pc.readContract({ address: wrapperAddr, abi: erc20Abi, functionName: "decimals", args: [] });
+        weiPerToken = 10n ** BigInt(18 - Number(decimals));
+        assert.equal(await facade.read.weiPerToken(), weiPerToken);
+    });
+
+    async function wrapperBalance(of: `0x${string}`): Promise<bigint> {
+        return (await pc.readContract({ address: wrapperAddr, abi: erc20Abi, functionName: "balanceOf", args: [of] })) as bigint;
+    }
+
+    it("deposit() wraps native gas, refunds sub-token dust, emits Deposit", async function () {
+        const balBefore = await wrapperBalance(me);
+        const nativeBefore = await pc.getBalance({ address: me });
+
+        const txHash = await facade.write.deposit([], { account: deployerAccount, value: WRAP_WEI + DUST_WEI });
+        const receipt = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(receipt.status, "success");
+
+        const events = parseEventLogs({ abi: facadeEventsAbi, logs: receipt.logs, eventName: "Deposit" });
+        assert.equal(events.length, 1, "exactly one Deposit event");
+        assert.equal(events[0].args.dst.toLowerCase(), me.toLowerCase());
+        assert.equal(events[0].args.wad, WRAP_WEI);
+
+        const balAfter = await wrapperBalance(me);
+        assert.equal(balAfter - balBefore, WRAP_WEI / weiPerToken, "wrapper tokens credited");
+
+        // Dust must come back: native spent = WRAP_WEI + gas (not the dust).
+        const gasPaid = receipt.gasUsed * receipt.effectiveGasPrice;
+        const nativeAfter = await pc.getBalance({ address: me });
+        assert.equal(nativeBefore - nativeAfter, WRAP_WEI + gasPaid, "only whole-token wei + gas leaves the wallet");
+    });
+
+    it("plain native send wraps via receive()", async function () {
+        const balBefore = await wrapperBalance(me);
+        const [wallet] = await viem.getWalletClients();
+        const txHash = await wallet.sendTransaction({ to: facade.address, value: WRAP_WEI });
+        const receipt = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(receipt.status, "success");
+
+        const events = parseEventLogs({ abi: facadeEventsAbi, logs: receipt.logs, eventName: "Deposit" });
+        assert.equal(events.length, 1, "receive() emits Deposit");
+        assert.equal(await wrapperBalance(me) - balBefore, WRAP_WEI / weiPerToken);
+    });
+
+    it("withdraw() unwraps back to native gas, emits Withdrawal", async function () {
+        const tokens = WRAP_WEI / weiPerToken;
+        const [wallet] = await viem.getWalletClients();
+        const approveHash = await wallet.writeContract({
+            address: wrapperAddr,
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [facade.address, tokens],
+        });
+        await pc.waitForTransactionReceipt({ hash: approveHash });
+
+        const balBefore = await wrapperBalance(me);
+        const nativeBefore = await pc.getBalance({ address: me });
+
+        const txHash = await facade.write.withdraw([WRAP_WEI], { account: deployerAccount });
+        const receipt = await pc.waitForTransactionReceipt({ hash: txHash });
+        assert.equal(receipt.status, "success");
+
+        const events = parseEventLogs({ abi: facadeEventsAbi, logs: receipt.logs, eventName: "Withdrawal" });
+        assert.equal(events.length, 1, "exactly one Withdrawal event");
+        assert.equal(events[0].args.src.toLowerCase(), me.toLowerCase());
+        assert.equal(events[0].args.wad, WRAP_WEI);
+
+        assert.equal(balBefore - (await wrapperBalance(me)), tokens, "wrapper tokens pulled");
+
+        const gasPaid = receipt.gasUsed * receipt.effectiveGasPrice;
+        const nativeAfter = await pc.getBalance({ address: me });
+        assert.equal(nativeAfter - nativeBefore, WRAP_WEI - gasPaid, "native credited minus gas");
+
+        // No residue may accumulate on the facade.
+        assert.equal(await wrapperBalance(facade.address), 0n, "facade holds no wrapper residue");
+        assert.equal(await pc.getBalance({ address: facade.address }), 0n, "facade holds no native residue");
+    });
+
+    it("withdraw() with sub-token granularity reverts", async function () {
+        await assert.rejects(
+            facade.write.withdraw([WRAP_WEI + DUST_WEI], { account: deployerAccount }),
+            /granularity|revert/i,
+        );
+    });
+});


### PR DESCRIPTION
## What

`contracts/wrap/WrappedGasFacade.sol` — a WETH9-shaped facade over the cached gas-wrapper precompiles:

- `deposit()` payable (and plain `receive()`) wraps native gas into the chain's gas-mint wrapper token
- `withdraw(uint256)` unwraps back to native gas (requires prior ERC-20 `approve`)
- Both emit canonical WETH9 `Deposit`/`Withdrawal` events

## Why

The raw precompile legs (`Withdraw.withdraw_to_ata` / `HelperProgram.deposit_from_ata`) leave zero EVM footprint — no logs, no value — so every explorer, indexer, and eth_getLogs consumer renders wrap/unwrap as an inscrutable Helper call with an em-dash amount. rome-solidity's CLAUDE.md already mandates WETH9-equivalent event semantics for this flow; this closes the gap without any rome-evm program change or lockstep redeploy.

## Design

- **Cached track only** (one-track rule): `WithdrawCached` 0xff..0b + the cached wrapper's ERC-20 surface.
- **Pooled custody** under the facade's own authority, exactly as WETH9 pools ETH.
- Sub-token dust refunds on deposit; `Granularity` guard on both legs; zero residue invariant.
- `ensureAta()` idempotent one-time bootstrap post-deploy. The wrap precompile's internal auto-create-ATA branch is NOT relied on — it fails in emulation with "instruction is not supported by ASplProgram" (flagged upstream separately).
- One UX delta vs WETH9: unwrap needs a prior `approve`, because the wrapper is an external token rather than a facade-internal ledger.

## Verification

TDD: failing integration test first (missing artifact), then contract. `tests/wrapped_gas_facade.integration.ts` against live Hadrian (funded): wrap with dust refund + Deposit event, `receive()` wrap, unwrap with exact native/wrapper balance deltas + Withdrawal event, zero facade residue, granularity revert — **4/4 passing 2026-07-09**. Oracle parser unit suite unaffected (14/14). `npx hardhat compile` clean.

## Follow-ups (separate)

- rome-ui `useWrapUnwrap` repoint to the facade once deployed per-chain
- via classifier tags for the direct precompile legs (historical txs): rome-apps + rome-via PRs
- upstream report: cached `withdraw_to_ata` auto-create-ATA branch unimplemented in emulation