### PR TITLE
feat(oracle): SEED_FEEDS_FILE input for deploy-seed-feeds + verified mainnet-beta catalog

### DIFF
--- a/scripts/oracle/deploy-seed-feeds.ts
+++ b/scripts/oracle/deploy-seed-feeds.ts
@@ -111,6 +111,36 @@ function b58ToBytes32(b58: string): `0x${string}` {
     return ("0x" + Buffer.from(bytes).toString("hex")) as `0x${string}`;
 }
 
+// The built-in seed lists above are Solana-DEVNET accounts. Other clusters
+// (mainnet-beta) pass their own catalog via SEED_FEEDS_FILE — a JSON file of
+// shape { "pyth": SeedFeed[], "switchboard": SeedFeed[] } (either key may be
+// omitted). Checked-in catalogs live under scripts/oracle/seeds/. Every
+// pubkey is validated (32-byte base58) before any network traffic.
+function loadSeeds(): { pyth: SeedFeed[]; switchboard: SeedFeed[] } {
+    const file = process.env.SEED_FEEDS_FILE;
+    if (!file) {
+        return { pyth: PYTH_SEEDS, switchboard: SWITCHBOARD_SEEDS };
+    }
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as {
+        pyth?: SeedFeed[];
+        switchboard?: SeedFeed[];
+    };
+    const pyth = parsed.pyth ?? [];
+    const switchboard = parsed.switchboard ?? [];
+    for (const s of [...pyth, ...switchboard]) {
+        if (!s.pair || !s.pubkeyBase58 || !s.description) {
+            throw new Error(
+                `SEED_FEEDS_FILE entry missing pair/pubkeyBase58/description: ${JSON.stringify(s)}`,
+            );
+        }
+        b58ToBytes32(s.pubkeyBase58);
+    }
+    console.log(
+        `Loaded ${pyth.length} pyth + ${switchboard.length} switchboard seeds from ${file}`,
+    );
+    return { pyth, switchboard };
+}
+
 type DeployResult = {
     pair: string;
     adapter: `0x${string}`;
@@ -120,6 +150,9 @@ type DeployResult = {
 };
 
 async function main() {
+    // Load + validate seeds BEFORE any network traffic, so a malformed
+    // SEED_FEEDS_FILE fails fast and gas-free.
+    const { pyth: pythSeeds, switchboard: switchboardSeeds } = loadSeeds();
     const { viem, networkName } = await hardhat.network.connect();
     const [deployer] = await viem.getWalletClients();
     if (!deployer?.account) {
@@ -307,7 +340,7 @@ async function main() {
     // ─── Pyth ───
     console.log("=== Deploying Pyth seed feeds ===");
     const pythResults: DeployResult[] = [];
-    for (const seed of PYTH_SEEDS) {
+    for (const seed of pythSeeds) {
         try {
             pythResults.push(await deployPythSeed(seed));
         } catch (e: any) {
@@ -320,7 +353,7 @@ async function main() {
     // ─── Switchboard ───
     console.log("\n=== Deploying Switchboard seed feeds ===");
     const sbResults: DeployResult[] = [];
-    for (const seed of SWITCHBOARD_SEEDS) {
+    for (const seed of switchboardSeeds) {
         try {
             sbResults.push(await deploySwitchboardSeed(seed));
         } catch (e: any) {
@@ -335,7 +368,7 @@ async function main() {
     const cachedFeedResults: DeployResult[] = [];
     if (v2.CachedPythAdapterImpl || v2.CachedFeedAdapterImpl) {
         console.log("\n=== Deploying cached-pyth seed feeds ===");
-        for (const seed of PYTH_SEEDS) {
+        for (const seed of pythSeeds) {
             try {
                 cachedPythResults.push(await deployCachedPythSeed(seed));
             } catch (e: any) {
@@ -376,10 +409,10 @@ async function main() {
     console.log();
     console.log("=== Summary ===");
     console.log(
-        `Pyth:        ${pythDeployed} deployed, ${pythSkipped} skipped, ${PYTH_SEEDS.length - pythResults.length} failed`,
+        `Pyth:        ${pythDeployed} deployed, ${pythSkipped} skipped, ${pythSeeds.length - pythResults.length} failed`,
     );
     console.log(
-        `Switchboard: ${sbDeployed} deployed, ${sbSkipped} skipped, ${SWITCHBOARD_SEEDS.length - sbResults.length} failed`,
+        `Switchboard: ${sbDeployed} deployed, ${sbSkipped} skipped, ${switchboardSeeds.length - sbResults.length} failed`,
     );
     console.log(
         `Wrote ${pythResults.length} Pyth + ${sbResults.length} Switchboard entries to ${deployPath}`,

--- a/scripts/oracle/seeds/mainnet-beta.json
+++ b/scripts/oracle/seeds/mainnet-beta.json
@@ -1,0 +1,30 @@
+{
+  "$comment": "Pyth Pull PriceFeedAccount PDAs on Solana MAINNET-BETA (shard 0, push-oracle pythWSnswVUd12oZpeFP8e9CVaEqJg25g1Vtc2biRsT, owner rec5EKMGg6MxZYaMdyBfgwp4d5rB9T1VQH5pJv5LtFJ). PDA addresses are cluster-agnostic (identical to the devnet built-ins); what this catalog asserts is that these accounts EXIST and are Pyth-Labs-maintained on mainnet-beta — each verified on-chain 2026-08-07: owner + embedded feed id + publish_time <=70s old. staleness matches the 3600s per-env convention. Used via SEED_FEEDS_FILE=scripts/oracle/seeds/mainnet-beta.json for mainnet chain deploys (first consumer: rubicon 7531).",
+  "pyth": [
+    {
+      "pair": "SOL/USD",
+      "pubkeyBase58": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+      "description": "SOL / USD",
+      "staleness": 3600
+    },
+    {
+      "pair": "BTC/USD",
+      "pubkeyBase58": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+      "description": "BTC / USD",
+      "staleness": 3600
+    },
+    {
+      "pair": "ETH/USD",
+      "pubkeyBase58": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+      "description": "ETH / USD",
+      "staleness": 3600
+    },
+    {
+      "pair": "USDC/USD",
+      "pubkeyBase58": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
+      "description": "USDC / USD",
+      "staleness": 3600
+    }
+  ],
+  "switchboard": []
+}


### PR DESCRIPTION
The seed lists built into `deploy-seed-feeds.ts` are Solana-devnet accounts, which made the script devnet-only. This adds an optional `SEED_FEEDS_FILE` env pointing at a JSON catalog (`{ pyth: SeedFeed[], switchboard: SeedFeed[] }`, either key omissible), validated — required fields + 32-byte base58 pubkeys — before any network traffic so a malformed catalog fails fast and gas-free. Without the env the built-ins are used and behavior is unchanged.

Also checks in `scripts/oracle/seeds/mainnet-beta.json`: SOL/BTC/ETH/USDC per-USD Pyth Pull PriceFeedAccounts for mainnet-beta. The PDA addresses are identical to the devnet built-ins (push-oracle PDAs are cluster-agnostic); what the catalog asserts — verified on-chain 2026-08-07 — is that these accounts exist on mainnet-beta, are owned by the Pyth receiver `rec5EKMG…`, embed the expected Hermes feed ids, and are actively maintained (publish_time ≤70s at check time). `staleness: 3600` per the per-env convention.

Smoke (gas-free): valid catalog → `Loaded 4 pyth + 0 switchboard` then stops at the wallet config prompt; malformed entry → fails fast on validation; no env → built-ins, unchanged.

First consumer: the rubicon (7531) Oracle Gateway V2 deploy.