### PR TITLE
fix: env-pinned legacy gasPrice for rubicon deploys

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -81,6 +81,14 @@ export default defineConfig({
       chainId: 7531,
       url: configVariable("RUBICON_RPC_URL"),
       accounts: [configVariable("RUBICON_PRIVATE_KEY")],
+      // The proxy enforces a pool-derived minimum gas price but serves stub
+      // eth_feeHistory values, so Hardhat's automatic fee estimation
+      // underprices every tx (rejected with "Gas_price is less than the
+      // minimum value"). Pin a legacy gasPrice for the run:
+      //   export RUBICON_GAS_PRICE=$(( $(cast gas-price -r <rpc>) * 11 / 10 ))
+      gasPrice: process.env.RUBICON_GAS_PRICE
+        ? BigInt(process.env.RUBICON_GAS_PRICE)
+        : "auto",
     },
     hardhatMainnet: {
       type: "edr-simulated",


### PR DESCRIPTION
Deploys on `rubicon` fail with `Gas_price is less than the minimum value: 1265 < 72577750000`. Root cause: the RPC enforces a pool-derived minimum gas price (~74 gwei right now) but serves stub `eth_feeHistory` values — 1000-wei base fee, and the requested percentile echoed back as the reward. Hardhat 3's automatic gas-price handler computes `maxFeePerGas = 1000 × 9²/8² = 1265` from exactly those stubs, so every tx underprices.

Fix: an env-driven `gasPrice` on the `rubicon` network entry. When `RUBICON_GAS_PRICE` is set, Hardhat's FixedGasPriceHandler sends legacy txs at that price (the same shape that already works via `cast --legacy --gas-price`); unset keeps `auto`, so nothing changes for other networks or CI.

Verified against the live RPC with an unfunded key: without the env var the probe reproduces `1265 < 72577750000`; with `RUBICON_GAS_PRICE=100000000000` the min-gas check passes and it fails on insufficient funds instead. `npx hardhat compile` green.

Usage: `export RUBICON_GAS_PRICE=$(( $(cast gas-price -r <rpc>) * 11 / 10 ))` before the deploy run.

The stub `eth_feeHistory` itself is the structural bug — filing separately.