### PR TITLE
feat: add hook-aware Token-2022 CPI wrapper

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -70,7 +70,10 @@ contract ERC20Users {
 /// are inert and are accepted.
 error ArmedTransferHookUnsupported(bytes32 mint, bytes32 hookProgram);
 
-contract SPL_ERC20 is IERC20, IERC20Metadata {
+/// @dev Shared implementation for the fixed-account and hook-aware direct-CPI
+/// wrappers. Concrete wrappers choose their admission policy in the base
+/// constructor; callers must never deploy this abstract implementation.
+abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
     // SystemProgram
     bytes32 public constant system_program_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
     // ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
@@ -82,7 +85,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
 
     string private _name;
     string private _symbol;
-    ERC20Users private _users;
+    ERC20Users internal _users;
     mapping(address => bytes32) private _accounts;
 
     error ERC20InvalidApprover(address approver);
@@ -94,7 +97,8 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         address _cpi_program, 
         string memory name_, 
         string memory symbol_,
-        ERC20Users users_
+        ERC20Users users_,
+        bool supports_armed_transfer_hook
     ) {
         // decimals is the only mint fact this wrapper needs, and mint_info
         // supplies it without parsing mint bytes in Solidity. It also tells us
@@ -103,7 +107,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         // the wrapper refuses to exist rather than reverting on every transfer.
         // A present-but-unarmed hook is inert and must pass.
         (, uint8 mint_decimals, bytes32 hook_program, ,) = HelperProgram.mint_info(_mint_id);
-        if (hook_program != bytes32(0)) {
+        if (hook_program != bytes32(0) && !supports_armed_transfer_hook) {
             revert ArmedTransferHookUnsupported(_mint_id, hook_program);
         }
 
@@ -268,7 +272,7 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         address from,
         address to,
         uint256 value
-    ) internal returns (bool) {
+    ) internal virtual returns (bool) {
         require(value <= type(uint64).max, "Transfer amount exceeds uint64");
         // Suppress unused-parameter warning. `user` was the SPL Token
         // authority passed explicitly in the legacy path. Post-migration
@@ -657,4 +661,19 @@ contract SPL_ERC20 is IERC20, IERC20Metadata {
         emit Transfer(address(0), to, value);
         return true;
     }
+}
+
+/// @title SPL_ERC20
+/// @notice Fixed-account direct-CPI wrapper for legacy SPL and Token-2022
+///         mints that do not have an armed Transfer Hook.
+/// @dev Its constructor deliberately retains the armed-hook safety gate. The
+///      hook-aware sibling is SPL_ERC20_Token2022Hooked.
+contract SPL_ERC20 is SPL_ERC20Base {
+    constructor(
+        bytes32 _mint_id,
+        address _cpi_program,
+        string memory name_,
+        string memory symbol_,
+        ERC20Users users_
+    ) SPL_ERC20Base(_mint_id, _cpi_program, name_, symbol_, users_, false) {}
 }

--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ERC20Users, ArmedTransferHookUnsupported} from "./erc20spl.sol";
+import {ERC20Users} from "./erc20spl.sol";
 import {SPL_ERC20_cached} from "./erc20spl_cached.sol";
+import {ERC20SPLHookedDeployer} from "./erc20spl_hooked_deployer.sol";
 import {MplTokenMetadataLib} from "../mpl_token_metadata/lib.sol";
 import {SplTokenLib} from "../spl_token/spl_token.sol";
 import {SystemProgramLib} from "../system_program/system_program.sol";
@@ -12,11 +13,17 @@ import {Convert} from "../convert.sol";
 import {AccountReader} from "../cpi/AccountReader.sol";
 
 contract ERC20SPLFactory {
+    enum WrapperKind {
+        None,
+        Cached,
+        Token2022HookedCpi
+    }
     uint8 public constant DEFAULT_DECIMALS = 9;
     uint64 internal constant SPL_MINT_LEN = 82;
     string internal constant METAPLEX_TOKEN_METADATA_PROGRAM_NAME = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s";
 
     mapping(bytes32 => address) public token_by_mint;
+    mapping(bytes32 => WrapperKind) public wrapper_kind_by_mint;
     mapping(bytes32 => bytes32) public mint_by_symbol_hash;
     mapping(bytes32 => address) public token_by_symbol_hash;
     mapping(address => uint64) public creator_nonce;
@@ -24,6 +31,7 @@ contract ERC20SPLFactory {
     bytes32 public immutable mpl_token_metadata_program;
     address public immutable cpi_program;
     ERC20Users public immutable users;
+    ERC20SPLHookedDeployer public immutable hooked_wrapper_deployer;
 
     event TokenCreated(
         address indexed creator,
@@ -40,6 +48,7 @@ contract ERC20SPLFactory {
         cpi_program = _cpi_program;
         mpl_token_metadata_program = SystemProgram.base58_to_bytes32(bytes(METAPLEX_TOKEN_METADATA_PROGRAM_NAME));
         users = new ERC20Users();
+        hooked_wrapper_deployer = new ERC20SPLHookedDeployer();
     }
 
     function _check_symbol_hash_exists(bytes32 symbolHash) internal view {
@@ -51,38 +60,44 @@ contract ERC20SPLFactory {
         bytes32 symbolHash = keccak256(bytes(symbol));
         _check_symbol_hash_exists(symbolHash);
 
-        // Refuse an armed transfer hook before deploying, not after. The wrapper
-        // constructor refuses it too, but a factory that only found out via a
-        // failing CREATE would burn the caller's gas and leave a confusing
-        // revert; this check names the reason. A present-but-unarmed hook is
-        // inert and is accepted — refusing on presence would reject most real
-        // Token-2022 mints.
+        // Armed Transfer Hooks need a dynamic account tail and therefore use
+        // the dedicated direct-CPI wrapper. Ordinary and present-but-unarmed
+        // mints retain the cached wrapper. The two existing fixed-account
+        // wrappers continue to reject armed hooks in their own constructors.
         (, , bytes32 hook_program, ,) = HelperProgram.mint_info(mint);
+        address wrapper;
         if (hook_program != bytes32(0)) {
-            revert ArmedTransferHookUnsupported(mint, hook_program);
+            wrapper = hooked_wrapper_deployer.deploy(
+                mint, cpi_program, name, symbol, users
+            );
+            wrapper_kind_by_mint[mint] = WrapperKind.Token2022HookedCpi;
+        } else {
+            // Deploy the cache-track wrapper. `SPL_ERC20_cached` exposes the
+            // identical IERC20 + IERC20Metadata surface as the prior
+            // `SPL_ERC20`, but dispatches every mutating SPL operation
+            // through `SplCached` / `AssociatedSplCached` (0xff..05 / 06).
+            // Net effects vs the legacy CPI-track wrapper:
+            //   - Iterative-VM compatible (cached SPL ops don't trip the
+            //     legacy CpiProhibitedInIterativeTx gate), so multi-step
+            //     flows like Compound's Bulker and multi-hop swaps compose.
+            //   - EVM-revert atomicity over the Solana-side SPL side
+            //     effects (committed only at end-of-tx via the cache).
+            //   - 2–10% CU reduction on most ops (see rome-solidity #210
+            //     bench).
+            // Constructor signature is identical, so the factory's
+            // ABI / event surface is unchanged.
+            SPL_ERC20_cached cached = new SPL_ERC20_cached(
+                mint, cpi_program, name, symbol, users
+            );
+            wrapper = address(cached);
+            wrapper_kind_by_mint[mint] = WrapperKind.Cached;
         }
-
-        // Deploy the cache-track wrapper. `SPL_ERC20_cached` exposes the
-        // identical IERC20 + IERC20Metadata surface as the prior
-        // `SPL_ERC20`, but dispatches every mutating SPL operation
-        // through `SplCached` / `AssociatedSplCached` (0xff..05 / 06).
-        // Net effects vs the legacy CPI-track wrapper:
-        //   - Iterative-VM compatible (cached SPL ops don't trip the
-        //     legacy CpiProhibitedInIterativeTx gate), so multi-step
-        //     flows like Compound's Bulker and multi-hop swaps compose.
-        //   - EVM-revert atomicity over the Solana-side SPL side
-        //     effects (committed only at end-of-tx via the cache).
-        //   - 2–10% CU reduction on most ops (see rome-solidity #210
-        //     bench).
-        // Constructor signature is identical, so the factory's
-        // ABI / event surface is unchanged.
-        SPL_ERC20_cached new_contract = new SPL_ERC20_cached(mint, cpi_program, name, symbol, users);
-        token_by_mint[mint] = address(new_contract);
+        token_by_mint[mint] = wrapper;
         mint_by_symbol_hash[symbolHash] = mint;
-        token_by_symbol_hash[symbolHash] = address(new_contract);
+        token_by_symbol_hash[symbolHash] = wrapper;
 
-        emit TokenCreated(msg.sender, mint, address(new_contract), name, symbol, creator_nonce[msg.sender]);
-        return address(new_contract);
+        emit TokenCreated(msg.sender, mint, wrapper, name, symbol, creator_nonce[msg.sender]);
+        return wrapper;
     }
 
     /**

--- a/contracts/erc20spl/erc20spl_hooked_deployer.sol
+++ b/contracts/erc20spl/erc20spl_hooked_deployer.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ERC20Users} from "./erc20spl.sol";
+import {SPL_ERC20_Token2022Hooked} from "./erc20spl_token2022_hooked.sol";
+
+/// @dev Keeps the hooked wrapper's creation code out of ERC20SPLFactory's
+/// runtime bytecode. Only the factory that created this deployer may use it.
+contract ERC20SPLHookedDeployer {
+    address public immutable factory;
+
+    error OnlyFactory(address caller);
+
+    constructor() {
+        factory = msg.sender;
+    }
+
+    function deploy(
+        bytes32 mint,
+        address cpiProgram,
+        string memory name,
+        string memory symbol,
+        ERC20Users users
+    ) external returns (address wrapper) {
+        if (msg.sender != factory) revert OnlyFactory(msg.sender);
+        wrapper = address(new SPL_ERC20_Token2022Hooked(
+            mint, cpiProgram, name, symbol, users
+        ));
+    }
+}

--- a/contracts/erc20spl/erc20spl_token2022_hooked.sol
+++ b/contracts/erc20spl/erc20spl_token2022_hooked.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {SPL_ERC20Base, ERC20Users} from "./erc20spl.sol";
+import {
+    ICrossProgramInvocation,
+    ISystemProgram,
+    SystemProgram,
+    HelperProgram
+} from "../interface.sol";
+import {RomeEVMAccount} from "../rome_evm_account.sol";
+import {SolanaConstants} from "../cpi/SolanaConstants.sol";
+import {Token2022HookedTransfer} from "../spl_token/token2022_hooked_transfer.sol";
+
+/// @title SPL_ERC20_Token2022Hooked
+/// @notice Direct-CPI ERC-20 surface for a Token-2022 mint with an armed
+///         Transfer Hook.
+/// @dev Transfer entrypoints take the complete, already-resolved hook account
+///      tail. The wrapper validates the invariant hook-program + validation-PDA
+///      trailer, then forwards the tail unchanged to Token-2022. Resolution is
+///      application/client work because ExtraAccountMetaList entries can depend
+///      on the instruction, endpoint accounts and account data.
+contract SPL_ERC20_Token2022Hooked is SPL_ERC20Base {
+    bytes internal constant EXTRA_ACCOUNT_METAS_SEED = "extra-account-metas";
+
+    bytes32 public immutable hook_program;
+    bytes32 public immutable validation_account;
+
+    error ArmedTransferHookRequired(bytes32 mint);
+    error Token2022MintRequired(bytes32 mint, bytes32 tokenProgram);
+    error HookAccountPlanRequired();
+    error HookConfigurationChanged(
+        bytes32 expectedHookProgram,
+        bytes32 actualHookProgram
+    );
+
+    constructor(
+        bytes32 _mint_id,
+        address _cpi_program,
+        string memory name_,
+        string memory symbol_,
+        ERC20Users users_
+    ) SPL_ERC20Base(_mint_id, _cpi_program, name_, symbol_, users_, true) {
+        (bytes32 tokenProgram, , bytes32 hookProgram, ,) =
+            HelperProgram.mint_info(_mint_id);
+        if (tokenProgram != SolanaConstants.TOKEN_2022_PROGRAM) {
+            revert Token2022MintRequired(_mint_id, tokenProgram);
+        }
+        if (hookProgram == bytes32(0)) {
+            revert ArmedTransferHookRequired(_mint_id);
+        }
+
+        ISystemProgram.Seed[] memory seeds = new ISystemProgram.Seed[](2);
+        seeds[0] = ISystemProgram.Seed(EXTRA_ACCOUNT_METAS_SEED);
+        seeds[1] = ISystemProgram.Seed(abi.encodePacked(_mint_id));
+        (bytes32 validation, ) =
+            SystemProgram.find_program_address(hookProgram, seeds);
+
+        hook_program = hookProgram;
+        validation_account = validation;
+    }
+
+    /// @notice Standard ERC-20 transfer cannot carry a dynamic Solana account
+    ///         plan. Call transferWithHookAccounts instead.
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert HookAccountPlanRequired();
+    }
+
+    /// @notice Standard ERC-20 transferFrom cannot carry a dynamic Solana
+    ///         account plan. Call transferFromWithHookAccounts instead.
+    function transferFrom(address, address, uint256)
+        public
+        pure
+        override
+        returns (bool)
+    {
+        revert HookAccountPlanRequired();
+    }
+
+    function transferWithHookAccounts(
+        address to,
+        uint256 value,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) public returns (bool) {
+        _users.ensure_user(msg.sender);
+        return _hookedTransfer(msg.sender, to, value, hookMetas);
+    }
+
+    function transferFromWithHookAccounts(
+        address from,
+        address to,
+        uint256 value,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) public returns (bool) {
+        _users.ensure_user(msg.sender);
+        return _hookedTransfer(from, to, value, hookMetas);
+    }
+
+    function _validateCurrentPlan(
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) internal view {
+        (bytes32 tokenProgram, , bytes32 currentHookProgram, ,) =
+            HelperProgram.mint_info(mint_id);
+        if (tokenProgram != SolanaConstants.TOKEN_2022_PROGRAM) {
+            revert Token2022MintRequired(mint_id, tokenProgram);
+        }
+        if (currentHookProgram != hook_program) {
+            revert HookConfigurationChanged(hook_program, currentHookProgram);
+        }
+        Token2022HookedTransfer.validate(
+            hook_program, validation_account, hookMetas
+        );
+    }
+
+    function _hookedTransfer(
+        address from,
+        address to,
+        uint256 value,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) internal returns (bool) {
+        require(value <= type(uint64).max, "Transfer amount exceeds uint64");
+        _validateCurrentPlan(hookMetas);
+
+        (, , , uint16 feeBps, ) = HelperProgram.mint_info(mint_id);
+        bool feeArmed = feeBps > 0;
+        uint256 beforeBalance = feeArmed ? balanceOf(to) : 0;
+
+        bytes32 destination = ensure_token_account(to);
+        bytes32 source = HelperProgram.ata(from, mint_id);
+        Token2022HookedTransfer.transferChecked(
+            source,
+            mint_id,
+            destination,
+            RomeEVMAccount.pda(msg.sender),
+            uint64(value),
+            decimals,
+            hookMetas
+        );
+
+        uint256 delivered = value;
+        if (feeArmed) {
+            uint256 afterBalance = balanceOf(to);
+            delivered = to == from
+                ? value - (beforeBalance - afterBalance)
+                : afterBalance - beforeBalance;
+        }
+        emit Transfer(from, to, delivered);
+        return true;
+    }
+
+    /// @notice The base bridge-out signature cannot carry hook accounts.
+    function bridgeOutToSolana(bytes32, uint256)
+        public
+        pure
+        override
+        returns (bool)
+    {
+        revert HookAccountPlanRequired();
+    }
+
+    function bridgeOutToSolanaWithHookAccounts(
+        bytes32 solanaRecipient,
+        uint256 value,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) public returns (bool) {
+        require(value <= type(uint64).max, "Bridge amount exceeds uint64");
+        require(solanaRecipient != bytes32(0), "Solana recipient cannot be zero");
+        _validateCurrentPlan(hookMetas);
+
+        _users.ensure_user(msg.sender);
+        bytes32 destination = ensureRecipientAta(solanaRecipient);
+        bytes32 source = HelperProgram.ata(msg.sender, mint_id);
+        Token2022HookedTransfer.transferChecked(
+            source,
+            mint_id,
+            destination,
+            RomeEVMAccount.pda(msg.sender),
+            uint64(value),
+            decimals,
+            hookMetas
+        );
+
+        emit BridgedOutToSolana(
+            msg.sender, solanaRecipient, mint_id, value
+        );
+        return true;
+    }
+}

--- a/contracts/spl_token/test/Token2022HookedTransferHarness.sol
+++ b/contracts/spl_token/test/Token2022HookedTransferHarness.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ICrossProgramInvocation} from "../../interface.sol";
+import {Token2022HookedTransfer} from "../token2022_hooked_transfer.sol";
+
+contract Token2022HookedTransferHarness {
+    function plan(
+        bytes32 source,
+        bytes32 mint,
+        bytes32 destination,
+        bytes32 authority,
+        uint64 amount,
+        uint8 decimals,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) external pure returns (bytes memory, ICrossProgramInvocation.AccountMeta[] memory) {
+        return Token2022HookedTransfer.plan(
+            source, mint, destination, authority, amount, decimals, hookMetas
+        );
+    }
+
+    function validate(
+        bytes32 hookProgram,
+        bytes32 validation,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) external pure {
+        Token2022HookedTransfer.validate(hookProgram, validation, hookMetas);
+    }
+}

--- a/contracts/spl_token/token2022_hooked_transfer.sol
+++ b/contracts/spl_token/token2022_hooked_transfer.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {ICrossProgramInvocation, CpiProgram} from "../interface.sol";
+import {SolanaConstants} from "../cpi/SolanaConstants.sol";
+
+/// @title Token2022HookedTransfer
+/// @notice Builds and executes Token-2022 TransferChecked with a caller-resolved
+///         Transfer Hook account plan.
+/// @dev Token-2022, not this library, executes and enforces the hook. The
+///      account tail must be resolved from the mint's ExtraAccountMetaList by
+///      the integrating client/adapter. This path is direct CPI only.
+library Token2022HookedTransfer {
+    uint8 internal constant TRANSFER_CHECKED = 12;
+
+    error CpiFailed(bytes reason);
+    error IncompleteHookAccountPlan(uint256 actual);
+    error InvalidHookProgramMeta(bytes32 expected, bytes32 actual, bool signer, bool writable);
+    error InvalidValidationMeta(bytes32 expected, bytes32 actual, bool signer, bool writable);
+
+    /// @notice Validate the invariant trailer Token-2022 appends after the four
+    ///         fixed TransferChecked accounts and all accounts resolved from
+    ///         ExtraAccountMetaList: hook program, then validation PDA.
+    function validate(
+        bytes32 expectedHookProgram,
+        bytes32 expectedValidation,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) internal pure {
+        if (hookMetas.length < 2) {
+            revert IncompleteHookAccountPlan(hookMetas.length);
+        }
+
+        uint256 hookIndex = hookMetas.length - 2;
+        ICrossProgramInvocation.AccountMeta memory hook = hookMetas[hookIndex];
+        if (
+            hook.pubkey != expectedHookProgram ||
+            hook.is_signer ||
+            hook.is_writable
+        ) {
+            revert InvalidHookProgramMeta(
+                expectedHookProgram, hook.pubkey, hook.is_signer, hook.is_writable
+            );
+        }
+
+        ICrossProgramInvocation.AccountMeta memory validation =
+            hookMetas[hookIndex + 1];
+        if (
+            validation.pubkey != expectedValidation ||
+            validation.is_signer ||
+            validation.is_writable
+        ) {
+            revert InvalidValidationMeta(
+                expectedValidation,
+                validation.pubkey,
+                validation.is_signer,
+                validation.is_writable
+            );
+        }
+    }
+
+    function plan(
+        bytes32 source,
+        bytes32 mint,
+        bytes32 destination,
+        bytes32 authority,
+        uint64 amount,
+        uint8 decimals,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    )
+        internal
+        pure
+        returns (
+            bytes memory data,
+            ICrossProgramInvocation.AccountMeta[] memory metas
+        )
+    {
+        data = transferCheckedData(amount, decimals);
+        metas = new ICrossProgramInvocation.AccountMeta[](4 + hookMetas.length);
+        metas[0] = ICrossProgramInvocation.AccountMeta(source, false, true);
+        metas[1] = ICrossProgramInvocation.AccountMeta(mint, false, false);
+        metas[2] = ICrossProgramInvocation.AccountMeta(destination, false, true);
+        metas[3] = ICrossProgramInvocation.AccountMeta(authority, true, false);
+        for (uint256 i; i < hookMetas.length; ++i) {
+            metas[4 + i] = hookMetas[i];
+        }
+    }
+
+    /// @dev Delegatecall is required: the Rome CPI precompile signs as the EVM
+    ///      caller visible in the current context. CALL would make the wrapper
+    ///      contract, rather than the user/delegate, the Solana authority.
+    function transferChecked(
+        bytes32 source,
+        bytes32 mint,
+        bytes32 destination,
+        bytes32 authority,
+        uint64 amount,
+        uint8 decimals,
+        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+    ) internal {
+        (bytes memory data, ICrossProgramInvocation.AccountMeta[] memory metas) =
+            plan(source, mint, destination, authority, amount, decimals, hookMetas);
+        (bool ok, bytes memory result) = address(CpiProgram).delegatecall(
+            abi.encodeWithSignature(
+                "invoke(bytes32,(bytes32,bool,bool)[],bytes)",
+                SolanaConstants.TOKEN_2022_PROGRAM,
+                metas,
+                data
+            )
+        );
+        if (!ok) revert CpiFailed(result);
+    }
+
+    function transferCheckedData(uint64 amount, uint8 decimals)
+        internal
+        pure
+        returns (bytes memory data)
+    {
+        data = new bytes(10);
+        data[0] = bytes1(TRANSFER_CHECKED);
+        for (uint256 i; i < 8; ++i) {
+            data[1 + i] = bytes1(uint8(amount >> (8 * i)));
+        }
+        data[9] = bytes1(decimals);
+    }
+}

--- a/evidence/leaf2-token2022-production-wrapper-hadrian-1785943190067.json
+++ b/evidence/leaf2-token2022-production-wrapper-hadrian-1785943190067.json
@@ -1,0 +1,28 @@
+{
+  "status": "pass",
+  "scope": "factory-created SPL_ERC20_Token2022Hooked on Hadrian",
+  "mint": "75wP528i7uzEH9NGJa1cpFigDrLE4bnb1kS1MUauRkSz",
+  "hookProgram": "6e52qcdWaHV1DHnafeCWf2FuAH2fqj13nAD1KVoZWTm3",
+  "validation": "3XK9JaBnrEHsXrLK455Vz6hXxtSP2qxMZw8uEJk1QzH6",
+  "factory": "0xd261b634583d2aaaa07b6a9d4c055db8ce1cfd1c",
+  "wrapper": "0xD80B71b26F1FB45917142077a69E597186e1BEA8",
+  "wrapperKind": 2,
+  "transactions": {
+    "factoryDeploy": "0xec82f3ce35f8458346b677868e1f1b794550b94d639139dbed21097e8b9f2aa4",
+    "register": "0x6a604c47c48ac23e4b959eb7591bdf9b6c00acf6846465428faa9b1a447ba2be",
+    "hookedTransfer": "0x7a70d3044f7df082ea91987883010e9465a02c5b2882feba2fa8c6760ad246dd"
+  },
+  "standardTransfer": {
+    "rejected": true,
+    "balancesUnchanged": true,
+    "detail": "The contract function \"transfer\" reverted.\n\nError: HookAccountPlanRequired()\n \nContract Call:\n  address:   0xD80B71b26F1FB45917142077a69E597186e1BEA8\n  function:  transfer(address to, uint256 value)\n  args:              (0x74d76F704109a14DDf4C4474548ecC7a0356188a, 1000)\n  sender:    0x5667b3700b4a021Cc475157cbf3dE2d756Fae597\n\nDocs: https://viem.sh/docs/contract/writeContract\nDetails: execution reverted: \nVersion: viem@2.55.10"
+  },
+  "balances": {
+    "sourceAta": "2gezXfNkX6UiFBxbNy4FRm1kDaPYAPKWbeLfWxVoiEPd",
+    "recipientAta": "2Qq17E3oFjM7Q12MA8LiLrSV5GqJbxapYi2G8pLs1MK3",
+    "sourceBefore": "1000000",
+    "sourceAfter": "999000",
+    "recipientBefore": "0",
+    "recipientAfter": "1000"
+  }
+}

--- a/evidence/leaf2-token2022-production-wrapper-hadrian-2026-08-05.md
+++ b/evidence/leaf2-token2022-production-wrapper-hadrian-2026-08-05.md
@@ -1,0 +1,84 @@
+# Leaf 2 — production hook-aware wrapper Hadrian evidence
+
+Date: 5 August 2026  
+Status: PASS
+
+## What this proves
+
+The production implementation—not the earlier generic spike adapter—completed
+the full path on Hadrian:
+
+```text
+ERC20SPLFactory
+  -> SPL_ERC20_Token2022Hooked
+  -> Rome generic CPI precompile (delegatecall)
+  -> Token-2022 TransferChecked
+  -> armed Transfer Hook
+  -> destination Token-2022 ATA
+```
+
+The factory read the mint's armed hook through `mint_info`, deployed the third
+wrapper type, and recorded `wrapperKind = 2` (`Token2022HookedCpi`). The wrapper
+pinned the expected hook program and derived the canonical
+`extra-account-metas` validation PDA.
+
+## Public identifiers
+
+- Mint: `75wP528i7uzEH9NGJa1cpFigDrLE4bnb1kS1MUauRkSz`
+- Hook program: `6e52qcdWaHV1DHnafeCWf2FuAH2fqj13nAD1KVoZWTm3`
+- Validation PDA: `3XK9JaBnrEHsXrLK455Vz6hXxtSP2qxMZw8uEJk1QzH6`
+- Factory: `0xd261b634583d2aaaa07b6a9d4c055db8ce1cfd1c`
+- Factory-created wrapper: `0xD80B71b26F1FB45917142077a69E597186e1BEA8`
+
+## Transactions
+
+- [Factory deployment](https://via-hadrian.testnet.romeprotocol.xyz/tx/0xec82f3ce35f8458346b677868e1f1b794550b94d639139dbed21097e8b9f2aa4)
+- [Armed mint registration and wrapper creation](https://via-hadrian.testnet.romeprotocol.xyz/tx/0x6a604c47c48ac23e4b959eb7591bdf9b6c00acf6846465428faa9b1a447ba2be)
+- [Hook-aware transfer](https://via-hadrian.testnet.romeprotocol.xyz/tx/0x7a70d3044f7df082ea91987883010e9465a02c5b2882feba2fa8c6760ad246dd)
+
+## Safety negative
+
+Calling the ordinary ERC-20 `transfer(address,uint256)` surface reverted during
+simulation with `HookAccountPlanRequired()`. No transaction was broadcast and
+neither source nor destination balance moved. This prevents an integration from
+silently omitting the hook accounts.
+
+The hook-aware call then supplied the fixture's complete account tail:
+
+```text
+[hook program, validation PDA]
+```
+
+This fixture's `ExtraAccountMetaList` is empty, so those two invariant trailer
+accounts are the complete plan. Production hooks with resolved policy accounts
+use the official order:
+
+```text
+[resolved policy accounts..., hook program, validation PDA]
+```
+
+## Balance proof
+
+| Account | Before | After | Delta |
+|---|---:|---:|---:|
+| Source ATA `2gez…iEPd` | 1,000,000 | 999,000 | -1,000 |
+| Recipient ATA `2Qq1…1MK3` | 0 | 1,000 | +1,000 |
+
+Raw machine-readable receipt:
+`leaf2-token2022-production-wrapper-hadrian-1785943190067.json`.
+
+## Local regression evidence
+
+- `npx hardhat compile --force`: PASS, 94 Solidity files.
+- Token-2022 suite: 54 passing.
+- Full local Node suite: 344 passing.
+- Runtime bytecode: factory 16,986 bytes; hooked wrapper 8,854 bytes;
+  factory-owned hooked deployer 11,674 bytes. All remain below EIP-170.
+
+## Remaining boundary
+
+This on-chain receipt proves the actual production wrapper against a genuinely
+armed hook with an empty resolved policy list. A named issuer integration must
+still resolve and test that issuer's non-empty `ExtraAccountMetaList` and target
+market action. That is per-application admission work, not a Rome EVM program
+change.

--- a/scripts/token2022/smoke-hooked-wrapper-hadrian.ts
+++ b/scripts/token2022/smoke-hooked-wrapper-hadrian.ts
@@ -1,0 +1,220 @@
+/**
+ * Hadrian smoke for the production hook-aware wrapper path:
+ * factory -> SPL_ERC20_Token2022Hooked -> generic CPI -> Token-2022 -> hook.
+ *
+ * Required environment (public fixture identifiers only):
+ *   LEAF2_MINT, LEAF2_HOOK_PROGRAM, LEAF2_VALIDATION
+ * Signing material is loaded from the established local test wallet file and
+ * is never printed or written to evidence.
+ */
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+    createPublicClient,
+    createWalletClient,
+    http,
+    type Hex,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+const HADRIAN_RPC = "https://hadrian.testnet.romeprotocol.xyz/";
+const CPI = "0xff00000000000000000000000000000000000008" as const;
+const ZERO = "0x0000000000000000000000000000000000000000" as const;
+const AMOUNT = 1_000n;
+
+const factoryAbi = [
+    { type: "function", name: "add_spl_token_no_metadata", stateMutability: "nonpayable", inputs: [{ type: "bytes32", name: "mint" }, { type: "string", name: "name" }, { type: "string", name: "symbol" }], outputs: [{ type: "address" }] },
+    { type: "function", name: "token_by_mint", stateMutability: "view", inputs: [{ type: "bytes32", name: "mint" }], outputs: [{ type: "address" }] },
+    { type: "function", name: "wrapper_kind_by_mint", stateMutability: "view", inputs: [{ type: "bytes32", name: "mint" }], outputs: [{ type: "uint8" }] },
+] as const;
+const wrapperAbi = [
+    { type: "error", name: "HookAccountPlanRequired", inputs: [] },
+    { type: "function", name: "get_token_account", stateMutability: "view", inputs: [{ type: "address", name: "user" }], outputs: [{ type: "bytes32" }] },
+    { type: "function", name: "hook_program", stateMutability: "view", inputs: [], outputs: [{ type: "bytes32" }] },
+    { type: "function", name: "validation_account", stateMutability: "view", inputs: [], outputs: [{ type: "bytes32" }] },
+    { type: "function", name: "transfer", stateMutability: "nonpayable", inputs: [{ type: "address", name: "to" }, { type: "uint256", name: "value" }], outputs: [{ type: "bool" }] },
+    { type: "function", name: "transferWithHookAccounts", stateMutability: "nonpayable", inputs: [
+        { type: "address", name: "to" },
+        { type: "uint256", name: "value" },
+        { type: "tuple[]", name: "hookMetas", components: [{ type: "bytes32", name: "pubkey" }, { type: "bool", name: "is_signer" }, { type: "bool", name: "is_writable" }] },
+    ], outputs: [{ type: "bool" }] },
+] as const;
+
+function envPublicKey(name: string): PublicKey {
+    const raw = process.env[name];
+    if (!raw) throw new Error(`${name} is required`);
+    return new PublicKey(raw);
+}
+
+function bytes32(key: PublicKey): `0x${string}` {
+    return `0x${Buffer.from(key.toBytes()).toString("hex")}`;
+}
+
+function publicKey(key: `0x${string}`): PublicKey {
+    return new PublicKey(Buffer.from(key.slice(2), "hex"));
+}
+
+function artifact(path: string): { abi: readonly unknown[]; bytecode: Hex } {
+    return JSON.parse(readFileSync(join(process.cwd(), path), "utf8"));
+}
+
+async function gasPrice(): Promise<bigint> {
+    const response = await fetch(HADRIAN_RPC, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_gasPrice", params: [] }),
+    });
+    const payload = await response.json() as { result?: Hex; error?: unknown };
+    if (!payload.result) throw new Error(`eth_gasPrice failed: ${JSON.stringify(payload.error)}`);
+    return (BigInt(payload.result) * 12n) / 10n;
+}
+
+async function tokenAmount(connection: Connection, ata: PublicKey): Promise<bigint> {
+    const info = await connection.getAccountInfo(ata, "confirmed");
+    if (!info) return 0n;
+    assert.ok(info.data.length >= 72, "token account data too short");
+    return info.data.readBigUInt64LE(64);
+}
+
+async function main(): Promise<void> {
+    const mint = envPublicKey("LEAF2_MINT");
+    const hook = envPublicKey("LEAF2_HOOK_PROGRAM");
+    const validation = envPublicKey("LEAF2_VALIDATION");
+    const solanaRpc = readFileSync(
+        join(homedir(), ".rome-test-wallets", "solana-devnet-rpc"),
+        "utf8",
+    ).trim();
+    const solana = new Connection(solanaRpc, "confirmed");
+    const issuer = privateKeyToAccount(
+        readFileSync(join(homedir(), ".rome-test-wallets", "evm.key"), "utf8").trim() as Hex,
+    );
+    const recipient = privateKeyToAccount(generatePrivateKey());
+    const publicClient = createPublicClient({ transport: http(HADRIAN_RPC) });
+    const walletClient = createWalletClient({ account: issuer, transport: http(HADRIAN_RPC) });
+    const options = { account: issuer, gasPrice: await gasPrice() };
+
+    const factoryArtifact = artifact(
+        "artifacts/contracts/erc20spl/erc20spl_factory.sol/ERC20SPLFactory.json",
+    );
+    const factoryDeployHash = await walletClient.deployContract({
+        ...options,
+        abi: factoryArtifact.abi,
+        bytecode: factoryArtifact.bytecode,
+        args: [CPI],
+    });
+    const factoryReceipt = await publicClient.waitForTransactionReceipt({ hash: factoryDeployHash });
+    assert.equal(factoryReceipt.status, "success");
+    assert.ok(factoryReceipt.contractAddress);
+
+    const registerHash = await walletClient.writeContract({
+        ...options,
+        address: factoryReceipt.contractAddress,
+        abi: factoryAbi,
+        functionName: "add_spl_token_no_metadata",
+        args: [bytes32(mint), "Leaf 2 Hook Fixture", "L2HOOK"],
+    });
+    assert.equal((await publicClient.waitForTransactionReceipt({ hash: registerHash })).status, "success");
+    const wrapper = await publicClient.readContract({
+        address: factoryReceipt.contractAddress,
+        abi: factoryAbi,
+        functionName: "token_by_mint",
+        args: [bytes32(mint)],
+    });
+    assert.notEqual(wrapper, ZERO);
+    const kind = await publicClient.readContract({
+        address: factoryReceipt.contractAddress,
+        abi: factoryAbi,
+        functionName: "wrapper_kind_by_mint",
+        args: [bytes32(mint)],
+    });
+    assert.equal(kind, 2);
+    assert.equal(await publicClient.readContract({ address: wrapper, abi: wrapperAbi, functionName: "hook_program" }), bytes32(hook));
+    assert.equal(await publicClient.readContract({ address: wrapper, abi: wrapperAbi, functionName: "validation_account" }), bytes32(validation));
+
+    const sourceAta = publicKey(await publicClient.readContract({
+        address: wrapper,
+        abi: wrapperAbi,
+        functionName: "get_token_account",
+        args: [issuer.address],
+    }));
+    const recipientAta = publicKey(await publicClient.readContract({
+        address: wrapper,
+        abi: wrapperAbi,
+        functionName: "get_token_account",
+        args: [recipient.address],
+    }));
+    const sourceBefore = await tokenAmount(solana, sourceAta);
+    const recipientBefore = await tokenAmount(solana, recipientAta);
+    assert.ok(sourceBefore >= AMOUNT, "fixture issuer balance is insufficient");
+
+    let standardTransferFailure = "";
+    try {
+        await walletClient.writeContract({
+            ...options,
+            address: wrapper,
+            abi: wrapperAbi,
+            functionName: "transfer",
+            args: [recipient.address, AMOUNT],
+        });
+        throw new Error("standard transfer unexpectedly succeeded");
+    } catch (error) {
+        if (error instanceof Error && error.message === "standard transfer unexpectedly succeeded") throw error;
+        standardTransferFailure = error instanceof Error ? error.message.slice(0, 600) : String(error).slice(0, 600);
+        assert.match(standardTransferFailure, /HookAccountPlanRequired/);
+    }
+    assert.equal(await tokenAmount(solana, sourceAta), sourceBefore);
+    assert.equal(await tokenAmount(solana, recipientAta), recipientBefore);
+
+    // This fixture has an empty ExtraAccountMetaList. The complete official
+    // trailer is therefore hook program + validation PDA.
+    const hookMetas = [
+        { pubkey: bytes32(hook), is_signer: false, is_writable: false },
+        { pubkey: bytes32(validation), is_signer: false, is_writable: false },
+    ];
+    const transferHash = await walletClient.writeContract({
+        ...options,
+        address: wrapper,
+        abi: wrapperAbi,
+        functionName: "transferWithHookAccounts",
+        args: [recipient.address, AMOUNT, hookMetas],
+    });
+    const transferReceipt = await publicClient.waitForTransactionReceipt({ hash: transferHash });
+    assert.equal(transferReceipt.status, "success");
+    const sourceAfter = await tokenAmount(solana, sourceAta);
+    const recipientAfter = await tokenAmount(solana, recipientAta);
+    assert.equal(sourceAfter, sourceBefore - AMOUNT);
+    assert.equal(recipientAfter, recipientBefore + AMOUNT);
+
+    const evidence = {
+        status: "pass",
+        scope: "factory-created SPL_ERC20_Token2022Hooked on Hadrian",
+        mint: mint.toBase58(),
+        hookProgram: hook.toBase58(),
+        validation: validation.toBase58(),
+        factory: factoryReceipt.contractAddress,
+        wrapper,
+        wrapperKind: Number(kind),
+        transactions: { factoryDeploy: factoryDeployHash, register: registerHash, hookedTransfer: transferHash },
+        standardTransfer: { rejected: true, balancesUnchanged: true, detail: standardTransferFailure },
+        balances: {
+            sourceAta: sourceAta.toBase58(),
+            recipientAta: recipientAta.toBase58(),
+            sourceBefore: sourceBefore.toString(),
+            sourceAfter: sourceAfter.toString(),
+            recipientBefore: recipientBefore.toString(),
+            recipientAfter: recipientAfter.toString(),
+        },
+    };
+    mkdirSync("evidence", { recursive: true });
+    const evidencePath = `evidence/leaf2-token2022-production-wrapper-hadrian-${Date.now()}.json`;
+    writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+    console.log(JSON.stringify({ ...evidence, evidence: evidencePath }, null, 2));
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});

--- a/tests/token2022/admission.test.ts
+++ b/tests/token2022/admission.test.ts
@@ -3,10 +3,9 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { network } from "hardhat";
 
-// Admission is keyed on the ARMED hook, at every path that can bring a wrapper
-// into existence. Three such paths exist: the factory, and each wrapper's own
-// constructor — the second reachable directly by the deploy scripts, which the
-// factory gate never sees.
+// Admission is keyed on the ARMED hook at each wrapper constructor. The two
+// fixed-account wrappers refuse it; the factory routes it to the dedicated
+// direct-CPI wrapper, whose caller supplies the resolved hook account plan.
 //
 // The first block asserts the wiring, which is what can silently regress: that
 // each path declares the error and reads mint_info on its own track. The second
@@ -30,7 +29,6 @@ function abi(iface: string) {
 }
 
 const PATHS: Array<[string, string, string]> = [
-    ["factory", "erc20spl/erc20spl_factory.sol", "HelperProgram"],
     ["legacy wrapper ctor", "erc20spl/erc20spl.sol", "HelperProgram"],
     ["cached wrapper ctor", "erc20spl/erc20spl_cached.sol", "SplCached"],
 ];
@@ -118,12 +116,14 @@ describe("armed-hook admission, executed", async () => {
         feeBps: number,
         tag: number,
         hookPresent = hookArmed,
+        legacy = false,
     ): `0x${string}` {
         const b = new Uint8Array(32);
         b[0] = decimals;
         b[1] = hookArmed ? 1 : 0;
         b[2] = (feeBps >> 8) & 0xff;
         b[3] = feeBps & 0xff;
+        b[4] = legacy ? 1 : 0;
         b[5] = hookPresent ? 1 : 0;
         b[31] = tag;
         return `0x${Buffer.from(b).toString("hex")}` as `0x${string}`;
@@ -182,18 +182,56 @@ describe("armed-hook admission, executed", async () => {
         );
     });
 
-    // The third admission path. It refuses before deploying rather than letting
-    // the wrapper's own constructor fail, so the caller does not pay for a CREATE
-    // that was always going to revert. The gate is the first thing the register
-    // path does after the symbol check, which is why it is reachable here without
-    // mocking the mint-creation machinery behind it.
-    it("the factory refuses an armed hook before it deploys anything", async () => {
+    it("the hook-aware wrapper requires an armed Token-2022 hook", async () => {
+        await assert.rejects(
+            deployWrapper("SPL_ERC20_Token2022Hooked", mintId(6, false, 0, 51)),
+            /ArmedTransferHookRequired/,
+        );
+        await assert.rejects(
+            deployWrapper("SPL_ERC20_Token2022Hooked", mintId(6, true, 0, 52, true, true)),
+            /Token2022MintRequired/,
+        );
+    });
+
+    it("the hook-aware wrapper makes the account-plan requirement explicit", async () => {
+        const hooked = await deployWrapper(
+            "SPL_ERC20_Token2022Hooked",
+            mintId(6, true, 0, 53),
+        );
+        await assert.rejects(
+            hooked.read.transfer(["0x0000000000000000000000000000000000000001", 1n]),
+            /HookAccountPlanRequired/,
+        );
+        await assert.rejects(
+            hooked.read.transferFrom([
+                "0x0000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000002",
+                1n,
+            ]),
+            /HookAccountPlanRequired/,
+        );
+    });
+
+    it("the factory routes an armed hook to the direct-CPI wrapper", async () => {
         const factory = await viem.deployContract("ERC20SPLFactory", [
             "0xff00000000000000000000000000000000000008",
         ]);
-        await assert.rejects(
-            factory.write.add_spl_token_no_metadata([mintId(6, true, 0, 6), "Wrapped", "WRAP"]),
-            /ArmedTransferHookUnsupported/,
+        const mint = mintId(6, true, 0, 6);
+        await factory.write.add_spl_token_no_metadata([mint, "Wrapped", "WRAP"]);
+
+        const wrapper = await factory.read.token_by_mint([mint]);
+        assert.notEqual(wrapper, "0x0000000000000000000000000000000000000000");
+        const hooked = await viem.getContractAt("SPL_ERC20_Token2022Hooked", wrapper as `0x${string}`);
+        assert.equal(await hooked.read.mint_id(), mint);
+        assert.notEqual(
+            await hooked.read.hook_program(),
+            `0x${"00".repeat(32)}`,
+            "the wrapper pins the armed hook discovered from mint_info",
+        );
+        assert.equal(
+            await factory.read.wrapper_kind_by_mint([mint]),
+            2,
+            "factory records Token2022HookedCpi for client routing",
         );
     });
 
@@ -215,6 +253,7 @@ describe("armed-hook admission, executed", async () => {
             "0x0000000000000000000000000000000000000000",
             "an inert hook must not stop the factory from registering",
         );
+        assert.equal(await factory.read.wrapper_kind_by_mint([mint]), 1);
     });
 });
 

--- a/tests/token2022/hooked-wrapper.test.ts
+++ b/tests/token2022/hooked-wrapper.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { network } from "hardhat";
+
+const key = (n: number) => `0x${n.toString(16).padStart(64, "0")}` as const;
+
+describe("SPL_ERC20_Token2022Hooked account-plan boundary", async () => {
+    const conn = await network.connect();
+    const { viem } = conn;
+
+    it("encodes TransferChecked and preserves the resolved account tail", async () => {
+        const harness = await viem.deployContract("Token2022HookedTransferHarness");
+        const hookProgram = key(5);
+        const validation = key(6);
+        const writableRule = key(7);
+
+        const [data, metas] = await harness.read.plan([
+            key(1), key(2), key(3), key(4), 0x0102_0304_0506_0708n, 6,
+            [
+                { pubkey: writableRule, is_signer: false, is_writable: true },
+                { pubkey: hookProgram, is_signer: false, is_writable: false },
+                { pubkey: validation, is_signer: false, is_writable: false },
+            ],
+        ]) as readonly [`0x${string}`, readonly { pubkey: `0x${string}`; is_signer: boolean; is_writable: boolean }[]];
+
+        assert.equal(data, "0x0c080706050403020106");
+        assert.deepEqual(metas.slice(0, 4), [
+            { pubkey: key(1), is_signer: false, is_writable: true },
+            { pubkey: key(2), is_signer: false, is_writable: false },
+            { pubkey: key(3), is_signer: false, is_writable: true },
+            { pubkey: key(4), is_signer: true, is_writable: false },
+        ]);
+        assert.deepEqual(metas.slice(4), [
+            { pubkey: writableRule, is_signer: false, is_writable: true },
+            { pubkey: hookProgram, is_signer: false, is_writable: false },
+            { pubkey: validation, is_signer: false, is_writable: false },
+        ]);
+    });
+
+    it("rejects an incomplete, substituted, writable or signer hook trailer", async () => {
+        const harness = await viem.deployContract("Token2022HookedTransferHarness");
+        const hook = key(20);
+        const validation = key(21);
+        const rule = { pubkey: key(19), is_signer: false, is_writable: true } as const;
+        const valid = [
+            rule,
+            { pubkey: hook, is_signer: false, is_writable: false },
+            { pubkey: validation, is_signer: false, is_writable: false },
+        ] as const;
+
+        await harness.read.validate([hook, validation, valid]);
+        await assert.rejects(harness.read.validate([hook, validation, []]), /IncompleteHookAccountPlan/);
+        await assert.rejects(harness.read.validate([hook, validation, [rule, { ...valid[1], pubkey: key(22) }, valid[2]]]), /InvalidHookProgramMeta/);
+        await assert.rejects(harness.read.validate([hook, validation, [rule, valid[1], { ...valid[2], pubkey: key(23) }]]), /InvalidValidationMeta/);
+        await assert.rejects(harness.read.validate([hook, validation, [rule, { ...valid[1], is_writable: true }, valid[2]]]), /InvalidHookProgramMeta/);
+        await assert.rejects(harness.read.validate([hook, validation, [rule, valid[1], { ...valid[2], is_signer: true }]]), /InvalidValidationMeta/);
+    });
+});


### PR DESCRIPTION
## Summary

- add `SPL_ERC20_Token2022Hooked`, a separate direct-CPI wrapper for armed Token-2022 transfer hooks
- keep fixed and cached wrappers rejecting armed hooks; factory selects the hook-aware route only for armed mints
- require a validated caller-resolved account plan; ordinary ERC-20 transfer paths explicitly reject missing hook accounts
- retain executable Hadrian smoke evidence for factory routing, safety rejection, and successful hooked transfer

## Validation

- `npx hardhat compile --force`
- `npx hardhat test tests/token2022/admission.test.ts tests/token2022/hooked-wrapper.test.ts --no-compile` (24 passing)
- Token-2022 suite: 54 passing
- full local Node suite: 344 passing
- Hadrian smoke: https://via-hadrian.testnet.romeprotocol.xyz/tx/0x7a70d3044f7df082ea91987883010e9465a02c5b2882feba2fa8c6760ad246dd

## Boundary

This is direct-CPI-only. A target application resolves its own `ExtraAccountMetaList` tail; cache/fixed routes remain deliberately incompatible with armed hooks.
