### PR TITLE
feat: rubicon (7531) network + WETH_MINT env override for v9 wrapper deploy

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -73,6 +73,15 @@ export default defineConfig({
       url: "https://hadrian.testnet.romeprotocol.xyz/",
       accounts: [configVariable("HADRIAN_PRIVATE_KEY")],
     },
+    // Mainnet. URL kept out of source so deploys can target a non-public
+    // endpoint; the key is injected transiently for one-shot runs.
+    rubicon: {
+      type: "http",
+      chainType: "l1",
+      chainId: 7531,
+      url: configVariable("RUBICON_RPC_URL"),
+      accounts: [configVariable("RUBICON_PRIVATE_KEY")],
+    },
     hardhatMainnet: {
       type: "edr-simulated",
       chainType: "l1",

--- a/scripts/bridge/deploy-weth-v9.ts
+++ b/scripts/bridge/deploy-weth-v9.ts
@@ -2,7 +2,9 @@ import hardhat from "hardhat";
 import { readDeployments } from "../lib/deployments.js";
 import { base58ToBytes32 } from "../lib/pubkey.js";
 const CPI = "0xFF00000000000000000000000000000000000008" as const;
-const WETH_MINT = "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs";
+// Devnet default; mainnet runs must pass the canonical Wormhole wETH mint
+// (7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs) via the env var.
+const WETH_MINT = process.env.WETH_MINT ?? "6F5YWWrUMNpee8C6BDUc6DmRvYRMDDTgJHwKhbXuifWs";
 async function main() {
   const { viem, networkName } = (await hardhat.network.connect()) as unknown as {
     viem: { getWalletClients: () => Promise<Array<{ account?: { address: `0x${string}` } }>>; deployContract: (n: "SPL_ERC20", a: readonly [`0x${string}`,`0x${string}`,string,string,`0x${string}`]) => Promise<{ address: `0x${string}` }>; };


### PR DESCRIPTION
Adds the `rubicon` (chain id 7531) mainnet network to `hardhat.config.ts`. URL and deployer key resolve from config variables (`RUBICON_RPC_URL` / `RUBICON_PRIVATE_KEY`) so one-shot deploys can target a non-public endpoint with a transiently injected key — same pattern as `sepolia`.

Also lets `scripts/bridge/deploy-weth-v9.ts` take the wETH mint from a `WETH_MINT` env var. The hardcoded constant is the devnet mint (`6F5YWW…`), which does not exist on Solana mainnet; mainnet runs pass the canonical Wormhole wETH mint (`7vfCXTUX…`). Default unchanged, so existing devnet invocations behave identically.

Prerequisite for the Rubicon bridge-contract deploy.