### PR TITLE
perf: reduce Token-2022 hooked wrapper CPI overhead

### DIFF
--- a/contracts/erc20spl/erc20spl.sol
+++ b/contracts/erc20spl/erc20spl.sol
@@ -86,7 +86,6 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
     string private _name;
     string private _symbol;
     ERC20Users internal _users;
-    mapping(address => bytes32) private _accounts;
 
     error ERC20InvalidApprover(address approver);
     error ERC20InvalidSpender(address spender);
@@ -150,12 +149,7 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
         );
         require(success, string(Convert.revert_msg(result)));
 
-        // Cache the derived ATA in `_accounts` for back-compat — derive
-        // client-side using the canonical ATA formula (deterministic from
-        // wallet + mint + spl_program).
-        bytes32 associated_account_address = HelperProgram.ata(user, mint_id);
-        _accounts[user] = associated_account_address;
-        return associated_account_address;
+        return HelperProgram.ata(user, mint_id);
     }
 
     /**
@@ -183,10 +177,6 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
         uint64 lamports = AccountReader.lamportsOf(ata);
         if (lamports != 0) {
             // Account already exists on Solana — no CPI needed.
-            // Cache write-through is optional; legacy callers checking
-            // `_accounts[user] != 0` still need a non-zero entry, so we
-            // populate it for back-compat.
-            _accounts[user] = ata;
             return ata;
         }
 
@@ -204,11 +194,7 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
      *      bridge-in deposits land and where balanceOf reads. No revert when
      *      the ATA hasn't been on-chain-initialized yet — callers that need
      *      it created must call `ensure_token_account(user)` (idempotent on
-     *      repeat calls). The legacy `_accounts` cache is no longer the
-     *      source of truth; this function ignores it to fix the split-brain
-     *      where balanceOf read AUTHORITY_PDA's ATA but transfer/approve/
-     *      transferFrom read the cached PAYER_PDA's ATA, breaking router-
-     *      mediated flows like Romeswap addLiquidity.
+     *      repeat calls).
      */
     function get_token_account(address user) public view returns (bytes32) {
         return HelperProgram.ata(user, mint_id);
@@ -487,14 +473,6 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
         require(value <= type(uint64).max, "Bridge amount exceeds uint64");
         require(solana_recipient != bytes32(0), "Solana recipient cannot be zero");
 
-        // Source ATA = caller's unified-user-PDA's ATA for this mint.
-        // Single CPI via `HelperProgram.ata(user, mint)` — composes the
-        // two `find_program_address` syscalls (EXTERNAL_AUTHORITY → user
-        // PDA → ATA-of-PDA) into one dispatch. Measured −152K Solana CU
-        // vs the prior two-hop path (Marcus 121301, 2026-05-11; Hadrian
-        // confirms −170K, 2026-05-14).
-        bytes32 from_ata = HelperProgram.ata(msg.sender, mint_id);
-
         // Recipient ATA pubkey — same canonical ATA derivation but for
         // the raw Solana recipient pubkey (not an EVM address), so the
         // `HelperProgram.ata(address, bytes32)` overload doesn't apply
@@ -535,7 +513,7 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
         // to the recipient's ATA. The `bytes32 to_ata` overload is
         // required because the recipient is a raw Solana pubkey (not
         // an EVM address). Signs as `external_auth(msg.sender)`,
-        // matching `from_ata`'s owner.
+        // matching the caller's PDA-owned source ATA.
         (bool xferOk, bytes memory xferResult) = address(HelperProgram).delegatecall(
             abi.encodeWithSignature(
                 "transfer_spl(bytes32,uint64,bytes32)",
@@ -543,11 +521,6 @@ abstract contract SPL_ERC20Base is IERC20, IERC20Metadata {
             )
         );
         require(xferOk, string(Convert.revert_msg(xferResult)));
-
-        // Reference `from_ata` so the compiler doesn't warn — kept as a
-        // doc-only variable since the precompile re-derives source ATA
-        // server-side from the caller's external_auth PDA.
-        from_ata;
 
         emit BridgedOutToSolana(msg.sender, solana_recipient, mint_id, value);
         return true;

--- a/contracts/erc20spl/erc20spl_cached.sol
+++ b/contracts/erc20spl/erc20spl_cached.sol
@@ -318,7 +318,14 @@ contract SPL_ERC20_cached is IERC20, IERC20Metadata {
     function mint_to(address to, uint256 value) external returns (bool) {
         require(value <= type(uint64).max, "Mint amount exceeds uint64");
         _users.ensure_user(msg.sender);
-        ensure_token_account(to);
+        // Mirror _transfer's overlay-aware ATA gate. Minting to an existing
+        // holder should not spend an idempotent create-ATA invoke; an ATA
+        // created earlier in this cached transaction is visible here too.
+        try SplCached.account(to, mint_id) returns (ISplCached.Account memory) {
+            // Recipient ATA already exists in the cache/on-chain state.
+        } catch {
+            ensure_token_account(to);
+        }
         (bool ok, bytes memory result) = address(SplCached).delegatecall(
             abi.encodeWithSignature(
                 "mint(address,uint256,bytes32)",

--- a/contracts/erc20spl/erc20spl_token2022_hooked.sol
+++ b/contracts/erc20spl/erc20spl_token2022_hooked.sol
@@ -80,8 +80,8 @@ contract SPL_ERC20_Token2022Hooked is SPL_ERC20Base {
     function transferWithHookAccounts(
         address to,
         uint256 value,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
-    ) public returns (bool) {
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
+    ) external returns (bool) {
         _users.ensure_user(msg.sender);
         return _hookedTransfer(msg.sender, to, value, hookMetas);
     }
@@ -90,16 +90,16 @@ contract SPL_ERC20_Token2022Hooked is SPL_ERC20Base {
         address from,
         address to,
         uint256 value,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
-    ) public returns (bool) {
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
+    ) external returns (bool) {
         _users.ensure_user(msg.sender);
         return _hookedTransfer(from, to, value, hookMetas);
     }
 
     function _validateCurrentPlan(
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
-    ) internal view {
-        (bytes32 tokenProgram, , bytes32 currentHookProgram, ,) =
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
+    ) internal view returns (uint16 feeBps) {
+        (bytes32 tokenProgram, , bytes32 currentHookProgram, uint16 currentFeeBps,) =
             HelperProgram.mint_info(mint_id);
         if (tokenProgram != SolanaConstants.TOKEN_2022_PROGRAM) {
             revert Token2022MintRequired(mint_id, tokenProgram);
@@ -110,18 +110,17 @@ contract SPL_ERC20_Token2022Hooked is SPL_ERC20Base {
         Token2022HookedTransfer.validate(
             hook_program, validation_account, hookMetas
         );
+        return currentFeeBps;
     }
 
     function _hookedTransfer(
         address from,
         address to,
         uint256 value,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     ) internal returns (bool) {
         require(value <= type(uint64).max, "Transfer amount exceeds uint64");
-        _validateCurrentPlan(hookMetas);
-
-        (, , , uint16 feeBps, ) = HelperProgram.mint_info(mint_id);
+        uint16 feeBps = _validateCurrentPlan(hookMetas);
         bool feeArmed = feeBps > 0;
         uint256 beforeBalance = feeArmed ? balanceOf(to) : 0;
 
@@ -161,13 +160,12 @@ contract SPL_ERC20_Token2022Hooked is SPL_ERC20Base {
     function bridgeOutToSolanaWithHookAccounts(
         bytes32 solanaRecipient,
         uint256 value,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
-    ) public returns (bool) {
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
+    ) external returns (bool) {
         require(value <= type(uint64).max, "Bridge amount exceeds uint64");
         require(solanaRecipient != bytes32(0), "Solana recipient cannot be zero");
         _validateCurrentPlan(hookMetas);
 
-        _users.ensure_user(msg.sender);
         bytes32 destination = ensureRecipientAta(solanaRecipient);
         bytes32 source = HelperProgram.ata(msg.sender, mint_id);
         Token2022HookedTransfer.transferChecked(

--- a/contracts/spl_token/test/Token2022HookedTransferHarness.sol
+++ b/contracts/spl_token/test/Token2022HookedTransferHarness.sol
@@ -12,7 +12,7 @@ contract Token2022HookedTransferHarness {
         bytes32 authority,
         uint64 amount,
         uint8 decimals,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     ) external pure returns (bytes memory, ICrossProgramInvocation.AccountMeta[] memory) {
         return Token2022HookedTransfer.plan(
             source, mint, destination, authority, amount, decimals, hookMetas
@@ -22,7 +22,7 @@ contract Token2022HookedTransferHarness {
     function validate(
         bytes32 hookProgram,
         bytes32 validation,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     ) external pure {
         Token2022HookedTransfer.validate(hookProgram, validation, hookMetas);
     }

--- a/contracts/spl_token/token2022_hooked_transfer.sol
+++ b/contracts/spl_token/token2022_hooked_transfer.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {ICrossProgramInvocation, CpiProgram} from "../interface.sol";
 import {SolanaConstants} from "../cpi/SolanaConstants.sol";
+import {Convert} from "../convert.sol";
 
 /// @title Token2022HookedTransfer
 /// @notice Builds and executes Token-2022 TransferChecked with a caller-resolved
@@ -24,14 +25,14 @@ library Token2022HookedTransfer {
     function validate(
         bytes32 expectedHookProgram,
         bytes32 expectedValidation,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     ) internal pure {
         if (hookMetas.length < 2) {
             revert IncompleteHookAccountPlan(hookMetas.length);
         }
 
         uint256 hookIndex = hookMetas.length - 2;
-        ICrossProgramInvocation.AccountMeta memory hook = hookMetas[hookIndex];
+        ICrossProgramInvocation.AccountMeta calldata hook = hookMetas[hookIndex];
         if (
             hook.pubkey != expectedHookProgram ||
             hook.is_signer ||
@@ -42,7 +43,7 @@ library Token2022HookedTransfer {
             );
         }
 
-        ICrossProgramInvocation.AccountMeta memory validation =
+        ICrossProgramInvocation.AccountMeta calldata validation =
             hookMetas[hookIndex + 1];
         if (
             validation.pubkey != expectedValidation ||
@@ -65,7 +66,7 @@ library Token2022HookedTransfer {
         bytes32 authority,
         uint64 amount,
         uint8 decimals,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     )
         internal
         pure
@@ -95,7 +96,7 @@ library Token2022HookedTransfer {
         bytes32 authority,
         uint64 amount,
         uint8 decimals,
-        ICrossProgramInvocation.AccountMeta[] memory hookMetas
+        ICrossProgramInvocation.AccountMeta[] calldata hookMetas
     ) internal {
         (bytes memory data, ICrossProgramInvocation.AccountMeta[] memory metas) =
             plan(source, mint, destination, authority, amount, decimals, hookMetas);
@@ -115,11 +116,8 @@ library Token2022HookedTransfer {
         pure
         returns (bytes memory data)
     {
-        data = new bytes(10);
-        data[0] = bytes1(TRANSFER_CHECKED);
-        for (uint256 i; i < 8; ++i) {
-            data[1 + i] = bytes1(uint8(amount >> (8 * i)));
-        }
-        data[9] = bytes1(decimals);
+        data = abi.encodePacked(
+            bytes1(TRANSFER_CHECKED), Convert.u64le(amount), bytes1(decimals)
+        );
     }
 }

--- a/evidence/leaf2-token2022-hooked-wrapper-ab-hadrian-1785950679436.json
+++ b/evidence/leaf2-token2022-hooked-wrapper-ab-hadrian-1785950679436.json
@@ -1,0 +1,116 @@
+{
+  "status": "pass",
+  "scope": "warmed-ATA Token-2022 Transfer Hook wrapper A/B on Hadrian",
+  "controls": {
+    "mint": "75wP528i7uzEH9NGJa1cpFigDrLE4bnb1kS1MUauRkSz",
+    "hookProgram": "6e52qcdWaHV1DHnafeCWf2FuAH2fqj13nAD1KVoZWTm3",
+    "validation": "3XK9JaBnrEHsXrLK455Vz6hXxtSP2qxMZw8uEJk1QzH6",
+    "sender": "0x5667b3700b4a021Cc475157cbf3dE2d756Fae597",
+    "recipient": "0x74d76F704109a14DDf4C4474548ecC7a0356188a",
+    "amount": "1000",
+    "samplesPerTrack": 3
+  },
+  "contracts": {
+    "baseline": "0xD80B71b26F1FB45917142077a69E597186e1BEA8",
+    "optimized": "0xf579ca3eaafaba094c869b98c5dfe5285c874ce9",
+    "users": "0x025828AEf53026509c01fEADa7Ca8cA34a342fa8",
+    "optimizedDeployment": "0x8025ef8abf6360a15d9805fdf69aa6db6e4ace19dd83b3933885bffc0eadc0ec"
+  },
+  "samples": [
+    {
+      "track": "baseline",
+      "sample": 1,
+      "evmTx": "0xbdad17102af1ac88aa3347926f10d07d081042c04818778605c648bbf1dabd22",
+      "evmGasUsed": "10001",
+      "solanaTx": "57Qtoj8YbHfs8mRrgC2A7hy6igZpvVK1Pkci1wHNaYLJb9m6eM8BwE62CAZ8TzRScJXUqfhTwVjBtud2EhwPFkF5",
+      "solanaCu": 538731,
+      "requestedCu": 586676,
+      "heapBytes": 50648,
+      "nativeFeeLamports": 5001
+    },
+    {
+      "track": "optimized",
+      "sample": 1,
+      "evmTx": "0x2a14e2260e9e9d97e7bfd56d2dc92e12db1662cc7e56f4abbedaf54ca5cc242d",
+      "evmGasUsed": "10001",
+      "solanaTx": "2PkvSJqQSUbXNg5yn6zWRiXinFx3KfFRspFnR5c9M6a9UwBsqMfLAFWWdgDURFQuMaP3cmB6iy1CRqGDCBDpeR2p",
+      "solanaCu": 448681,
+      "requestedCu": 496626,
+      "heapBytes": 47088,
+      "nativeFeeLamports": 5001
+    },
+    {
+      "track": "baseline",
+      "sample": 2,
+      "evmTx": "0x1fbc9e8e20cbe0a1b00f4e7e2b8d6156d693c622cfdca6486d3d4f6dd1537945",
+      "evmGasUsed": "10001",
+      "solanaTx": "3KLBBdzDZu8KdAq1YGBfkUqamFPshrUAzigqzXhayUztZtAJHY35YAbJhqcDDprvvUhE6nPrPhy1nJdXgfTKDG8L",
+      "solanaCu": 537181,
+      "requestedCu": 585126,
+      "heapBytes": 50648,
+      "nativeFeeLamports": 5001
+    },
+    {
+      "track": "optimized",
+      "sample": 2,
+      "evmTx": "0xd869a43419d169c8bf1a224ac8de2210e4425dc22833a15b5f9ae3699b7c3782",
+      "evmGasUsed": "10001",
+      "solanaTx": "4hrM6RsjaDXxHenYAhJ18QHMaYcrAzJ8Qon43w8HQYf6vLkpnBMzYpdVDJFuJPjakJFnGiYBjvSofXrF1oxMnRix",
+      "solanaCu": 445680,
+      "requestedCu": 493625,
+      "heapBytes": 47088,
+      "nativeFeeLamports": 5001
+    },
+    {
+      "track": "baseline",
+      "sample": 3,
+      "evmTx": "0x6c1f44e2965bcfc680066e0412643ec7003588c083250e2f934b9ddb4e456fa2",
+      "evmGasUsed": "10001",
+      "solanaTx": "3UsXFKbb4Yv2LuzftaRT2A9FJDZ2PwqwGcT9KRsjb6SzsZXLzv8Bj9W8LsG6mMceTpiKpjHBBiXECw1tEbaHs74F",
+      "solanaCu": 534181,
+      "requestedCu": 582126,
+      "heapBytes": 50648,
+      "nativeFeeLamports": 5001
+    },
+    {
+      "track": "optimized",
+      "sample": 3,
+      "evmTx": "0xa1c5095ffa826f2122abd9647f812d89931fa707721141d9968118cd709bfd62",
+      "evmGasUsed": "10001",
+      "solanaTx": "5HVPKfTuS7nmNgDcKNhGSarxYZp28E5kq1Qtw8RoUmwLqr8i6jeSNBpLdvSH6YN4DTZNWUfvHzoNhstKCvkf3SAm",
+      "solanaCu": 442681,
+      "requestedCu": 490626,
+      "heapBytes": 47088,
+      "nativeFeeLamports": 5001
+    }
+  ],
+  "summary": {
+    "baseline": {
+      "samples": 3,
+      "meanEvmGasUsed": 10001,
+      "meanSolanaCu": 536697.6666666666,
+      "meanHeapBytes": 50648,
+      "requestedCu": [
+        586676,
+        585126,
+        582126
+      ]
+    },
+    "optimized": {
+      "samples": 3,
+      "meanEvmGasUsed": 10001,
+      "meanSolanaCu": 445680.6666666667,
+      "meanHeapBytes": 47088,
+      "requestedCu": [
+        496626,
+        493625,
+        490626
+      ]
+    },
+    "delta": {
+      "evmGasUsed": 0,
+      "solanaCu": -91016.99999999994,
+      "heapBytes": -3560
+    }
+  }
+}

--- a/evidence/leaf2-token2022-hooked-wrapper-ab-hadrian-2026-08-05.md
+++ b/evidence/leaf2-token2022-hooked-wrapper-ab-hadrian-2026-08-05.md
@@ -1,0 +1,69 @@
+# Leaf 2 — hook-aware wrapper CU A/B, Hadrian
+
+Date: 2026-08-05
+Status: PASS
+Scope: warmed-recipient Token-2022 transfer through a real armed Transfer Hook.
+
+## Question
+
+Does the hook-aware wrapper optimization reduce the actual Rome/Solana cost of
+the production direct-CPI transfer path?
+
+## Controls
+
+The benchmark alternated the immutable production wrapper from the prior
+Hadrian proof with a fresh deployment of the optimized implementation. Each
+sample used the same:
+
+- Token-2022 mint: `75wP528i7uzEH9NGJa1cpFigDrLE4bnb1kS1MUauRkSz`
+- armed hook program and canonical validation PDA;
+- EVM-derived sender, transfer amount (1,000 base units), and already-created
+  recipient ATA;
+- two-account dynamic hook tail: hook program + validation PDA.
+
+This intentionally measures the warm transfer path only. It excludes wrapper
+deployment and ATA creation, which are separate operations.
+
+## Result
+
+| Metric | Baseline wrapper | Optimized wrapper | Delta |
+|---|---:|---:|---:|
+| Samples | 3 | 3 | — |
+| Mean Solana settlement CU | 536,698 | 445,680 | **-91,017 (-17.0%)** |
+| Rome heap | 50,648 B | 47,088 B | **-3,560 B** |
+| Requested CU | 582,126–586,676 | 490,626–496,626 | lower by ~91–92k |
+| EVM receipt gas | 10,001 | 10,001 | 0 |
+
+Both tracks settled successfully and the native fee was 5,001 lamports in all
+six samples. The conclusion is based on Solana `computeUnitsConsumed` after
+mapping each outer EVM transaction with `rome_solanaTxForEvmTx`, not on EVM
+receipt gas.
+
+## Receipts
+
+Baseline:
+
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0xbdad17102af1ac88aa3347926f10d07d081042c04818778605c648bbf1dabd22
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0x1fbc9e8e20cbe0a1b00f4e7e2b8d6156d693c622cfdca6486d3d4f6dd1537945
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0x6c1f44e2965bcfc680066e0412643ec7003588c083250e2f934b9ddb4e456fa2
+
+Optimized:
+
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0x2a14e2260e9e9d97e7bfd56d2dc92e12db1662cc7e56f4abbedaf54ca5cc242d
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0xd869a43419d169c8bf1a224ac8de2210e4425dc22833a15b5f9ae3699b7c3782
+- https://via-hadrian.testnet.romeprotocol.xyz/tx/0xa1c5095ffa826f2122abd9647f812d89931fa707721141d9968118cd709bfd62
+
+The machine-readable samples are in
+`leaf2-token2022-hooked-wrapper-ab-hadrian-1785950679436.json`.
+
+## Interpretation
+
+The reduction is from Solidity/wrapper work that is repeated on every direct
+CPI transfer: no duplicate mint-info precompile read, calldata retained until
+the single required CPI meta allocation, and a compact TransferChecked data
+encoder. It does **not** remove the live mint/hook-plan validation, dynamic
+account tail, or fresh-account safety behavior.
+
+This is strong evidence for the warmed direct-CPI wrapper path. It is not a
+claim about every issuer hook: a non-empty ExtraAccountMetaList or additional
+hook-side program logic must be measured with that issuer's actual account plan.

--- a/evidence/leaf2-token2022-hooked-wrapper-cold-hadrian-1785950702635.json
+++ b/evidence/leaf2-token2022-hooked-wrapper-cold-hadrian-1785950702635.json
@@ -1,0 +1,39 @@
+{
+  "status": "pass",
+  "scope": "cold-recipient hook-aware wrapper parity on Hadrian",
+  "controls": {
+    "mint": "75wP528i7uzEH9NGJa1cpFigDrLE4bnb1kS1MUauRkSz",
+    "hookProgram": "6e52qcdWaHV1DHnafeCWf2FuAH2fqj13nAD1KVoZWTm3",
+    "validation": "3XK9JaBnrEHsXrLK455Vz6hXxtSP2qxMZw8uEJk1QzH6",
+    "sender": "0x5667b3700b4a021Cc475157cbf3dE2d756Fae597",
+    "amount": "1000"
+  },
+  "optimizedDeployment": {
+    "address": "0x828d1f58fd4bb1a7460e50fdf1a7c714bbe613a3",
+    "transaction": "0x7668333fd27034271aa43d416a264d8ff64916c92c70cb5050ad8ebb88853a84"
+  },
+  "results": [
+    {
+      "track": "baseline",
+      "wrapper": "0xD80B71b26F1FB45917142077a69E597186e1BEA8",
+      "recipient": "0xE83Be25dabC033ceAaf55Bb3AA22a82BfE0E0752",
+      "recipientAta": "ELSsUsB2YAQcNC6tQjWPR5bz2Zzr1R3HB88P61vVvwgx",
+      "before": "absent",
+      "afterAmount": "1000",
+      "evmTx": "0x018a1fcbbcb9cfc811ab5488fb7f2a9f24870cc807d3e0b5dd463d12fd65c82f",
+      "evmGasUsed": "4986401",
+      "solanaCu": 717501
+    },
+    {
+      "track": "optimized",
+      "wrapper": "0x828d1f58fd4bb1a7460e50fdf1a7c714bbe613a3",
+      "recipient": "0x589b4089bE59224e7963c02E9BE351e3653B5f9C",
+      "recipientAta": "CAJxzgCg28r5B9Wvr8mktifJN5VSDu2QCnN2dau1q5rJ",
+      "before": "absent",
+      "afterAmount": "1000",
+      "evmTx": "0x22712d9a387c9a98f1e2d7886ab22f0e9a8826301d416464616d1ea02e07472d",
+      "evmGasUsed": "3552641",
+      "solanaCu": 609108
+    }
+  ]
+}

--- a/evidence/leaf2-token2022-hooked-wrapper-cold-hadrian-2026-08-05.md
+++ b/evidence/leaf2-token2022-hooked-wrapper-cold-hadrian-2026-08-05.md
@@ -1,0 +1,42 @@
+# Leaf 2 — hook-aware wrapper cold-recipient parity, Hadrian
+
+Date: 2026-08-05
+Status: PASS
+
+## Purpose
+
+Verify that the optimized direct-CPI Token-2022 hook wrapper preserves the
+ordinary wrapper experience for a first transfer: the caller supplies no
+recipient ATA and does no UI/client preflight. The wrapper must discover that
+the ATA is absent, create it idempotently, and then execute the armed-hook
+transfer.
+
+## Method
+
+The deployed pre-optimization wrapper and a freshly deployed optimized wrapper
+each transferred 1,000 units of the same armed Token-2022 mint to a distinct,
+new EVM address. Distinct recipients are necessary for both calls to exercise
+the cold branch. Before each transaction, the recipient's derived Token-2022
+ATA was confirmed absent through Solana RPC.
+
+## Result
+
+| Track | Recipient ATA before | Recipient ATA after | Balance after | Settlement CU |
+|---|---|---|---:|---:|
+| Baseline | absent | created | 1,000 | 717,501 |
+| Optimized | absent | created | 1,000 | 609,108 |
+
+Both transfers used the same armed mint, hook program, validation PDA, sender,
+amount, and two-account hook trailer. The contract—not the UI—created the
+recipient ATA. The optimized wrapper therefore preserves the existing
+check-if-exists / create-if-missing behavior while reducing this single cold
+sample by 108,393 settlement CU. That cost difference is directional; the
+behavioral conclusion is the primary result of this test.
+
+## Outer receipts
+
+- Baseline: https://via-hadrian.testnet.romeprotocol.xyz/tx/0x018a1fcbbcb9cfc811ab5488fb7f2a9f24870cc807d3e0b5dd463d12fd65c82f
+- Optimized: https://via-hadrian.testnet.romeprotocol.xyz/tx/0x22712d9a387c9a98f1e2d7886ab22f0e9a8826301d416464616d1ea02e07472d
+
+Machine-readable evidence:
+`leaf2-token2022-hooked-wrapper-cold-hadrian-1785950702635.json`.

--- a/tests/token2022/hooked-wrapper-perf.test.ts
+++ b/tests/token2022/hooked-wrapper-perf.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  "contracts/erc20spl/erc20spl_token2022_hooked.sol",
+  "utf8",
+);
+const directWrapper = readFileSync("contracts/erc20spl/erc20spl.sol", "utf8");
+const cachedWrapper = readFileSync(
+  "contracts/erc20spl/erc20spl_cached.sol",
+  "utf8",
+);
+const hookTransfer = readFileSync(
+  "contracts/spl_token/token2022_hooked_transfer.sol",
+  "utf8",
+);
+
+function body(functionName: string): string {
+  const start = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(start, -1, `${functionName} must exist`);
+  const next = source.indexOf("\n    function ", start + 1);
+  return source.slice(start, next === -1 ? undefined : next);
+}
+
+describe("SPL_ERC20_Token2022Hooked hot-path dispatch", () => {
+  it("reads mint metadata once per hooked transfer", () => {
+    const validate = body("_validateCurrentPlan");
+    const transfer = body("_hookedTransfer");
+
+    assert.match(
+      validate,
+      /returns \(uint16 feeBps\)/,
+      "the metadata validation pass must return the fee predicate it already read",
+    );
+    assert.equal(
+      (validate.match(/HelperProgram\.mint_info\(/g) ?? []).length,
+      1,
+      "the validation pass is the one authoritative metadata read",
+    );
+    assert.doesNotMatch(
+      transfer,
+      /HelperProgram\.mint_info\(/,
+      "the hot transfer path must reuse feeBps from validation rather than read the mint twice",
+    );
+  });
+
+  it("keeps hook plans in calldata until the single required CPI meta allocation", () => {
+    for (const entrypoint of [
+      "transferWithHookAccounts",
+      "transferFromWithHookAccounts",
+      "bridgeOutToSolanaWithHookAccounts",
+    ]) {
+      assert.match(body(entrypoint), /AccountMeta\[\] calldata hookMetas/);
+    }
+    assert.match(
+      hookTransfer,
+      /AccountMeta\[\] calldata hookMetas/,
+      "the library must not reintroduce a memory copy before it builds fixed + hook metas",
+    );
+  });
+
+  it("uses the shared compact u64 encoder rather than eight Solidity memory writes", () => {
+    assert.match(hookTransfer, /Convert\.u64le\(amount\)/);
+    assert.doesNotMatch(hookTransfer, /for \(uint256 i; i < 8; \+\+i\)/);
+  });
+
+  it("retains automatic ATA creation for a first hooked transfer", () => {
+    assert.match(
+      body("_hookedTransfer"),
+      /bytes32 destination = ensure_token_account\(to\)/,
+      "the hook-aware path must retain the base wrapper's check-or-create recipient ATA behavior",
+    );
+  });
+
+  it("does not retain obsolete direct-wrapper cache writes or derivations", () => {
+    assert.doesNotMatch(
+      directWrapper,
+      /mapping\(address => bytes32\) private _accounts/,
+    );
+    assert.doesNotMatch(directWrapper, /bytes32 from_ata\s*=/);
+  });
+
+  it("does not register a hook bridge caller twice", () => {
+    assert.doesNotMatch(
+      body("bridgeOutToSolanaWithHookAccounts"),
+      /_users\.ensure_user\(msg\.sender\)/,
+    );
+  });
+
+  it("gates cached mint recipient ATA creation on overlay-aware existence", () => {
+    const mintTo = cachedWrapper.slice(
+      cachedWrapper.indexOf("function mint_to("),
+    );
+    assert.match(mintTo, /try SplCached\.account\(to, mint_id\)/);
+    assert.match(mintTo, /catch \{\s*ensure_token_account\(to\);\s*\}/);
+  });
+});


### PR DESCRIPTION
Summary

- Avoids the duplicate mint_info read on each hook-aware transfer.
- Keeps resolved hook metas in calldata until CPI meta construction and uses a compact TransferChecked encoder.
- Removes dead ATA cache writes and redundant hook bridge registration.
- Avoids cached-wrapper ATA creation when the overlay already has the recipient.

Hadrian evidence

- Warm, armed-hook transfer: 3 alternating samples; mean settlement CU 536,698 to 445,680 (-91,017 / -17.0%); heap 50,648 B to 47,088 B.
- Cold recipient: both baseline and candidate automatically created the absent Token-2022 ATA and credited exactly 1,000 units through the armed hook.
- Evidence reports and machine-readable mapped Solana receipts are committed under evidence/.

Validation

- npx hardhat compile --force (94 Solidity files)
- Focused Token-2022/ERC20 SPL suite: 115 passing
- Full runnable Node suite: 324 passing
- Hadrian warm A/B and cold-recipient proofs passed

Review notes

Independent Solidity review found no blocker in the hook optimization. An unrelated bridge-out ATA fast path was removed before this PR because nonzero lamports alone do not establish a valid initialized ATA.