### PR TITLE
feat(oracle): PriceBook — one aggregated oracle write, unchanged Chainlink reads

### DIFF
--- a/contracts/oracle/BookFeedAdapter.sol
+++ b/contracts/oracle/BookFeedAdapter.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IAggregatorV3Interface.sol";
+import "./IAdapterFactory.sol";
+import "./IAdapterMetadata.sol";
+
+/// @notice Read surface a BookFeedAdapter needs from the PriceBook.
+interface IPriceBookRead {
+    function entryOf(bytes32 sourceAccount)
+        external
+        view
+        returns (int256 answer, uint64 publishTime, uint64 cachedAt, uint8 status);
+}
+
+/// @title BookFeedAdapter
+/// @notice Chainlink-compatible view facade over one PriceBook entry. Holds no
+///         cache of its own — `latestRoundData()` reads the book's entry for
+///         its source account and applies the same staleness math as
+///         CachedPythAdapter (clock = publishTime; same error selectors).
+///
+///         There is deliberately NO pause check on the read path — matching
+///         CachedPythAdapter, where `_checkPaused` gates only `refresh()`.
+///         Pausing this adapter in the book stops the book from refreshing the
+///         entry, which then ages out and reads revert `StalePriceFeed`.
+///
+///         Deployed as EIP-1167 clone by the book at feed registration.
+contract BookFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
+    address public book;
+    bytes32 public sourceAccount;
+    string private _description;
+    uint256 public maxStaleness;
+    bool public initialized;
+    uint64 public createdAt;
+
+    error StalePriceFeed();
+    error UninitializedPriceFeed();
+    error HistoricalRoundsNotSupported();
+    error AlreadyInitialized();
+    error StalenessOutOfRange(uint256 staleness);
+
+    /// @notice Lock the implementation from direct initialization (clones unaffected).
+    constructor() {
+        initialized = true;
+    }
+
+    function initialize(address _book, bytes32 _sourceAccount, string calldata desc, uint256 _maxStaleness)
+        external
+    {
+        if (initialized) revert AlreadyInitialized();
+        if (_maxStaleness < 1 || _maxStaleness > 24 hours) revert StalenessOutOfRange(_maxStaleness);
+        initialized = true;
+        book = _book;
+        sourceAccount = _sourceAccount;
+        _description = desc;
+        maxStaleness = _maxStaleness;
+        createdAt = uint64(block.timestamp);
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 8;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external pure override returns (uint256) {
+        return 2;
+    }
+
+    function metadata() external view override returns (AdapterMetadata memory) {
+        return AdapterMetadata({
+            description: _description,
+            sourceType: OracleSource.Pyth,
+            solanaAccount: sourceAccount,
+            maxStaleness: maxStaleness,
+            createdAt: createdAt,
+            factory: book,
+            paused: IAdapterFactory(book).isPaused(address(this))
+        });
+    }
+
+    /// @notice Book entry as a Chainlink round. Pure SLOADs (via the book).
+    ///         Reverts `UninitializedPriceFeed` before the entry's first commit
+    ///         and `StalePriceFeed` past `maxStaleness` — same conditions and
+    ///         selectors as CachedPythAdapter.
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        (int256 a, uint64 publishTime,, uint8 status) = IPriceBookRead(book).entryOf(sourceAccount);
+        if (status == 0) revert UninitializedPriceFeed();
+        if (publishTime > block.timestamp || block.timestamp - publishTime > maxStaleness) {
+            revert StalePriceFeed();
+        }
+        answer = a;
+        roundId = 1;
+        startedAt = uint256(publishTime);
+        updatedAt = uint256(publishTime);
+        answeredInRound = 1;
+    }
+
+    function getRoundData(uint80) external pure override returns (uint80, int256, uint256, uint256, uint80) {
+        revert HistoricalRoundsNotSupported();
+    }
+}

--- a/contracts/oracle/PriceBook.sol
+++ b/contracts/oracle/PriceBook.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "./PythPullParser.sol";
+import "./BookFeedAdapter.sol";
+import {CpiProgram} from "../interface.sol";
+
+/// @title PriceBook
+/// @notice One aggregated oracle write, unchanged Chainlink reads
+///         (spec: rome-specs active/technical/oracle-pricebook.md).
+///
+///         The book owns every registered feed's cache; per-feed
+///         BookFeedAdapter clones are stateless view facades. The keeper (or
+///         anyone — `refreshAll` is permissionless and grief-safe: the only
+///         input is which registered feeds to attempt) submits the roster in
+///         measured-width chunks; each feed is an independent branch-isolated
+///         unit — one bad feed never reverts the batch, and the batch reverts
+///         only when every attempted feed faulted.
+///
+///         Write-path invariants (R1–R4): verified source (owner, registered
+///         account, discriminator, Full variant, parsed feed id == registered
+///         id), monotonic publishTime (older/equal → healthy skip), future
+///         publishTime → fault (a committed future timestamp would wedge the
+///         feed against monotonicity), value bounds → fault with no write
+///         (prior entry keeps serving until it ages out), pause → healthy
+///         write-side skip (reads are never pause-gated; the entry ages out).
+///
+///         Cheap-skip: a bound feed on the fast path pre-reads publish_time
+///         (one u64) and skips before the full fetch + parse. The pre-read
+///         trusts Full-variant offsets, so it is bypassed once the entry's age
+///         exceeds half the feed's staleness window — a feed drifting toward
+///         staleness always gets the full validated read.
+contract PriceBook {
+    struct Registration {
+        bytes32 expectedFeedId; // Pyth feed id the source account must carry
+        address adapter; // the feed's BookFeedAdapter clone
+        uint16 maxConfBps; // conf/price bound, bps
+        uint32 halfWindowSec; // cheap-skip bypass threshold (maxStaleness/2)
+    }
+
+    address public owner;
+    bytes32 public immutable pythReceiverProgramId;
+    address public immutable adapterImplementation;
+
+    mapping(bytes32 => Registration) internal _regs;
+    /// Entry slot: price8 int64 | publishTime u64 <<64 | cachedAt u64 <<128 | status u8 <<192.
+    mapping(bytes32 => uint256) internal _entries;
+    bytes32[] internal _accounts; // registration order — the keeper's roster
+    mapping(address => bytes32) public accountOfAdapter; // pause ops reject unknown addresses
+    mapping(address => bool) internal _paused;
+
+    uint16 public constant DEFAULT_MAX_CONF_BPS = 200; // legacy adapters' constant
+    uint256 private constant OUTCOME_COMMIT = 0;
+    uint256 private constant OUTCOME_SKIP = 1;
+    uint256 private constant OUTCOME_FAULT = 2;
+
+    event FeedRegistered(bytes32 indexed sourceAccount, bytes32 feedId, address adapter);
+    event FeedRefreshed(bytes32 indexed sourceAccount, bytes32 feedId, int256 answer, uint64 publishTime);
+    event FeedSkippedNotNewer(bytes32 indexed sourceAccount, uint64 storedPublishTime);
+    event FeedSkippedPaused(bytes32 indexed sourceAccount);
+    event FeedRefreshFailed(bytes32 indexed sourceAccount, bytes4 reason);
+    event AdapterPauseSet(address indexed adapter, bool paused);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    error NotOwner();
+    error AlreadyRegistered();
+    error InvalidSourceOwner();
+    error StalenessOutOfRange(uint256 staleness);
+    error ConfBpsOutOfRange(uint256 bps);
+    error NotARegisteredAdapter();
+    error RegistrationRefreshFailed(bytes4 reason);
+    error AllFeedsFaulted();
+    // per-feed fault reasons (also surfaced via FeedRefreshFailed)
+    error UnregisteredFeed();
+    error FetchFailed();
+    error FeedIdMismatch();
+    error FuturePublishTime();
+    error NonPositivePrice();
+    error ConfidenceExceedsThreshold();
+    error NormalizationOverflow();
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    constructor(bytes32 _pythReceiverProgramId, address _adapterImplementation) {
+        owner = msg.sender;
+        pythReceiverProgramId = _pythReceiverProgramId;
+        adapterImplementation = _adapterImplementation;
+    }
+
+    // ── registration (owner-gated; ends with the feed's solo first refresh) ──
+
+    /// @notice Register a feed: validate the source account, deploy its
+    ///         adapter clone, and perform the solo first refresh inline — a
+    ///         feed is never registered in a state where its adapter would
+    ///         serve `UninitializedPriceFeed`, and cold writes never ride a
+    ///         keeper tick chunk.
+    function registerFeed(
+        bytes32 sourceAccount,
+        bytes32 expectedFeedId,
+        uint256 maxConfBps,
+        string calldata desc,
+        uint256 maxStaleness
+    ) external onlyOwner returns (address adapter) {
+        if (_regs[sourceAccount].adapter != address(0)) revert AlreadyRegistered();
+        if (maxStaleness < 1 || maxStaleness > 24 hours) revert StalenessOutOfRange(maxStaleness);
+        if (maxConfBps > 10_000) revert ConfBpsOutOfRange(maxConfBps);
+        if (_accountOwner(sourceAccount) != pythReceiverProgramId) revert InvalidSourceOwner();
+
+        adapter = Clones.clone(adapterImplementation);
+        BookFeedAdapter(adapter).initialize(address(this), sourceAccount, desc, maxStaleness);
+
+        _regs[sourceAccount] = Registration({
+            expectedFeedId: expectedFeedId,
+            adapter: adapter,
+            maxConfBps: maxConfBps == 0 ? DEFAULT_MAX_CONF_BPS : uint16(maxConfBps),
+            halfWindowSec: uint32(maxStaleness / 2)
+        });
+        _accounts.push(sourceAccount);
+        accountOfAdapter[adapter] = sourceAccount;
+
+        (uint256 outcome, bytes4 reason) = _refreshOne(sourceAccount, true);
+        if (outcome != OUTCOME_COMMIT) revert RegistrationRefreshFailed(reason);
+        emit FeedRegistered(sourceAccount, expectedFeedId, adapter);
+    }
+
+    // ── the aggregated write ────────────────────────────────────────────
+
+    /// @notice Refresh the given registered feeds in one transaction.
+    ///         Permissionless. Per-feed branch isolation; reverts only when
+    ///         every attempted feed faulted (all-skip is healthy). An empty
+    ///         list is a no-op.
+    function refreshAll(bytes32[] calldata sourceAccounts)
+        external
+        returns (uint256 committed, uint256 skipped, uint256 faulted)
+    {
+        for (uint256 i = 0; i < sourceAccounts.length; i++) {
+            (uint256 outcome, bytes4 reason) = _refreshOne(sourceAccounts[i], false);
+            if (outcome == OUTCOME_COMMIT) {
+                committed++;
+            } else if (outcome == OUTCOME_SKIP) {
+                skipped++;
+            } else {
+                faulted++;
+                emit FeedRefreshFailed(sourceAccounts[i], reason);
+            }
+        }
+        if (sourceAccounts.length > 0 && faulted == sourceAccounts.length) revert AllFeedsFaulted();
+    }
+
+    // ── views ───────────────────────────────────────────────────────────
+
+    function entryOf(bytes32 sourceAccount)
+        external
+        view
+        returns (int256 answer, uint64 publishTime, uint64 cachedAt, uint8 status)
+    {
+        uint256 packed = _entries[sourceAccount];
+        answer = int256(int64(uint64(packed)));
+        publishTime = uint64(packed >> 64);
+        cachedAt = uint64(packed >> 128);
+        status = uint8(packed >> 192);
+    }
+
+    function registrationOf(bytes32 sourceAccount) external view returns (Registration memory) {
+        return _regs[sourceAccount];
+    }
+
+    function adapterOf(bytes32 sourceAccount) external view returns (address) {
+        return _regs[sourceAccount].adapter;
+    }
+
+    function registrationCount() external view returns (uint256) {
+        return _accounts.length;
+    }
+
+    function registrationAt(uint256 index) external view returns (bytes32) {
+        return _accounts[index];
+    }
+
+    /// @notice IAdapterFactory-compatible pause lookup for the adapters.
+    function isPaused(address adapter) external view returns (bool) {
+        return _paused[adapter];
+    }
+
+    // ── admin ───────────────────────────────────────────────────────────
+
+    function pauseAdapter(address adapter) external onlyOwner {
+        if (accountOfAdapter[adapter] == bytes32(0)) revert NotARegisteredAdapter();
+        _paused[adapter] = true;
+        emit AdapterPauseSet(adapter, true);
+    }
+
+    function unpauseAdapter(address adapter) external onlyOwner {
+        if (accountOfAdapter[adapter] == bytes32(0)) revert NotARegisteredAdapter();
+        _paused[adapter] = false;
+        emit AdapterPauseSet(adapter, false);
+    }
+
+    /// @dev Direct transfer (no two-step): mirrors OracleAdapterFactory.
+    function transferOwnership(address newOwner) external onlyOwner {
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    // ── per-feed unit: branches only, nothing here may revert ───────────
+
+    function _refreshOne(bytes32 acct, bool isRegistration) internal returns (uint256 outcome, bytes4 reason) {
+        Registration storage reg = _regs[acct];
+        if (reg.adapter == address(0)) return (OUTCOME_FAULT, UnregisteredFeed.selector);
+        if (_paused[reg.adapter]) {
+            emit FeedSkippedPaused(acct);
+            return (OUTCOME_SKIP, 0);
+        }
+
+        uint256 packed = _entries[acct];
+        uint8 status = uint8(packed >> 192);
+        uint64 storedPt = uint64(packed >> 64);
+
+        // Cheap-skip: only while the entry is comfortably fresh (age within
+        // half the staleness window); beyond that, always take the full
+        // validated read (the pre-read trusts Full-variant offsets).
+        if (status != 0 && !isRegistration && block.timestamp - storedPt <= reg.halfWindowSec) {
+            (bool peeked, uint64 livePt) = _peekPublishTime(acct);
+            if (peeked && livePt <= storedPt) {
+                emit FeedSkippedNotNewer(acct, storedPt);
+                return (OUTCOME_SKIP, 0);
+            }
+        }
+
+        (bool ok, bytes memory data) = _fetchRaw(acct);
+        if (!ok) return (OUTCOME_FAULT, FetchFailed.selector);
+        (bool pok, bytes4 perr, int64 price, uint64 conf, int32 expo, uint64 publishTime, bytes32 feedId) =
+            _parseFast(data);
+        if (!pok) return (OUTCOME_FAULT, perr);
+
+        if (feedId != reg.expectedFeedId) return (OUTCOME_FAULT, FeedIdMismatch.selector);
+        if (publishTime > block.timestamp) return (OUTCOME_FAULT, FuturePublishTime.selector);
+        if (status != 0 && publishTime <= storedPt) {
+            emit FeedSkippedNotNewer(acct, storedPt);
+            return (OUTCOME_SKIP, 0);
+        }
+        if (price <= 0) return (OUTCOME_FAULT, NonPositivePrice.selector);
+        if (uint256(conf) * 10_000 > uint256(uint64(price)) * reg.maxConfBps) {
+            return (OUTCOME_FAULT, ConfidenceExceedsThreshold.selector);
+        }
+        (bool nok, int64 price8) = _normalize64(price, expo);
+        if (!nok) return (OUTCOME_FAULT, NormalizationOverflow.selector);
+
+        _entries[acct] = uint256(uint64(price8)) | (uint256(publishTime) << 64)
+            | (uint256(uint64(block.timestamp)) << 128) | (uint256(1) << 192);
+        emit FeedRefreshed(acct, feedId, int256(price8), publishTime);
+        return (OUTCOME_COMMIT, 0);
+    }
+
+    /// @dev Assembly PriceUpdateV2 parse: discriminator + Full-variant guard,
+    ///      one mload + byteswap per needed field (EMA fields never touched).
+    ///      Byte-equivalent to PythPullParser.parse for the fields the book
+    ///      uses; reuses the parser's error selectors.
+    function _parseFast(bytes memory data)
+        internal
+        pure
+        returns (bool ok, bytes4 err, int64 price, uint64 conf, int32 expo, uint64 publishTime, bytes32 feedId)
+    {
+        if (data.length < PythPullParser.MIN_DATA_LENGTH) {
+            return (false, PythPullParser.PythPullDataTooShort.selector, 0, 0, 0, 0, 0);
+        }
+        bool discOk;
+        bool variantOk;
+        uint64 rawPrice;
+        uint64 rawConf;
+        uint32 rawExpo;
+        uint64 rawPt;
+        assembly {
+            function le64(w) -> v {
+                let x := shr(192, w)
+                v :=
+                    or(
+                        or(
+                            or(and(shr(56, x), 0xff), and(shr(40, x), 0xff00)),
+                            or(and(shr(24, x), 0xff0000), and(shr(8, x), 0xff000000))
+                        ),
+                        or(
+                            or(and(shl(8, x), 0xff00000000), and(shl(24, x), 0xff0000000000)),
+                            or(and(shl(40, x), 0xff000000000000), shl(56, and(x, 0xff)))
+                        )
+                    )
+            }
+            let p := add(data, 0x20)
+            discOk := eq(shr(192, mload(p)), 0x22f123639d7ef4cd)
+            variantOk := eq(byte(0, mload(add(p, 40))), 0x01)
+            feedId := mload(add(p, 41))
+            rawPrice := le64(mload(add(p, 73)))
+            rawConf := le64(mload(add(p, 81)))
+            let y := shr(224, mload(add(p, 89)))
+            rawExpo :=
+                or(
+                    or(and(shr(24, y), 0xff), and(shr(8, y), 0xff00)),
+                    or(and(shl(8, y), 0xff0000), shl(24, and(y, 0xff)))
+                )
+            rawPt := le64(mload(add(p, 93)))
+        }
+        if (!discOk) return (false, PythPullParser.InvalidPythPullAccount.selector, 0, 0, 0, 0, 0);
+        if (!variantOk) return (false, PythPullParser.UnsupportedVerificationVariant.selector, 0, 0, 0, 0, 0);
+        return (true, 0, int64(rawPrice), rawConf, int32(rawExpo), rawPt, feedId);
+    }
+
+    /// @dev Normalize to the Chainlink 8-decimal int64 answer, faulting (not
+    ///      reverting) on overflow. Same math as the legacy adapters for every
+    ///      sane exponent; guards keep the path revert-free.
+    function _normalize64(int64 price, int32 expo) internal pure returns (bool ok, int64 price8) {
+        int256 scaled = int256(price);
+        int32 diff = expo + 8;
+        if (diff > 0) {
+            if (diff > 18) return (false, 0); // any int64 × 10^19 exceeds int64
+            scaled = scaled * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            if (diff < -76) return (false, 0); // legacy reverts on 10**77 — fault instead
+            if (diff < -18) return (true, 0); // any int64 / 10^19 == 0 — match legacy
+            scaled = scaled / int256(10 ** uint32(-diff));
+        }
+        if (scaled > type(int64).max || scaled < type(int64).min) return (false, 0);
+        return (true, int64(scaled));
+    }
+
+    // ── account reads (virtual for the test harness) ────────────────────
+
+    /// @dev Raw success-flagged read of the full PriceUpdateV2 prefix via the
+    ///      account precompile; failure returns ok=false, never reverts.
+    function _fetchRaw(bytes32 acct) internal view virtual returns (bool ok, bytes memory data) {
+        address cpi = address(CpiProgram);
+        uint256 want = PythPullParser.MIN_DATA_LENGTH;
+        assembly {
+            let m := mload(0x40)
+            mstore(m, shl(224, 0x593762e8)) // account_data_at(bytes32,uint16,uint16)
+            mstore(add(m, 4), acct)
+            mstore(add(m, 36), 0)
+            mstore(add(m, 68), want)
+            ok := staticcall(gas(), cpi, m, 100, 0, 0)
+            if ok {
+                switch lt(returndatasize(), 0x40)
+                case 1 { ok := 0 }
+                default {
+                    returndatacopy(m, 0x20, 0x20)
+                    let len := mload(m)
+                    switch lt(len, want)
+                    case 1 { ok := 0 }
+                    default {
+                        data := m
+                        mstore(data, len)
+                        let padded := and(add(len, 31), not(31))
+                        returndatacopy(add(data, 0x20), 0x40, padded)
+                        mstore(0x40, add(add(data, 0x20), padded))
+                    }
+                }
+            }
+        }
+    }
+
+    /// @dev Cheap-skip pre-read: publish_time at offset 93 (Full-variant layout).
+    function _peekPublishTime(bytes32 acct) internal view virtual returns (bool ok, uint64 publishTime) {
+        try CpiProgram.account_u64_at(acct, 93) returns (uint64 pt) {
+            return (true, pt);
+        } catch {
+            return (false, 0);
+        }
+    }
+
+    /// @dev Solana owner of the source account (registration-time check).
+    function _accountOwner(bytes32 acct) internal view virtual returns (bytes32 accountOwner) {
+        (, accountOwner,,,,) = CpiProgram.account_info(acct);
+    }
+}

--- a/contracts/oracle/test/PriceBookHarness.sol
+++ b/contracts/oracle/test/PriceBookHarness.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PriceBook.sol";
+
+/// @title PriceBookHarness
+/// @notice Test double for PriceBook: the three account reads (full fetch,
+///         publish_time peek, owner lookup) are backed by settable state —
+///         the precompiles are unavailable on the simulated network. The peek
+///         is settable INDEPENDENTLY of the full bytes so tests can observe
+///         the cheap-skip short-circuit (peek says not-newer while the full
+///         data would commit).
+contract PriceBookHarness is PriceBook {
+    mapping(bytes32 => bytes) private _data;
+    mapping(bytes32 => uint64) private _peek;
+    mapping(bytes32 => bytes32) private _owners;
+
+    constructor(bytes32 receiverId, address adapterImpl) PriceBook(receiverId, adapterImpl) {}
+
+    function setAccountData(bytes32 acct, bytes calldata data) external {
+        _data[acct] = data;
+    }
+
+    function setPeekValue(bytes32 acct, uint64 publishTime) external {
+        _peek[acct] = publishTime;
+    }
+
+    function setAccountOwner(bytes32 acct, bytes32 accountOwner) external {
+        _owners[acct] = accountOwner;
+    }
+
+    /// @notice Rewind the stored publishTime by `delta` seconds so tests can
+    ///         age an entry past the cheap-skip bypass threshold.
+    function setEntryAgeForTest(bytes32 acct, uint256 delta) external {
+        uint256 packed = _entries[acct];
+        uint64 pt = uint64(packed >> 64);
+        uint64 aged = pt - uint64(delta);
+        _entries[acct] = (packed & ~(uint256(type(uint64).max) << 64)) | (uint256(aged) << 64);
+    }
+
+    function _fetchRaw(bytes32 acct) internal view override returns (bool ok, bytes memory data) {
+        data = _data[acct];
+        ok = data.length > 0;
+    }
+
+    function _peekPublishTime(bytes32 acct) internal view override returns (bool ok, uint64 publishTime) {
+        if (_peek[acct] != 0) return (true, _peek[acct]);
+        bytes memory d = _data[acct];
+        if (d.length < 101) return (false, 0);
+        uint64 v;
+        for (uint256 i = 0; i < 8; i++) {
+            v |= uint64(uint8(d[93 + i])) << uint64(8 * i);
+        }
+        return (true, v);
+    }
+
+    function _accountOwner(bytes32 acct) internal view override returns (bytes32) {
+        bytes32 o = _owners[acct];
+        return o == bytes32(0) ? pythReceiverProgramId : o;
+    }
+}
+
+/// @title BookFeedAdapterHarness
+/// @notice Unlocks the implementation's initialize so equivalence tests can
+///         exercise an adapter over a never-registered account (the
+///         `UninitializedPriceFeed` leg — unreachable through registerFeed,
+///         which always ends in a committed first refresh).
+contract BookFeedAdapterHarness is BookFeedAdapter {
+    constructor() BookFeedAdapter() {
+        initialized = false;
+    }
+}

--- a/contracts/oracle/test/PriceBookProbe.sol
+++ b/contracts/oracle/test/PriceBookProbe.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PythPullParser.sol";
+import {AccountReader} from "../../cpi/AccountReader.sol";
+
+/// @title PriceBookProbe
+/// @notice Phase-0 measurement kernel for the PriceBook spec: N feeds of
+///         (account read + PriceUpdateV2 parse + validate + SSTORE) inside ONE
+///         transaction, per-feed fault-isolated. This exists to measure compute
+///         units, account metas, and serialized tx size at widths 1/2/4/8 on a
+///         live chain — it is NOT the production book (no factory, no
+///         registration flow, no read adapters, no pause hook).
+///
+///         Write-path semantics mirror the spec so measured cost is honest:
+///         - per-feed try-units: one malformed/faulted feed never reverts the
+///           batch; it emits `FeedRefreshFailed` and the rest commit
+///         - monotonic publishTime: an older/equal source is a per-feed skip
+///           (`FeedSkippedNotNewer`), never a rollback, never a revert
+///         - all-skip is a HEALTHY no-op; the batch reverts only when every
+///           attempted feed faulted
+///         - confidence / positive-price bounds fault the feed for the round
+///         - feed_id integrity: the id parsed from the account bytes is bound
+///           on first commit; any later mismatch faults the feed (steady-state
+///           cost: one SLOAD + compare per feed, same as the book's
+///           registration check)
+///
+///         Deliberately excluded (CU-negligible, one timestamp compare):
+///         staleness windows — they would couple capacity runs to keeper
+///         cadence without changing the measurement.
+contract PriceBookProbe {
+    struct Entry {
+        int256 answer; // Chainlink-normalized 8 decimals
+        bytes32 feedId; // bound on first commit, checked afterwards
+        uint64 publishTime;
+        uint64 cachedAt;
+        uint8 status; // 0 = never written, 1 = active
+    }
+
+    mapping(bytes32 => Entry) public entries;
+
+    /// @notice Max permitted conf/price ratio in bps (matches the adapters).
+    uint256 public constant MAX_CONF_BPS = 200;
+
+    event FeedRefreshed(bytes32 indexed acct, bytes32 feedId, int256 answer, uint64 publishTime);
+    event FeedSkippedNotNewer(bytes32 indexed acct, uint64 storedPublishTime);
+    event FeedRefreshFailed(bytes32 indexed acct, bytes4 reason);
+
+    error NonPositivePrice();
+    error ConfidenceExceedsThreshold();
+    error FeedIdMismatch();
+    error AllFeedsFaulted();
+    error SelfOnly();
+
+    /// @notice One tx, N feeds. `force` bypasses the monotonic skip so capacity
+    ///         runs measure the full commit path at every width even when the
+    ///         source did not advance between runs (steady-state rewrites; run
+    ///         once beforehand so first-write storage creation is not counted).
+    function refreshAll(bytes32[] calldata accts, bool force)
+        external
+        returns (uint256 committed, uint256 skipped, uint256 faulted)
+    {
+        for (uint256 i = 0; i < accts.length; i++) {
+            try this.refreshOne(accts[i], force) returns (bool updated) {
+                if (updated) {
+                    committed++;
+                } else {
+                    skipped++;
+                }
+            } catch (bytes memory err) {
+                faulted++;
+                bytes4 sel;
+                if (err.length >= 4) {
+                    assembly {
+                        sel := mload(add(err, 0x20))
+                    }
+                }
+                emit FeedRefreshFailed(accts[i], sel);
+            }
+        }
+        if (accts.length > 0 && faulted == accts.length) revert AllFeedsFaulted();
+    }
+
+    /// @notice Per-feed try-unit. External so refreshAll can catch its reverts;
+    ///         callable only by the probe itself.
+    function refreshOne(bytes32 acct, bool force) external returns (bool updated) {
+        if (msg.sender != address(this)) revert SelfOnly();
+
+        bytes memory data = _fetchAccount(acct);
+        PythPullParser.PythPullPrice memory p = PythPullParser.parse(data);
+
+        // feed_id at offset 41 of the raw account bytes (+0x20 length prefix).
+        bytes32 parsedFeedId;
+        assembly {
+            parsedFeedId := mload(add(data, 0x49))
+        }
+
+        Entry storage e = entries[acct];
+        if (e.status != 0 && e.feedId != parsedFeedId) revert FeedIdMismatch();
+        if (e.status != 0 && !force && p.publishTime <= e.publishTime) {
+            emit FeedSkippedNotNewer(acct, e.publishTime);
+            return false;
+        }
+        if (p.price <= 0) revert NonPositivePrice();
+        if (uint256(p.conf) * 10_000 > uint256(uint64(p.price)) * MAX_CONF_BPS) {
+            revert ConfidenceExceedsThreshold();
+        }
+
+        if (e.status == 0) e.feedId = parsedFeedId;
+        e.answer = _normalize(p.price, p.expo);
+        e.publishTime = p.publishTime;
+        e.cachedAt = uint64(block.timestamp);
+        e.status = 1;
+        emit FeedRefreshed(acct, parsedFeedId, e.answer, p.publishTime);
+        return true;
+    }
+
+    /// @dev Virtual so the test harness can inject mock bytes (the account-read
+    ///      precompile is unavailable on the simulated network).
+    function _fetchAccount(bytes32 acct) internal view virtual returns (bytes memory) {
+        return AccountReader.readBytesAt(acct, 0, uint16(PythPullParser.MIN_DATA_LENGTH));
+    }
+
+    /// @dev Normalize Pyth price to 8 decimals (same math as the adapters).
+    function _normalize(int64 price, int32 expo) internal pure returns (int256) {
+        int256 scaledPrice = int256(price);
+        int32 diff = expo - (-8);
+        if (diff > 0) {
+            scaledPrice = scaledPrice * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            scaledPrice = scaledPrice / int256(10 ** uint32(-diff));
+        }
+        return scaledPrice;
+    }
+}

--- a/contracts/oracle/test/PriceBookProbeFast.sol
+++ b/contracts/oracle/test/PriceBookProbeFast.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PythPullParser.sol";
+import {cpi_program_address, CpiProgram} from "../../interface.sol";
+
+/// @title PriceBookProbeFast
+/// @notice Optimized-parse variant of the PriceBook Phase-0 measurement
+///         kernel. Same write-path semantics as PriceBookProbe (per-feed
+///         fault isolation, monotonic skip, all-skip healthy, all-faulted
+///         revert, feed_id binding), but built for the CU budget:
+///
+///         - branch-based fault isolation: no external self-call, no
+///           try/catch — the fetch is a raw success-flagged staticcall and
+///           the parse validates with flags, so nothing on the per-feed path
+///           can revert the batch
+///         - assembly parse: one mload + byteswap per field instead of
+///           Convert's eight bounds-checked byte reads per u64; the unused
+///           EMA fields are never touched
+///         - cheap-skip: once a feed is bound, force=false ticks pre-read
+///           publish_time alone (u64 at offset 93) and skip before the full
+///           133-byte fetch + parse. A never-advancing mis-bound account is
+///           therefore skipped rather than instantly faulted — it can never
+///           serve a wrong price (the full path faults it on any advance)
+///           and a permanently silent source is the age alert's job
+///         - single packed storage slot per feed steady-state
+///           (price8 i64 | publishTime u64 | cachedAt u64 | status u8);
+///           feedId slot written once at bind
+///
+///         Normalization packs into int64: a normalized answer beyond int64
+///         faults the feed (the legacy probe stores int256 and only faults
+///         via arithmetic revert) — divergence exists only for |expo| far
+///         outside Pyth's real range and is the book's intended R3 behavior.
+contract PriceBookProbeFast {
+    struct Entry {
+        bytes32 feedId; // bound on first commit
+        uint256 packed; // price8 i64 | publishTime u64 << 64 | cachedAt u64 << 128 | status u8 << 192
+    }
+
+    mapping(bytes32 => Entry) internal _entries;
+
+    uint256 public constant MAX_CONF_BPS = 200;
+
+    event FeedRefreshed(bytes32 indexed acct, bytes32 feedId, int256 answer, uint64 publishTime);
+    event FeedSkippedNotNewer(bytes32 indexed acct, uint64 storedPublishTime);
+    event FeedRefreshFailed(bytes32 indexed acct, bytes4 reason);
+
+    error AllFeedsFaulted();
+    error FetchFailed();
+    error NonPositivePrice();
+    error ConfidenceExceedsThreshold();
+    error FeedIdMismatch();
+    error NormalizationOverflow();
+
+    uint256 private constant OUTCOME_COMMIT = 0;
+    uint256 private constant OUTCOME_SKIP = 1;
+    uint256 private constant OUTCOME_FAULT = 2;
+
+    function refreshAll(bytes32[] calldata accts, bool force)
+        external
+        returns (uint256 committed, uint256 skipped, uint256 faulted)
+    {
+        for (uint256 i = 0; i < accts.length; i++) {
+            (uint256 outcome, bytes4 reason) = _refreshOne(accts[i], force);
+            if (outcome == OUTCOME_COMMIT) {
+                committed++;
+            } else if (outcome == OUTCOME_SKIP) {
+                skipped++;
+            } else {
+                faulted++;
+                emit FeedRefreshFailed(accts[i], reason);
+            }
+        }
+        if (accts.length > 0 && faulted == accts.length) revert AllFeedsFaulted();
+    }
+
+    function getEntry(bytes32 acct)
+        external
+        view
+        returns (int256 answer, bytes32 feedId, uint64 publishTime, uint64 status)
+    {
+        Entry storage e = _entries[acct];
+        uint256 packed = e.packed;
+        answer = int256(int64(uint64(packed)));
+        feedId = e.feedId;
+        publishTime = uint64(packed >> 64);
+        status = uint8(packed >> 192);
+    }
+
+    // ── measurement decomposition entrypoints (no stores, real txs) ─────
+
+    /// @notice Account fetch only — attributes the precompile-read share.
+    function fetchAll(bytes32[] calldata accts) external returns (uint256 okCount) {
+        for (uint256 i = 0; i < accts.length; i++) {
+            (bool ok,) = _fetchRaw(accts[i]);
+            if (ok) okCount++;
+        }
+    }
+
+    /// @notice Fetch + fast parse + validate, no store.
+    function parseAllFast(bytes32[] calldata accts) external returns (uint256 okCount) {
+        for (uint256 i = 0; i < accts.length; i++) {
+            (bool ok, bytes memory data) = _fetchRaw(accts[i]);
+            if (!ok) continue;
+            (bool pok,,,,,,) = _parseFast(data);
+            if (pok) okCount++;
+        }
+    }
+
+    /// @notice Fetch + LEGACY parser, no store — the A/B for the parse share.
+    ///         Measurement-only: a malformed account reverts the whole call.
+    function parseAllLegacy(bytes32[] calldata accts) external returns (uint256 okCount) {
+        for (uint256 i = 0; i < accts.length; i++) {
+            (bool ok, bytes memory data) = _fetchRaw(accts[i]);
+            if (!ok) continue;
+            PythPullParser.PythPullPrice memory p = PythPullParser.parse(data);
+            if (p.publishTime != 0) okCount++;
+        }
+    }
+
+    // ── per-feed unit: branches only, nothing here may revert ───────────
+
+    function _refreshOne(bytes32 acct, bool force) internal returns (uint256 outcome, bytes4 reason) {
+        Entry storage e = _entries[acct];
+        uint256 packed = e.packed;
+        uint8 status = uint8(packed >> 192);
+        uint64 storedPt = uint64(packed >> 64);
+
+        // Cheap-skip: bound feeds on a force=false tick peek publish_time
+        // (one u64 read) before paying the full fetch + parse.
+        if (status != 0 && !force) {
+            (bool peeked, uint64 livePt) = _peekPublishTime(acct);
+            if (peeked && livePt <= storedPt) {
+                emit FeedSkippedNotNewer(acct, storedPt);
+                return (OUTCOME_SKIP, 0);
+            }
+        }
+
+        (bool ok, bytes memory data) = _fetchRaw(acct);
+        if (!ok) return (OUTCOME_FAULT, FetchFailed.selector);
+        (bool pok, bytes4 perr, int64 price, uint64 conf, int32 expo, uint64 publishTime, bytes32 feedId) =
+            _parseFast(data);
+        if (!pok) return (OUTCOME_FAULT, perr);
+
+        if (status != 0) {
+            if (e.feedId != feedId) return (OUTCOME_FAULT, FeedIdMismatch.selector);
+            if (!force && publishTime <= storedPt) {
+                emit FeedSkippedNotNewer(acct, storedPt);
+                return (OUTCOME_SKIP, 0);
+            }
+        }
+        if (price <= 0) return (OUTCOME_FAULT, NonPositivePrice.selector);
+        if (uint256(conf) * 10_000 > uint256(uint64(price)) * MAX_CONF_BPS) {
+            return (OUTCOME_FAULT, ConfidenceExceedsThreshold.selector);
+        }
+        (bool nok, int64 price8) = _normalize64(price, expo);
+        if (!nok) return (OUTCOME_FAULT, NormalizationOverflow.selector);
+
+        if (status == 0) e.feedId = feedId;
+        e.packed = uint256(uint64(price8)) | (uint256(publishTime) << 64) | (uint256(uint64(block.timestamp)) << 128)
+            | (uint256(1) << 192);
+        emit FeedRefreshed(acct, feedId, int256(price8), publishTime);
+        return (OUTCOME_COMMIT, 0);
+    }
+
+    /// @dev Assembly PriceUpdateV2 parse: discriminator + Full-variant guard,
+    ///      then one mload + byteswap per needed field. Byte-equivalent to
+    ///      PythPullParser.parse for the fields the book uses (EMA skipped).
+    function _parseFast(bytes memory data)
+        internal
+        pure
+        returns (bool ok, bytes4 err, int64 price, uint64 conf, int32 expo, uint64 publishTime, bytes32 feedId)
+    {
+        if (data.length < PythPullParser.MIN_DATA_LENGTH) {
+            return (false, PythPullParser.PythPullDataTooShort.selector, 0, 0, 0, 0, 0);
+        }
+        bool discOk;
+        bool variantOk;
+        uint64 rawPrice;
+        uint64 rawConf;
+        uint32 rawExpo;
+        uint64 rawPt;
+        assembly {
+            function le64(w) -> v {
+                let x := shr(192, w)
+                v :=
+                    or(
+                        or(
+                            or(and(shr(56, x), 0xff), and(shr(40, x), 0xff00)),
+                            or(and(shr(24, x), 0xff0000), and(shr(8, x), 0xff000000))
+                        ),
+                        or(
+                            or(and(shl(8, x), 0xff00000000), and(shl(24, x), 0xff0000000000)),
+                            or(and(shl(40, x), 0xff000000000000), shl(56, and(x, 0xff)))
+                        )
+                    )
+            }
+            let p := add(data, 0x20)
+            discOk := eq(shr(192, mload(p)), 0x22f123639d7ef4cd)
+            variantOk := eq(byte(0, mload(add(p, 40))), 0x01)
+            feedId := mload(add(p, 41))
+            rawPrice := le64(mload(add(p, 73)))
+            rawConf := le64(mload(add(p, 81)))
+            let y := shr(224, mload(add(p, 89)))
+            rawExpo :=
+                or(
+                    or(and(shr(24, y), 0xff), and(shr(8, y), 0xff00)),
+                    or(and(shl(8, y), 0xff0000), shl(24, and(y, 0xff)))
+                )
+            rawPt := le64(mload(add(p, 93)))
+        }
+        if (!discOk) return (false, PythPullParser.InvalidPythPullAccount.selector, 0, 0, 0, 0, 0);
+        if (!variantOk) return (false, PythPullParser.UnsupportedVerificationVariant.selector, 0, 0, 0, 0, 0);
+        return (true, 0, int64(rawPrice), rawConf, int32(rawExpo), rawPt, feedId);
+    }
+
+    /// @dev Normalize to 8 decimals and pack into int64, faulting instead of
+    ///      reverting on overflow (R3). Mirrors the adapter math for all sane
+    ///      exponents; guards keep every path revert-free.
+    function _normalize64(int64 price, int32 expo) internal pure returns (bool ok, int64 price8) {
+        int256 scaled = int256(price);
+        int32 diff = expo + 8;
+        if (diff > 0) {
+            if (diff > 18) return (false, 0); // price*10^19 can never fit int64
+            scaled = scaled * int256(10 ** uint32(diff));
+        } else if (diff < 0) {
+            if (diff < -76) return (false, 0); // legacy reverts (10**77 overflow) → fault
+            if (diff < -18) return (true, 0); // any int64 / 10^19 == 0, match legacy
+            scaled = scaled / int256(10 ** uint32(-diff));
+        }
+        if (scaled > type(int64).max || scaled < type(int64).min) return (false, 0);
+        return (true, int64(scaled));
+    }
+
+    /// @dev Raw success-flagged account read: account_data_at via staticcall,
+    ///      payload lifted without abi.decode. Failure returns ok=false —
+    ///      never reverts. Virtual for the test harness.
+    function _fetchRaw(bytes32 acct) internal view virtual returns (bool ok, bytes memory data) {
+        address cpi = cpi_program_address;
+        uint256 want = PythPullParser.MIN_DATA_LENGTH;
+        assembly {
+            let m := mload(0x40)
+            mstore(m, shl(224, 0x593762e8)) // account_data_at(bytes32,uint16,uint16)
+            mstore(add(m, 4), acct)
+            mstore(add(m, 36), 0)
+            mstore(add(m, 68), want)
+            ok := staticcall(gas(), cpi, m, 100, 0, 0)
+            if ok {
+                switch lt(returndatasize(), 0x40)
+                case 1 { ok := 0 }
+                default {
+                    returndatacopy(m, 0x20, 0x20)
+                    let len := mload(m)
+                    switch lt(len, want)
+                    case 1 { ok := 0 }
+                    default {
+                        data := m
+                        mstore(data, len)
+                        let padded := and(add(len, 31), not(31))
+                        returndatacopy(add(data, 0x20), 0x40, padded)
+                        mstore(0x40, add(add(data, 0x20), padded))
+                    }
+                }
+            }
+        }
+    }
+
+    /// @dev Cheap-skip pre-read: publish_time as a single LE u64 at offset 93.
+    ///      Virtual for the test harness.
+    function _peekPublishTime(bytes32 acct) internal view virtual returns (bool ok, uint64 publishTime) {
+        try CpiProgram.account_u64_at(acct, 93) returns (uint64 pt) {
+            return (true, pt);
+        } catch {
+            return (false, 0);
+        }
+    }
+}

--- a/contracts/oracle/test/PriceBookProbeFastHarness.sol
+++ b/contracts/oracle/test/PriceBookProbeFastHarness.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./PriceBookProbeFast.sol";
+
+/// @title PriceBookProbeFastHarness
+/// @notice Test double for PriceBookProbeFast: replaces both account-read
+///         paths (raw fetch + publish_time peek) with settable per-account
+///         bytes, plus a fetch-failure switch for the fault path. Both
+///         overrides are required — the precompile address has no code on the
+///         simulated network, and the no-code guard reverts in the caller.
+contract PriceBookProbeFastHarness is PriceBookProbeFast {
+    mapping(bytes32 => bytes) private _data;
+    mapping(bytes32 => bool) private _fail;
+
+    function setAccountData(bytes32 acct, bytes calldata data) external {
+        _data[acct] = data;
+    }
+
+    function setFetchFail(bytes32 acct, bool fail) external {
+        _fail[acct] = fail;
+    }
+
+    function _fetchRaw(bytes32 acct) internal view override returns (bool ok, bytes memory data) {
+        if (_fail[acct]) return (false, "");
+        return (true, _data[acct]);
+    }
+
+    function _peekPublishTime(bytes32 acct) internal view override returns (bool ok, uint64 publishTime) {
+        bytes memory d = _data[acct];
+        if (_fail[acct] || d.length < 101) return (false, 0);
+        uint64 v;
+        for (uint256 i = 0; i < 8; i++) {
+            v |= uint64(uint8(d[93 + i])) << uint64(8 * i);
+        }
+        return (true, v);
+    }
+}

--- a/contracts/oracle/test/PriceBookProbeHarness.sol
+++ b/contracts/oracle/test/PriceBookProbeHarness.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./PriceBookProbe.sol";
+
+/// @title PriceBookProbeHarness
+/// @notice Test double for PriceBookProbe: replaces the account-read precompile
+///         with settable per-account bytes so the write-path semantics can be
+///         exercised on the simulated network. Empty (unset) data trips the
+///         parser's length guard — the missing-account fault path.
+contract PriceBookProbeHarness is PriceBookProbe {
+    mapping(bytes32 => bytes) private _data;
+
+    function setAccountData(bytes32 acct, bytes calldata data) external {
+        _data[acct] = data;
+    }
+
+    function _fetchAccount(bytes32 acct) internal view override returns (bytes memory) {
+        return _data[acct];
+    }
+}

--- a/scripts/oracle/deploy-pricebook.mjs
+++ b/scripts/oracle/deploy-pricebook.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * PriceBook deploy + registration + in-situ capacity measurement.
+ *
+ * Flow (per the PriceBook spec's registration order):
+ *   1. deploy BookFeedAdapter implementation + PriceBook(receiverId, impl)
+ *   2. per feed: read the live source account, parse feed_id at offset 41,
+ *      registerFeed(...) — the solo first refresh happens inside the tx
+ *   3. cross-check book entries vs the deployed raw adapters (EXACT match)
+ *   4. measured refreshAll runs at growing widths + a cheap-skip round,
+ *      attributed from Solana receipts (CU, keys, size, execution shape)
+ *
+ * Env: RPC, SOLANA_RPC, EVM_KEY_FILE, FEEDS_JSON, ROME_EVM_PROGRAM (as the
+ * triage driver), RECEIVER_ID (bytes32 hex — read it from the OG-V2 factory:
+ * cast call <factory> "pythReceiverProgramId()(bytes32)"), MAX_STALENESS
+ * (default 300), BOOK (reuse a deployed book; skips deploy+register), OUT.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { createPublicClient, createWalletClient, http, decodeEventLog } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+const need = (k) => {
+    const v = process.env[k];
+    if (!v) {
+        console.error(`missing env ${k}`);
+        process.exit(1);
+    }
+    return v;
+};
+const RPC = need("RPC");
+const SOLANA_RPC = need("SOLANA_RPC");
+const KEY_FILE = need("EVM_KEY_FILE");
+const FEEDS_JSON = need("FEEDS_JSON");
+const PROGRAM = need("ROME_EVM_PROGRAM");
+const RECEIVER_ID = need("RECEIVER_ID");
+const MAX_STALENESS = BigInt(process.env.MAX_STALENESS ?? "300");
+const OUT = process.env.OUT ?? "pricebook-deploy-results.json";
+
+const BOOK_ART = JSON.parse(readFileSync(new URL("../../artifacts/contracts/oracle/PriceBook.sol/PriceBook.json", import.meta.url)));
+const IMPL_ART = JSON.parse(readFileSync(new URL("../../artifacts/contracts/oracle/BookFeedAdapter.sol/BookFeedAdapter.json", import.meta.url)));
+const AGG_ABI = [
+    {
+        type: "function",
+        name: "latestRoundData",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [
+            { name: "roundId", type: "uint80" },
+            { name: "answer", type: "int256" },
+            { name: "startedAt", type: "uint256" },
+            { name: "updatedAt", type: "uint256" },
+            { name: "answeredInRound", type: "uint80" },
+        ],
+    },
+];
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function b58ToBytes32(s) {
+    let n = 0n;
+    for (const c of s) {
+        const i = B58.indexOf(c);
+        if (i < 0) throw new Error(`bad base58: ${s}`);
+        n = n * 58n + BigInt(i);
+    }
+    let hex = n.toString(16);
+    if (hex.length % 2) hex = "0" + hex;
+    let zeros = 0;
+    for (const c of s) {
+        if (c === "1") zeros++;
+        else break;
+    }
+    const out = Buffer.concat([Buffer.alloc(zeros), Buffer.from(hex, "hex")]);
+    if (out.length !== 32) throw new Error(`${s} decodes to ${out.length} bytes, want 32`);
+    return "0x" + out.toString("hex");
+}
+
+let solId = 0;
+async function sol(method, params) {
+    const res = await fetch(SOLANA_RPC, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++solId, method, params }),
+    });
+    const j = await res.json();
+    if (j.error) throw new Error(`${method}: ${JSON.stringify(j.error)}`);
+    return j.result;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── inputs ──────────────────────────────────────────────────────────────
+const reg = JSON.parse(readFileSync(FEEDS_JSON, "utf8"));
+const FEEDS = Object.entries(reg.feeds)
+    .filter(([, f]) => f.source === "pyth")
+    .map(([name, f]) => ({ name, rawAdapter: f.address, pda: f.underlyingAccount, acct: b58ToBytes32(f.underlyingAccount) }));
+if (FEEDS.length === 0) throw new Error("no pyth feeds in FEEDS_JSON");
+const anchorPda = FEEDS[0].pda;
+
+const account = privateKeyToAccount(readFileSync(KEY_FILE, "utf8").trim());
+const transport = http(RPC, { timeout: 180_000 }); // proxy executes synchronously; wide batches exceed the 10s default
+const pub = createPublicClient({ transport });
+const wallet = createWalletClient({ account, transport });
+const gasPrice = await pub.getGasPrice();
+const chainId = await pub.getChainId();
+console.log(`chain ${chainId} · sender ${account.address} · ${FEEDS.length} pyth feeds · window ${MAX_STALENESS}s`);
+
+async function send(desc, fn) {
+    for (let attempt = 1; ; attempt++) {
+        try {
+            const hash = await fn();
+            const rc = await pub.waitForTransactionReceipt({ hash, timeout: 240_000 });
+            if (rc.status !== "success") throw new Error(`${desc}: reverted on-chain (${hash})`);
+            return rc;
+        } catch (e) {
+            if (attempt >= 3 || /reverted on-chain/.test(e.message ?? "")) throw e;
+            console.log(`  ${desc}: retry ${attempt} (${(e.shortMessage ?? e.message ?? "").split("\n")[0].slice(0, 100)})`);
+            await sleep(4000);
+        }
+    }
+}
+
+// ── 1. deploy ───────────────────────────────────────────────────────────
+let book = process.env.BOOK;
+let implAddr;
+if (!book) {
+    const rcImpl = await send("deploy impl", () =>
+        wallet.deployContract({ abi: IMPL_ART.abi, bytecode: IMPL_ART.bytecode, args: [], gasPrice, chain: null }),
+    );
+    implAddr = rcImpl.contractAddress;
+    console.log(`BookFeedAdapter impl ${implAddr}`);
+    const rcBook = await send("deploy book", () =>
+        wallet.deployContract({ abi: BOOK_ART.abi, bytecode: BOOK_ART.bytecode, args: [RECEIVER_ID, implAddr], gasPrice, chain: null }),
+    );
+    book = rcBook.contractAddress;
+    await sleep(6000); // fresh accounts are lock-TTL'd; let estimation settle
+}
+console.log(`PriceBook ${book}`);
+
+// ── 2. register (solo first refresh inside each tx) ─────────────────────
+const registered = [];
+const failed = [];
+if (!process.env.BOOK) {
+    for (const f of FEEDS) {
+        const info = await sol("getAccountInfo", [f.pda, { encoding: "base64" }]);
+        if (!info?.value) {
+            failed.push({ feed: f.name, reason: "source account missing" });
+            continue;
+        }
+        const raw = Buffer.from(info.value.data[0], "base64");
+        const feedId = "0x" + raw.subarray(41, 73).toString("hex");
+        try {
+            const rc = await send(`register ${f.name}`, () =>
+                wallet.writeContract({
+                    address: book,
+                    abi: BOOK_ART.abi,
+                    functionName: "registerFeed",
+                    args: [f.acct, feedId, 0n, f.name, MAX_STALENESS],
+                    gasPrice,
+                    gas: 30_000_000n,
+                    chain: null,
+                }),
+            );
+            const adapter = await pub.readContract({ address: book, abi: BOOK_ART.abi, functionName: "adapterOf", args: [f.acct] });
+            registered.push({ ...f, feedId, adapter, regGasUsed: rc.gasUsed.toString() });
+            console.log(`  ${f.name.padEnd(12)} adapter ${adapter} (gasUsed ${rc.gasUsed})`);
+        } catch (e) {
+            failed.push({ feed: f.name, reason: (e.shortMessage ?? e.message ?? "").split("\n").slice(0, 3).join(" ") });
+            console.log(`  ${f.name.padEnd(12)} REGISTRATION FAILED: ${failed.at(-1).reason.slice(0, 120)}`);
+        }
+    }
+} else {
+    const count = await pub.readContract({ address: book, abi: BOOK_ART.abi, functionName: "registrationCount", args: [] });
+    for (let i = 0n; i < count; i++) {
+        const acct = await pub.readContract({ address: book, abi: BOOK_ART.abi, functionName: "registrationAt", args: [i] });
+        const f = FEEDS.find((x) => x.acct.toLowerCase() === acct.toLowerCase());
+        if (f) registered.push({ ...f, adapter: await pub.readContract({ address: book, abi: BOOK_ART.abi, functionName: "adapterOf", args: [acct] }) });
+    }
+}
+console.log(`registered ${registered.length}/${FEEDS.length}${failed.length ? ` (failed: ${failed.map((f) => f.feed).join(", ")})` : ""}`);
+if (registered.length === 0) throw new Error("nothing registered");
+
+// ── 3. cross-check vs raw adapters ──────────────────────────────────────
+console.log("\ncross-check vs deployed raw adapters:");
+const checks = [];
+for (const f of registered.slice(0, 3)) {
+    const e = await pub.readContract({ address: book, abi: BOOK_ART.abi, functionName: "entryOf", args: [f.acct] });
+    const a = await pub.readContract({ address: f.rawAdapter, abi: AGG_ABI, functionName: "latestRoundData" });
+    const match = e[1] === BigInt(a[3]) ? (e[0] === a[1] ? "EXACT" : "MISMATCH!") : "source-advanced";
+    checks.push({ feed: f.name, bookAnswer: e[0].toString(), bookPt: e[1].toString(), rawAnswer: a[1].toString(), rawPt: a[3].toString(), match });
+    console.log(`  ${f.name.padEnd(12)} book=${e[0]} pt=${e[1]} | raw=${a[1]} pt=${a[3]} → ${match}`);
+    if (match === "MISMATCH!") process.exitCode = 1;
+}
+
+// ── 4. measured refreshAll runs ─────────────────────────────────────────
+async function classify(sig) {
+    const [j, b] = await Promise.all([
+        sol("getTransaction", [sig, { encoding: "json", maxSupportedTransactionVersion: 0, commitment: "confirmed" }]),
+        sol("getTransaction", [sig, { encoding: "base64", maxSupportedTransactionVersion: 0, commitment: "confirmed" }]),
+    ]);
+    if (!j) return null;
+    const msg = j.transaction.message;
+    const loaded = j.meta.loadedAddresses ?? { writable: [], readonly: [] };
+    const allKeys = [...msg.accountKeys, ...loaded.writable, ...loaded.readonly];
+    if (!allKeys.includes(PROGRAM)) return null;
+    const rawB64 = b.transaction[0];
+    if (!Buffer.from(rawB64, "base64").toString("hex").includes(book.slice(2).toLowerCase())) return null;
+    return {
+        sig,
+        cu: j.meta.computeUnitsConsumed,
+        err: j.meta.err,
+        totalKeys: allKeys.length,
+        size: Buffer.from(rawB64, "base64").length,
+        shape: (j.meta.logMessages ?? []).find((l) => l.includes("Instruction:"))?.split("Instruction:")[1]?.trim(),
+    };
+}
+
+const runs = [];
+async function run(label, accts) {
+    const anchor = (await sol("getSignaturesForAddress", [anchorPda, { limit: 1, commitment: "confirmed" }]))[0]?.signature;
+    const sim = await pub.simulateContract({ address: book, abi: BOOK_ART.abi, functionName: "refreshAll", args: [accts], account });
+    const rc = await send(label, () =>
+        wallet.writeContract({ address: book, abi: BOOK_ART.abi, functionName: "refreshAll", args: [accts], gasPrice, gas: 30_000_000n, chain: null }),
+    );
+    const events = { FeedRefreshed: 0, FeedSkippedNotNewer: 0, FeedSkippedPaused: 0, FeedRefreshFailed: 0 };
+    for (const log of rc.logs) {
+        try {
+            const ev = decodeEventLog({ abi: BOOK_ART.abi, data: log.data, topics: log.topics });
+            if (ev.eventName in events) events[ev.eventName]++;
+        } catch {}
+    }
+    await sleep(4000);
+    const legs = [];
+    const params = { limit: 60, commitment: "confirmed" };
+    if (anchor) params.until = anchor;
+    for (const s of await sol("getSignaturesForAddress", [anchorPda, params])) {
+        const c = await classify(s.signature);
+        if (c) legs.push(c);
+    }
+    legs.reverse();
+    const totalCU = legs.reduce((a, l) => a + (l.cu ?? 0), 0);
+    const r = {
+        label,
+        width: accts.length,
+        simOutcome: sim.result.map(String),
+        ethGasUsed: rc.gasUsed.toString(),
+        events,
+        solanaLegs: legs.length,
+        totalCU,
+        legs,
+    };
+    runs.push(r);
+    console.log(
+        `${label.padEnd(8)} w=${accts.length} C/S/F=${events.FeedRefreshed}/${events.FeedSkippedNotNewer + events.FeedSkippedPaused}/${events.FeedRefreshFailed} ` +
+            `legs=${legs.length} CU=${totalCU} keys=${legs[0]?.totalKeys ?? "?"} size=${legs[0]?.size ?? "?"}B ${legs[0]?.shape ?? ""}`,
+    );
+    return r;
+}
+
+const A = registered.map((f) => f.acct);
+const WIDTHS = (process.env.WIDTHS ?? "1,2,4,8,all,skip").split(",");
+console.log("\nmeasured refreshAll runs (production semantics — sources advance between runs):");
+for (const w of WIDTHS) {
+    try {
+        if (w === "skip") await run("SKIPFAST", A); // right after a full run: cheap-skip path
+        else if (w === "all") await run(`W${A.length}`, A);
+        else await run(`W${w}`, A.slice(0, Number(w)));
+    } catch (e) {
+        runs.push({ label: w, error: (e.shortMessage ?? e.message ?? "").split("\n")[0] });
+        console.log(`  ${w}: FAILED after retries — recorded, continuing`);
+    }
+    await sleep(8000); // drain locks/pending between runs
+}
+
+writeFileSync(OUT, JSON.stringify({ chainId, book, impl: implAddr, sender: account.address, receiverId: RECEIVER_ID, maxStaleness: MAX_STALENESS.toString(), registered, failed, checks, runs }, (k, v) => (typeof v === "bigint" ? v.toString() : v), 2));
+console.log(`\nresults → ${OUT}`);

--- a/scripts/oracle/pricebook-triage.mjs
+++ b/scripts/oracle/pricebook-triage.mjs
@@ -3,16 +3,20 @@
  * PriceBook Phase-0 triage — measures refreshAll() capacity on a LIVE Rome
  * chain from on-chain receipts (never from architecture): Solana compute
  * units, account metas, serialized tx size, and whether the proxy kept each
- * width atomic. Protocol:
+ * width atomic.
  *
- *   INIT      refreshAll(8, force=false)  first-write storage creation (labeled, excluded from marginals)
- *   W1/2/4/8  refreshAll(w, force=true)   steady-state commit path at each width
- *   SKIP8     refreshAll(8, force=false)  the all-skip (nothing newer) path
- *   FAULT     refreshAll([bogus]+7, true) one faulted feed inside a surviving batch
+ * MODE=legacy (default) → PriceBookProbe (PythPullParser path):
+ *   INIT, W1/2/4/8 (force), SKIP8, FAULT
+ * MODE=fast → PriceBookProbeFast (assembly parse, cheap-skip, packed slot):
+ *   same protocol, plus decomposition runs that attribute the per-feed cost:
+ *   FETCH8 (reads only), PARSEFAST8 (read+fast parse), PARSELEG2 (read+legacy
+ *   parse at an atomic-safe width for the A/B).
  *
  * Attribution: after each EVM tx, new Solana signatures touching feed[0]'s
  * account (anchored with `until`) are classified by whether the raw tx bytes
  * contain the probe address (ours) vs a known adapter address (keeper's).
+ * Holder-staged executions escape this filter — reconcile those with the
+ * post-hoc leg scan by instruction log.
  *
  * Env (all endpoints/keys injected, nothing baked in):
  *   RPC               Rome EVM JSON-RPC                  (required)
@@ -20,6 +24,7 @@
  *   EVM_KEY_FILE      path to 0x-hex private key file    (required; key never printed)
  *   FEEDS_JSON        registry-style oracle.json         (required)
  *   ROME_EVM_PROGRAM  base58 program id                  (required)
+ *   MODE              legacy | fast                      (default legacy)
  *   PROBE             pre-deployed probe address         (optional; skips deploy)
  *   OUT               JSON results path                  (optional)
  */
@@ -40,10 +45,12 @@ const SOLANA_RPC = need("SOLANA_RPC");
 const KEY_FILE = need("EVM_KEY_FILE");
 const FEEDS_JSON = need("FEEDS_JSON");
 const PROGRAM = need("ROME_EVM_PROGRAM");
-const OUT = process.env.OUT ?? "pricebook-triage-results.json";
+const MODE = process.env.MODE ?? "legacy";
+const OUT = process.env.OUT ?? `pricebook-triage-${MODE}.json`;
 
+const CONTRACT = MODE === "fast" ? "PriceBookProbeFast" : "PriceBookProbe";
 const ART = JSON.parse(
-    readFileSync(new URL("../../artifacts/contracts/oracle/test/PriceBookProbe.sol/PriceBookProbe.json", import.meta.url)),
+    readFileSync(new URL(`../../artifacts/contracts/oracle/test/${CONTRACT}.sol/${CONTRACT}.json`, import.meta.url)),
 );
 const AGG_ABI = [
     {
@@ -109,7 +116,7 @@ const pub = createPublicClient({ transport: http(RPC) });
 const wallet = createWalletClient({ account, transport: http(RPC) });
 const gasPrice = await pub.getGasPrice(); // legacy sends: feeHistory is stubbed on Rome proxies
 const chainId = await pub.getChainId();
-console.log(`chain ${chainId} · sender ${account.address} · gasPrice ${gasPrice} · ${FEEDS.length} pyth feeds`);
+console.log(`chain ${chainId} · mode ${MODE} · sender ${account.address} · gasPrice ${gasPrice} · ${FEEDS.length} pyth feeds`);
 
 // ── deploy (or reuse) ───────────────────────────────────────────────────
 let probe = process.env.PROBE;
@@ -119,8 +126,9 @@ if (!probe) {
     const rc = await pub.waitForTransactionReceipt({ hash, timeout: 240_000 });
     if (rc.status !== "success") throw new Error("deploy failed");
     probe = rc.contractAddress;
+    await sleep(6000); // freshly created probe accounts are lock-TTL'd; let estimation settle
 }
-console.log(`probe ${probe}`);
+console.log(`probe ${probe} (${CONTRACT})`);
 const probeHex = probe.slice(2).toLowerCase();
 const adapterHexes = pythFeeds.map((f) => f.adapter.slice(2).toLowerCase());
 
@@ -145,7 +153,7 @@ async function classify(sig) {
     const rawHex = Buffer.from(rawB64, "base64").toString("hex");
     const size = Buffer.from(rawB64, "base64").length;
     const owner = rawHex.includes(probeHex) ? "probe" : adapterHexes.some((a) => rawHex.includes(a)) ? "keeper" : "other";
-    const cuLog = (j.meta.logMessages ?? []).filter((l) => l.includes("consumed") && l.includes(PROGRAM));
+    const shape = (j.meta.logMessages ?? []).find((l) => l.includes("Instruction:"))?.split("Instruction:")[1]?.trim();
     return {
         sig,
         owner,
@@ -158,21 +166,33 @@ async function classify(sig) {
         totalKeys: allKeys.length,
         altLookups: (msg.addressTableLookups ?? []).length,
         size,
-        cuLog,
+        shape,
     };
 }
 
 // ── one measured run ────────────────────────────────────────────────────
 const runs = [];
-async function run(label, accts, force) {
+async function run(label, functionName, args) {
     const anchor = (await sol("getSignaturesForAddress", [anchorPda, { limit: 1, commitment: "confirmed" }]))[0]?.signature;
     const t0 = Math.floor(Date.now() / 1000);
-    const gas = await pub.estimateContractGas({ address: probe, abi: ART.abi, functionName: "refreshAll", args: [accts, force], account });
+    let gas;
+    for (let attempt = 1; ; attempt++) {
+        try {
+            gas = await pub.estimateContractGas({ address: probe, abi: ART.abi, functionName, args, account });
+            break;
+        } catch (e) {
+            // Post-deploy/estimation transients (account lock TTL, pool payer)
+            // self-heal in seconds — retry before giving up.
+            if (attempt >= 3) throw e;
+            console.log(`  estimate retry ${attempt} (${(e.shortMessage ?? e.message ?? "").split("\n")[0].slice(0, 110)})`);
+            await sleep(4000);
+        }
+    }
     const hash = await wallet.writeContract({
         address: probe,
         abi: ART.abi,
-        functionName: "refreshAll",
-        args: [accts, force],
+        functionName,
+        args,
         gas: (gas * 15n) / 10n,
         gasPrice,
         chain: null,
@@ -194,10 +214,11 @@ async function run(label, accts, force) {
     }
     legs.reverse(); // chronological
     const totalCU = legs.reduce((a, l) => a + (l.cu ?? 0), 0);
+    const width = Array.isArray(args[0]) ? args[0].length : 0;
     const r = {
         label,
-        width: accts.length,
-        force,
+        functionName,
+        width,
         ethTx: hash,
         ethGasUsed: rc.gasUsed.toString(),
         ethStatus: rc.status,
@@ -208,29 +229,37 @@ async function run(label, accts, force) {
     };
     runs.push(r);
     console.log(
-        `${label.padEnd(6)} w=${accts.length} eth=${rc.status} gasUsed=${rc.gasUsed} ` +
+        `${label.padEnd(10)} w=${width} eth=${rc.status} gasUsed=${rc.gasUsed} ` +
             `C/S/F=${events.FeedRefreshed}/${events.FeedSkippedNotNewer}/${events.FeedRefreshFailed} ` +
-            `legs=${legs.length} CU=${totalCU} keys=${legs[0]?.totalKeys ?? "?"} size=${legs[0]?.size ?? "?"}B`,
+            `legs=${legs.length} CU=${totalCU} keys=${legs[0]?.totalKeys ?? "?"} size=${legs[0]?.size ?? "?"}B ${legs[0]?.shape ?? ""}`,
     );
     return r;
 }
 
 // ── protocol ────────────────────────────────────────────────────────────
 const A = FEEDS.map((f) => f.acct);
-await run("INIT", A, false);
-await run("W1", A.slice(0, 1), true);
-await run("W2", A.slice(0, 2), true);
-await run("W4", A.slice(0, 4), true);
-await run("W8", A, true);
-await run("SKIP8", A, false);
+await run("INIT", "refreshAll", [A, false]);
+await run("W1", "refreshAll", [A.slice(0, 1), true]);
+await run("W2", "refreshAll", [A.slice(0, 2), true]);
+await run("W4", "refreshAll", [A.slice(0, 4), true]);
+await run("W8", "refreshAll", [A, true]);
+await run("SKIP8", "refreshAll", [A, false]);
 const bogus = process.env.FAULT_ACCOUNT ?? sbFeed?.underlyingAccount;
-if (bogus) await run("FAULT", [b58ToBytes32(bogus), ...A.slice(0, 7)], true);
+if (bogus) await run("FAULT", "refreshAll", [[b58ToBytes32(bogus), ...A.slice(0, 7)], true]);
+if (MODE === "fast") {
+    await run("FETCH8", "fetchAll", [A]);
+    await run("PARSEFAST8", "parseAllFast", [A]);
+    await run("PARSELEG2", "parseAllLegacy", [A.slice(0, 2)]);
+}
 
 // ── cross-check: probe entries vs live raw adapters ─────────────────────
 console.log("\ncross-check vs deployed raw adapters:");
 const checks = [];
 for (const f of FEEDS.slice(0, 3)) {
-    const e = await pub.readContract({ address: probe, abi: ART.abi, functionName: "entries", args: [f.acct] });
+    const e =
+        MODE === "fast"
+            ? await pub.readContract({ address: probe, abi: ART.abi, functionName: "getEntry", args: [f.acct] })
+            : await pub.readContract({ address: probe, abi: ART.abi, functionName: "entries", args: [f.acct] });
     const a = await pub.readContract({ address: f.adapter, abi: AGG_ABI, functionName: "latestRoundData" });
     const match = e[2] === BigInt(a[3]) ? (e[0] === a[1] ? "EXACT" : "MISMATCH!") : "source-advanced";
     checks.push({ feed: f.name, probeAnswer: e[0].toString(), probePt: e[2].toString(), adapterAnswer: a[1].toString(), adapterPt: a[3].toString(), match });
@@ -250,5 +279,5 @@ if (w[1] && w[8] && w[1].solanaLegs === 1 && w[8].solanaLegs === 1) {
     console.log("\n8-wide did not land as a single atomic leg — see per-run legs for the real tx count");
 }
 
-writeFileSync(OUT, JSON.stringify({ chainId, probe, sender: account.address, feeds: FEEDS, runs, checks, summary }, (k, v) => (typeof v === "bigint" ? v.toString() : v), 2));
+writeFileSync(OUT, JSON.stringify({ chainId, mode: MODE, probe, sender: account.address, feeds: FEEDS, runs, checks, summary }, (k, v) => (typeof v === "bigint" ? v.toString() : v), 2));
 console.log(`\nresults → ${OUT}`);

--- a/scripts/oracle/pricebook-triage.mjs
+++ b/scripts/oracle/pricebook-triage.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * PriceBook Phase-0 triage — measures refreshAll() capacity on a LIVE Rome
+ * chain from on-chain receipts (never from architecture): Solana compute
+ * units, account metas, serialized tx size, and whether the proxy kept each
+ * width atomic. Protocol:
+ *
+ *   INIT      refreshAll(8, force=false)  first-write storage creation (labeled, excluded from marginals)
+ *   W1/2/4/8  refreshAll(w, force=true)   steady-state commit path at each width
+ *   SKIP8     refreshAll(8, force=false)  the all-skip (nothing newer) path
+ *   FAULT     refreshAll([bogus]+7, true) one faulted feed inside a surviving batch
+ *
+ * Attribution: after each EVM tx, new Solana signatures touching feed[0]'s
+ * account (anchored with `until`) are classified by whether the raw tx bytes
+ * contain the probe address (ours) vs a known adapter address (keeper's).
+ *
+ * Env (all endpoints/keys injected, nothing baked in):
+ *   RPC               Rome EVM JSON-RPC                  (required)
+ *   SOLANA_RPC        Solana RPC for receipt reads       (required)
+ *   EVM_KEY_FILE      path to 0x-hex private key file    (required; key never printed)
+ *   FEEDS_JSON        registry-style oracle.json         (required)
+ *   ROME_EVM_PROGRAM  base58 program id                  (required)
+ *   PROBE             pre-deployed probe address         (optional; skips deploy)
+ *   OUT               JSON results path                  (optional)
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { createPublicClient, createWalletClient, http, decodeEventLog } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+const need = (k) => {
+    const v = process.env[k];
+    if (!v) {
+        console.error(`missing env ${k}`);
+        process.exit(1);
+    }
+    return v;
+};
+const RPC = need("RPC");
+const SOLANA_RPC = need("SOLANA_RPC");
+const KEY_FILE = need("EVM_KEY_FILE");
+const FEEDS_JSON = need("FEEDS_JSON");
+const PROGRAM = need("ROME_EVM_PROGRAM");
+const OUT = process.env.OUT ?? "pricebook-triage-results.json";
+
+const ART = JSON.parse(
+    readFileSync(new URL("../../artifacts/contracts/oracle/test/PriceBookProbe.sol/PriceBookProbe.json", import.meta.url)),
+);
+const AGG_ABI = [
+    {
+        type: "function",
+        name: "latestRoundData",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [
+            { name: "roundId", type: "uint80" },
+            { name: "answer", type: "int256" },
+            { name: "startedAt", type: "uint256" },
+            { name: "updatedAt", type: "uint256" },
+            { name: "answeredInRound", type: "uint80" },
+        ],
+    },
+];
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function b58ToBytes32(s) {
+    let n = 0n;
+    for (const c of s) {
+        const i = B58.indexOf(c);
+        if (i < 0) throw new Error(`bad base58: ${s}`);
+        n = n * 58n + BigInt(i);
+    }
+    let hex = n.toString(16);
+    if (hex.length % 2) hex = "0" + hex;
+    let zeros = 0;
+    for (const c of s) {
+        if (c === "1") zeros++;
+        else break;
+    }
+    const out = Buffer.concat([Buffer.alloc(zeros), Buffer.from(hex, "hex")]);
+    if (out.length !== 32) throw new Error(`${s} decodes to ${out.length} bytes, want 32`);
+    return "0x" + out.toString("hex");
+}
+
+let solId = 0;
+async function sol(method, params) {
+    const res = await fetch(SOLANA_RPC, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: ++solId, method, params }),
+    });
+    const j = await res.json();
+    if (j.error) throw new Error(`${method}: ${JSON.stringify(j.error)}`);
+    return j.result;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── inputs ──────────────────────────────────────────────────────────────
+const reg = JSON.parse(readFileSync(FEEDS_JSON, "utf8"));
+const pythFeeds = Object.entries(reg.feeds)
+    .filter(([, f]) => f.source === "pyth")
+    .map(([name, f]) => ({ name, adapter: f.address, pda: f.underlyingAccount, acct: b58ToBytes32(f.underlyingAccount) }));
+const sbFeed = Object.values(reg.feeds).find((f) => f.source === "switchboard");
+if (pythFeeds.length < 8) throw new Error(`need ≥8 pyth feeds, got ${pythFeeds.length}`);
+const FEEDS = pythFeeds.slice(0, 8);
+const anchorPda = FEEDS[0].pda; // every run includes feed[0]
+
+const account = privateKeyToAccount(readFileSync(KEY_FILE, "utf8").trim());
+const pub = createPublicClient({ transport: http(RPC) });
+const wallet = createWalletClient({ account, transport: http(RPC) });
+const gasPrice = await pub.getGasPrice(); // legacy sends: feeHistory is stubbed on Rome proxies
+const chainId = await pub.getChainId();
+console.log(`chain ${chainId} · sender ${account.address} · gasPrice ${gasPrice} · ${FEEDS.length} pyth feeds`);
+
+// ── deploy (or reuse) ───────────────────────────────────────────────────
+let probe = process.env.PROBE;
+if (!probe) {
+    const hash = await wallet.deployContract({ abi: ART.abi, bytecode: ART.bytecode, args: [], gasPrice, chain: null });
+    console.log(`deploy tx ${hash}`);
+    const rc = await pub.waitForTransactionReceipt({ hash, timeout: 240_000 });
+    if (rc.status !== "success") throw new Error("deploy failed");
+    probe = rc.contractAddress;
+}
+console.log(`probe ${probe}`);
+const probeHex = probe.slice(2).toLowerCase();
+const adapterHexes = pythFeeds.map((f) => f.adapter.slice(2).toLowerCase());
+
+// ── solana attribution ──────────────────────────────────────────────────
+async function newSigsSince(untilSig, t0, t1) {
+    const params = { limit: 100, commitment: "confirmed" };
+    if (untilSig) params.until = untilSig;
+    const sigs = await sol("getSignaturesForAddress", [anchorPda, params]);
+    return sigs.filter((s) => !s.blockTime || (s.blockTime >= t0 - 60 && s.blockTime <= t1 + 60));
+}
+async function classify(sig) {
+    const [j, b] = await Promise.all([
+        sol("getTransaction", [sig, { encoding: "json", maxSupportedTransactionVersion: 0, commitment: "confirmed" }]),
+        sol("getTransaction", [sig, { encoding: "base64", maxSupportedTransactionVersion: 0, commitment: "confirmed" }]),
+    ]);
+    if (!j) return null;
+    const msg = j.transaction.message;
+    const loaded = j.meta.loadedAddresses ?? { writable: [], readonly: [] };
+    const allKeys = [...msg.accountKeys, ...loaded.writable, ...loaded.readonly];
+    if (!allKeys.includes(PROGRAM)) return null; // not a rome-evm execution
+    const rawB64 = b.transaction[0];
+    const rawHex = Buffer.from(rawB64, "base64").toString("hex");
+    const size = Buffer.from(rawB64, "base64").length;
+    const owner = rawHex.includes(probeHex) ? "probe" : adapterHexes.some((a) => rawHex.includes(a)) ? "keeper" : "other";
+    const cuLog = (j.meta.logMessages ?? []).filter((l) => l.includes("consumed") && l.includes(PROGRAM));
+    return {
+        sig,
+        owner,
+        blockTime: j.blockTime,
+        cu: j.meta.computeUnitsConsumed,
+        fee: j.meta.fee,
+        err: j.meta.err,
+        staticKeys: msg.accountKeys.length,
+        loadedKeys: loaded.writable.length + loaded.readonly.length,
+        totalKeys: allKeys.length,
+        altLookups: (msg.addressTableLookups ?? []).length,
+        size,
+        cuLog,
+    };
+}
+
+// ── one measured run ────────────────────────────────────────────────────
+const runs = [];
+async function run(label, accts, force) {
+    const anchor = (await sol("getSignaturesForAddress", [anchorPda, { limit: 1, commitment: "confirmed" }]))[0]?.signature;
+    const t0 = Math.floor(Date.now() / 1000);
+    const gas = await pub.estimateContractGas({ address: probe, abi: ART.abi, functionName: "refreshAll", args: [accts, force], account });
+    const hash = await wallet.writeContract({
+        address: probe,
+        abi: ART.abi,
+        functionName: "refreshAll",
+        args: [accts, force],
+        gas: (gas * 15n) / 10n,
+        gasPrice,
+        chain: null,
+    });
+    const rc = await pub.waitForTransactionReceipt({ hash, timeout: 240_000 });
+    const t1 = Math.floor(Date.now() / 1000);
+    const events = { FeedRefreshed: 0, FeedSkippedNotNewer: 0, FeedRefreshFailed: 0 };
+    for (const log of rc.logs) {
+        try {
+            const ev = decodeEventLog({ abi: ART.abi, data: log.data, topics: log.topics });
+            if (ev.eventName in events) events[ev.eventName]++;
+        } catch {}
+    }
+    await sleep(4000); // let confirmations/index settle before attribution
+    const legs = [];
+    for (const s of await newSigsSince(anchor, t0, t1)) {
+        const c = await classify(s.signature);
+        if (c && c.owner === "probe") legs.push(c);
+    }
+    legs.reverse(); // chronological
+    const totalCU = legs.reduce((a, l) => a + (l.cu ?? 0), 0);
+    const r = {
+        label,
+        width: accts.length,
+        force,
+        ethTx: hash,
+        ethGasUsed: rc.gasUsed.toString(),
+        ethStatus: rc.status,
+        events,
+        solanaLegs: legs.length,
+        totalCU,
+        legs,
+    };
+    runs.push(r);
+    console.log(
+        `${label.padEnd(6)} w=${accts.length} eth=${rc.status} gasUsed=${rc.gasUsed} ` +
+            `C/S/F=${events.FeedRefreshed}/${events.FeedSkippedNotNewer}/${events.FeedRefreshFailed} ` +
+            `legs=${legs.length} CU=${totalCU} keys=${legs[0]?.totalKeys ?? "?"} size=${legs[0]?.size ?? "?"}B`,
+    );
+    return r;
+}
+
+// ── protocol ────────────────────────────────────────────────────────────
+const A = FEEDS.map((f) => f.acct);
+await run("INIT", A, false);
+await run("W1", A.slice(0, 1), true);
+await run("W2", A.slice(0, 2), true);
+await run("W4", A.slice(0, 4), true);
+await run("W8", A, true);
+await run("SKIP8", A, false);
+const bogus = process.env.FAULT_ACCOUNT ?? sbFeed?.underlyingAccount;
+if (bogus) await run("FAULT", [b58ToBytes32(bogus), ...A.slice(0, 7)], true);
+
+// ── cross-check: probe entries vs live raw adapters ─────────────────────
+console.log("\ncross-check vs deployed raw adapters:");
+const checks = [];
+for (const f of FEEDS.slice(0, 3)) {
+    const e = await pub.readContract({ address: probe, abi: ART.abi, functionName: "entries", args: [f.acct] });
+    const a = await pub.readContract({ address: f.adapter, abi: AGG_ABI, functionName: "latestRoundData" });
+    const match = e[2] === BigInt(a[3]) ? (e[0] === a[1] ? "EXACT" : "MISMATCH!") : "source-advanced";
+    checks.push({ feed: f.name, probeAnswer: e[0].toString(), probePt: e[2].toString(), adapterAnswer: a[1].toString(), adapterPt: a[3].toString(), match });
+    console.log(`  ${f.name.padEnd(12)} probe=${e[0]} pt=${e[2]} | adapter=${a[1]} pt=${a[3]} → ${match}`);
+    if (match === "MISMATCH!") process.exitCode = 1;
+}
+
+// ── marginal fit (steady-state widths only) ─────────────────────────────
+const w = Object.fromEntries(runs.filter((r) => /^W\d$/.test(r.label)).map((r) => [r.width, r]));
+let summary = {};
+if (w[1] && w[8] && w[1].solanaLegs === 1 && w[8].solanaLegs === 1) {
+    const marginal = Math.round((w[8].totalCU - w[1].totalCU) / 7);
+    const fixed = w[1].totalCU - marginal;
+    summary = { fixedCU: fixed, marginalCUPerFeed: marginal, atomic8: w[8].totalCU, headroomTo1M4: 1_400_000 - w[8].totalCU };
+    console.log(`\nfixed≈${fixed} CU · marginal≈${marginal} CU/feed · 8-wide=${w[8].totalCU} CU (headroom to 1.4M: ${summary.headroomTo1M4})`);
+} else {
+    console.log("\n8-wide did not land as a single atomic leg — see per-run legs for the real tx count");
+}
+
+writeFileSync(OUT, JSON.stringify({ chainId, probe, sender: account.address, feeds: FEEDS, runs, checks, summary }, (k, v) => (typeof v === "bigint" ? v.toString() : v), 2));
+console.log(`\nresults → ${OUT}`);

--- a/tests/oracle/BookEquivalence.test.ts
+++ b/tests/oracle/BookEquivalence.test.ts
@@ -1,0 +1,131 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * A2 — ABI-equivalence suite (spec R5): the identical call matrix against a
+ * legacy CachedPythAdapter and a BookFeedAdapter must produce identical
+ * selectors, revert data, and decoded outputs.
+ *
+ * Matrix: uninitialized / fresh / stale / getRoundData / decimals / version /
+ * description / metadata shape. Pause is intentionally NOT in the read
+ * matrix — the legacy read path has no pause check (verified: _checkPaused
+ * gates only refresh()); write-side pause behavior is covered in
+ * PriceBook.test.ts.
+ */
+
+const RECEIVER = ("0x" + "de".repeat(32)) as `0x${string}`;
+const ACCT = ("0x" + "aa".repeat(32)) as `0x${string}`;
+const FEED = ("0x" + "11".repeat(32)) as `0x${string}`;
+const FACTORY_NONE = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+const DESC = "SOL / USD";
+const WINDOW = 3600n;
+
+describe("BookFeedAdapter ≡ CachedPythAdapter (A2)", () => {
+    let viem: any;
+    let pc: any;
+
+    const nowTs = async () => Number((await pc.getBlock()).timestamp);
+    const bytes = async (pt?: number) =>
+        buildPythPullAccount({
+            price: 7_385_800_000n,
+            conf: 1_000n,
+            expo: -8,
+            publishTime: pt ?? (await nowTs()) - 30,
+            feedId: FEED,
+        });
+
+    before(async () => {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        pc = await viem.getPublicClient();
+    });
+
+    /** Deploy both sides served by the same account bytes. */
+    async function pair(data: `0x${string}`, opts: { window?: bigint; register?: boolean } = {}) {
+        const window = opts.window ?? WINDOW;
+        const legacy = await viem.deployContract("CachedPythAdapterHarness", []);
+        await legacy.write.initialize([ACCT, DESC, window, FACTORY_NONE]);
+        await legacy.write.setMockData([data]);
+
+        const impl = await viem.deployContract("BookFeedAdapter", []);
+        const book = await viem.deployContract("PriceBookHarness", [RECEIVER, impl.address]);
+        await book.write.setAccountData([ACCT, data]);
+        let bookAdapter: `0x${string}`;
+        if (opts.register === false) {
+            // uninitialized case: adapter over a never-registered account
+            const bare = await viem.deployContract("BookFeedAdapterHarness", []);
+            await bare.write.initialize([book.address, ACCT, DESC, window]);
+            bookAdapter = bare.address;
+        } else {
+            await book.write.registerFeed([ACCT, FEED, 200n, DESC, window]);
+            bookAdapter = await book.read.adapterOf([ACCT]);
+        }
+        const adapter = await viem.getContractAt("BookFeedAdapter", bookAdapter);
+        return { legacy, book, adapter };
+    }
+
+    async function bothReject(a: any, b: any, fn: string, selector: string) {
+        for (const [side, c] of [["legacy", a], ["book", b]] as const) {
+            await assert.rejects(
+                c.read[fn](),
+                (e: any) => e.message.includes(selector),
+                `${side}.${fn} must revert ${selector}`,
+            );
+        }
+    }
+
+    it("uninitialized: both revert UninitializedPriceFeed", async () => {
+        const { legacy, adapter } = await pair(await bytes(), { register: false });
+        // legacy: initialized but never refreshed; book: adapter over unregistered account
+        await bothReject(legacy, adapter, "latestRoundData", "UninitializedPriceFeed");
+    });
+
+    it("fresh: identical decoded outputs", async () => {
+        const data = await bytes();
+        const { legacy, adapter } = await pair(data);
+        await legacy.write.refresh([]);
+        const l = (await legacy.read.latestRoundData()) as readonly bigint[];
+        const b = (await adapter.read.latestRoundData()) as readonly bigint[];
+        assert.deepEqual([...b], [...l], "roundId/answer/startedAt/updatedAt/answeredInRound identical");
+    });
+
+    it("stale: both revert StalePriceFeed under the same window math", async () => {
+        const data = await bytes(); // fresh now, WINDOW=3600
+        const { legacy, adapter } = await pair(data);
+        await legacy.write.refresh([]); // both sides now cache the same round
+
+        const test = await viem.getTestClient();
+        await test.increaseTime({ seconds: 7200 }); // age past the window
+        await test.mine({ blocks: 1 });
+
+        await bothReject(legacy, adapter, "latestRoundData", "StalePriceFeed");
+    });
+
+    it("getRoundData: both revert HistoricalRoundsNotSupported", async () => {
+        const { legacy, adapter } = await pair(await bytes());
+        for (const c of [legacy, adapter]) {
+            await assert.rejects(c.read.getRoundData([1n]), (e: any) => e.message.includes("HistoricalRoundsNotSupported"));
+        }
+    });
+
+    it("decimals / version / description identical", async () => {
+        const { legacy, adapter } = await pair(await bytes());
+        assert.equal(await adapter.read.decimals(), await legacy.read.decimals());
+        assert.equal(await adapter.read.version(), await legacy.read.version());
+        assert.equal(await adapter.read.description(), await legacy.read.description());
+    });
+
+    it("metadata: same shape and field semantics (factory/createdAt excepted by design)", async () => {
+        const { legacy, adapter } = await pair(await bytes());
+        await legacy.write.refresh([]);
+        const l = (await legacy.read.metadata()) as any;
+        const b = (await adapter.read.metadata()) as any;
+        assert.equal(b.description, l.description);
+        assert.equal(b.sourceType, l.sourceType);
+        assert.equal(b.solanaAccount, l.solanaAccount);
+        assert.equal(b.maxStaleness, l.maxStaleness);
+        assert.equal(b.paused, false);
+    });
+});

--- a/tests/oracle/PriceBook.test.ts
+++ b/tests/oracle/PriceBook.test.ts
@@ -1,0 +1,206 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * PriceBook — A1 semantic matrix from the PriceBook spec
+ * (rome-specs active/technical/oracle-pricebook.md):
+ *   registration (owner-gated, validates source, deploys adapter, solo first
+ *   refresh inline), permissionless refreshAll, monotonic skip, future-pt
+ *   fault, value-bound faults, feed-id binding, unregistered fault,
+ *   pause = healthy write-side skip, all-faulted-only revert (per call),
+ *   empty no-op, automatic fault recovery, cheap-skip with the
+ *   age > window/2 bypass.
+ *
+ * Harness overrides the account reads (precompile unavailable on the
+ * simulated network): per-account full bytes, an independent peek value
+ * (so cheap-skip short-circuit is observable), and a settable account owner.
+ */
+
+const RECEIVER = ("0x" + "de".repeat(32)) as `0x${string}`;
+const ACCT_A = ("0x" + "aa".repeat(32)) as `0x${string}`;
+const ACCT_B = ("0x" + "bb".repeat(32)) as `0x${string}`;
+const ACCT_C = ("0x" + "cc".repeat(32)) as `0x${string}`;
+const FEED_A = ("0x" + "11".repeat(32)) as `0x${string}`;
+const FEED_B = ("0x" + "22".repeat(32)) as `0x${string}`;
+const WINDOW = 3600n;
+
+describe("PriceBook", () => {
+    let viem: any;
+    let pc: any;
+    let book: any;
+    let impl: any;
+
+    const nowTs = async () => Number((await pc.getBlock()).timestamp);
+    const fresh = async (opts: any = {}) =>
+        buildPythPullAccount({
+            price: 300_000_000_000n,
+            conf: 0n,
+            expo: -8,
+            publishTime: (await nowTs()) - 30,
+            feedId: FEED_A,
+            ...opts,
+        });
+
+    async function deployBook() {
+        impl = await viem.deployContract("BookFeedAdapter", []);
+        return viem.deployContract("PriceBookHarness", [RECEIVER, impl.address]);
+    }
+    async function register(b: any, acct: `0x${string}`, feedId: `0x${string}`, data: `0x${string}`) {
+        await b.write.setAccountData([acct, data]);
+        await b.write.registerFeed([acct, feedId, 200n, "X / USD", WINDOW]);
+        return b.read.adapterOf([acct]);
+    }
+
+    before(async () => {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        pc = await viem.getPublicClient();
+    });
+
+    // ── registration ────────────────────────────────────────────────────
+    it("registers a feed: validates source, deploys adapter, solo first refresh inline", async () => {
+        book = await deployBook();
+        const adapter = await register(book, ACCT_A, FEED_A, await fresh());
+        assert.notEqual(adapter, "0x0000000000000000000000000000000000000000");
+        const [answer, , , status] = await book.read.entryOf([ACCT_A]);
+        assert.equal(answer, 300_000_000_000n); // active immediately — no uninit window
+        assert.equal(status, 1);
+        assert.equal(await book.read.registrationCount(), 1n);
+        assert.equal((await book.read.registrationAt([0n])).toLowerCase(), ACCT_A.toLowerCase());
+    });
+
+    it("registration rejects: wrong account owner, feed-id mismatch, duplicate, non-owner, bad staleness", async () => {
+        const b = await deployBook();
+        await b.write.setAccountData([ACCT_A, await fresh()]);
+
+        await b.write.setAccountOwner([ACCT_A, ("0x" + "01".repeat(32)) as `0x${string}`]);
+        await assert.rejects(b.write.registerFeed([ACCT_A, FEED_A, 200n, "X", WINDOW]), /InvalidSourceOwner/);
+        await b.write.setAccountOwner([ACCT_A, RECEIVER]);
+
+        // wrong expectedFeedId: the inline solo first refresh fails fast with
+        // the wrapped per-feed reason (0xc2a25c1b == FeedIdMismatch.selector)
+        await assert.rejects(
+            b.write.registerFeed([ACCT_A, FEED_B, 200n, "X", WINDOW]),
+            /RegistrationRefreshFailed[\s\S]*0xc2a25c1b/,
+        );
+
+        await b.write.registerFeed([ACCT_A, FEED_A, 200n, "X", WINDOW]);
+        await assert.rejects(b.write.registerFeed([ACCT_A, FEED_A, 200n, "X", WINDOW]), /AlreadyRegistered/);
+
+        const [, other] = await viem.getWalletClients();
+        await assert.rejects(
+            b.write.registerFeed([ACCT_B, FEED_B, 200n, "X", WINDOW], { account: other.account }),
+            /NotOwner/,
+        );
+        await assert.rejects(b.write.registerFeed([ACCT_B, FEED_B, 200n, "X", 0n]), /StalenessOutOfRange/);
+    });
+
+    // ── refreshAll semantics ────────────────────────────────────────────
+    it("commits newer, skips not-newer, is permissionless", async () => {
+        book = await deployBook();
+        await register(book, ACCT_A, FEED_A, await fresh());
+        const [, pt0] = await book.read.entryOf([ACCT_A]);
+
+        // not newer → skip (send from a non-owner account: permissionless)
+        const [, other] = await viem.getWalletClients();
+        const r1 = await book.simulate.refreshAll([[ACCT_A]], { account: other.account });
+        assert.deepEqual(r1.result, [0n, 1n, 0n]);
+
+        // newer → commit
+        await book.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 10 })]);
+        await book.write.setPeekValue([ACCT_A, pt0 + 10n]);
+        const r2 = await book.simulate.refreshAll([[ACCT_A]], { account: other.account });
+        assert.deepEqual(r2.result, [1n, 0n, 0n]);
+    });
+
+    it("faults: future publishTime, wide confidence, non-positive price, feed-id mismatch, unregistered", async () => {
+        const b = await deployBook();
+        await register(b, ACCT_A, FEED_A, await fresh());
+        await register(b, ACCT_B, FEED_B, await fresh({ feedId: FEED_B }));
+        const now = await nowTs();
+
+        const cases: Array<[string, `0x${string}`]> = [
+            ["future pt", await fresh({ publishTime: now + 900 })],
+            ["wide conf", await fresh({ publishTime: now + 5, price: 100n, conf: 3n })],
+            ["zero price", await fresh({ publishTime: now + 5, price: 0n })],
+            ["wrong feed id", await fresh({ publishTime: now + 5, feedId: FEED_B })],
+        ];
+        for (const [name, bytes] of cases) {
+            await b.write.setAccountData([ACCT_A, bytes]);
+            await b.write.setPeekValue([ACCT_A, BigInt(now + 900)]);
+            const { result } = await b.simulate.refreshAll([[ACCT_A, ACCT_B]]);
+            assert.deepEqual(result, [0n, 1n, 1n], `${name}: expected fault + B skip`); // B not-newer
+        }
+        const { result } = await b.simulate.refreshAll([[ACCT_C, ACCT_B]]);
+        assert.deepEqual(result, [0n, 1n, 1n], "unregistered faults, B skips");
+    });
+
+    it("entry is never rolled back or overwritten by a faulting round", async () => {
+        const b = await deployBook();
+        await register(b, ACCT_A, FEED_A, await fresh());
+        const [answer0, pt0] = await b.read.entryOf([ACCT_A]);
+        await b.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 10, price: 0n })]);
+        await b.write.setPeekValue([ACCT_A, pt0 + 10n]);
+        await assert.rejects(b.write.refreshAll([[ACCT_A]]), /AllFeedsFaulted/); // sole feed faulted
+        const [answer1, pt1] = await b.read.entryOf([ACCT_A]);
+        assert.equal(answer1, answer0);
+        assert.equal(pt1, pt0);
+    });
+
+    it("recovers automatically on the next valid update after a fault", async () => {
+        const b = await deployBook();
+        await register(b, ACCT_A, FEED_A, await fresh());
+        const [, pt0] = await b.read.entryOf([ACCT_A]);
+        await b.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 5, price: 0n })]);
+        await b.write.setPeekValue([ACCT_A, pt0 + 5n]);
+        await assert.rejects(b.write.refreshAll([[ACCT_A]]), /AllFeedsFaulted/);
+        await b.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 6 })]);
+        await b.write.setPeekValue([ACCT_A, pt0 + 6n]);
+        const { result } = await b.simulate.refreshAll([[ACCT_A]]);
+        assert.deepEqual(result, [1n, 0n, 0n]);
+    });
+
+    it("pause is a healthy write-side skip and never counts toward all-faulted", async () => {
+        const b = await deployBook();
+        const adapter = await register(b, ACCT_A, FEED_A, await fresh());
+        await b.write.pauseAdapter([adapter]);
+        assert.equal(await b.read.isPaused([adapter]), true);
+
+        const { result } = await b.simulate.refreshAll([[ACCT_A]]);
+        assert.deepEqual(result, [0n, 1n, 0n], "paused → skip, no revert despite zero commits");
+
+        await b.write.unpauseAdapter([adapter]);
+        assert.equal(await b.read.isPaused([adapter]), false);
+    });
+
+    it("reverts AllFeedsFaulted only when every attempted feed faulted; empty list is a no-op", async () => {
+        const b = await deployBook();
+        await register(b, ACCT_A, FEED_A, await fresh());
+        const { result: empty } = await b.simulate.refreshAll([[]]);
+        assert.deepEqual(empty, [0n, 0n, 0n]);
+        await assert.rejects(b.simulate.refreshAll([[ACCT_B, ACCT_C]]), /AllFeedsFaulted/); // both unregistered
+    });
+
+    // ── cheap-skip + bypass ─────────────────────────────────────────────
+    it("cheap-skip short-circuits on peek within window/2; full path runs beyond it", async () => {
+        const b = await deployBook();
+        await register(b, ACCT_A, FEED_A, await fresh());
+        const [, pt0] = await b.read.entryOf([ACCT_A]);
+
+        // Fresh entry (age < window/2). Full data WOULD commit (newer), but the
+        // peek reports not-newer → cheap-skip short-circuits to SKIP: proof the
+        // full fetch+parse never ran.
+        await b.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 20 })]);
+        await b.write.setPeekValue([ACCT_A, pt0]);
+        const r1 = await b.simulate.refreshAll([[ACCT_A]]);
+        assert.deepEqual(r1.result, [0n, 1n, 0n], "peek short-circuit expected");
+
+        // Age the entry past window/2 → bypass: full path runs and COMMITS the
+        // newer data even though the peek still claims not-newer.
+        await b.write.setEntryAgeForTest([ACCT_A, WINDOW / 2n + 60n]);
+        const r2 = await b.simulate.refreshAll([[ACCT_A]]);
+        assert.deepEqual(r2.result, [1n, 0n, 0n], "bypass must take the full validated path");
+    });
+});

--- a/tests/oracle/PriceBookProbe.test.ts
+++ b/tests/oracle/PriceBookProbe.test.ts
@@ -1,0 +1,170 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * PriceBookProbe — semantics tests for the Phase-0 measurement kernel of the
+ * PriceBook spec (rome-specs#204).
+ *
+ * The probe encodes the spec's write-path invariants so the CU numbers it
+ * produces on a live chain are measured against honest behavior:
+ *   - per-feed try-unit isolation (one bad feed never reverts the batch)
+ *   - monotonic publishTime (older/equal source → per-feed skip, not revert)
+ *   - all-skip is a HEALTHY no-op; only every-feed-faulted reverts
+ *   - confidence / positive-price bounds → per-feed fault
+ *   - feed_id integrity: bound on first write, later mismatch → per-feed fault
+ */
+
+const ACCT_A = ("0x" + "aa".repeat(32)) as `0x${string}`;
+const ACCT_B = ("0x" + "bb".repeat(32)) as `0x${string}`;
+const FEED_ID_A = ("0x" + "11".repeat(32)) as `0x${string}`;
+const FEED_ID_B = ("0x" + "22".repeat(32)) as `0x${string}`;
+
+const fresh = (publishTime: number, feedId: `0x${string}` = FEED_ID_A) =>
+    buildPythPullAccount({
+        price: 123_456_789n, // expo -8 → normalized answer 123_456_789
+        conf: 1_000n, //  well under 2% of price
+        expo: -8,
+        publishTime,
+        feedId,
+    });
+
+describe("PriceBookProbe", () => {
+    let viem: any;
+    let probe: any;
+    let pc: any;
+
+    async function deployProbe() {
+        return viem.deployContract("PriceBookProbeHarness", []);
+    }
+
+    before(async () => {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        pc = await viem.getPublicClient();
+    });
+
+    it("commits fresh feeds and stores normalized entries", async () => {
+        probe = await deployProbe();
+        await probe.write.setAccountData([ACCT_A, fresh(1000)]);
+        await probe.write.setAccountData([ACCT_B, fresh(1000, FEED_ID_B)]);
+
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], false]);
+        assert.deepEqual(result, [2n, 0n, 0n]); // committed, skipped, faulted
+        await probe.write.refreshAll([[ACCT_A, ACCT_B], false]);
+
+        const [answer, feedId, publishTime, , status] = await probe.read.entries([ACCT_A]);
+        assert.equal(answer, 123_456_789n);
+        assert.equal(feedId, FEED_ID_A);
+        assert.equal(publishTime, 1000n);
+        assert.equal(status, 1);
+    });
+
+    it("all-skip (nothing newer) is a healthy no-op, NOT a revert", async () => {
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], false]);
+        assert.deepEqual(result, [0n, 2n, 0n]);
+    });
+
+    it("an older source publishTime can never roll the entry back", async () => {
+        await probe.write.setAccountData([ACCT_A, fresh(500)]);
+        const { result } = await probe.simulate.refreshAll([[ACCT_A], false]);
+        assert.deepEqual(result, [0n, 1n, 0n]);
+        const [, , publishTime] = await probe.read.entries([ACCT_A]);
+        assert.equal(publishTime, 1000n); // unchanged
+        await probe.write.setAccountData([ACCT_A, fresh(1000)]); // restore
+    });
+
+    it("force=true re-commits the full write path for capacity runs", async () => {
+        const { result } = await probe.simulate.refreshAll([[ACCT_A], true]);
+        assert.deepEqual(result, [1n, 0n, 0n]);
+    });
+
+    it("isolates a malformed feed; the rest of the batch commits", async () => {
+        const bad = buildPythPullAccount({
+            discriminator: 0xdeadbeefdeadbeefn,
+            price: 1n,
+            conf: 0n,
+            expo: -8,
+            publishTime: 2000,
+        });
+        await probe.write.setAccountData([ACCT_A, bad]);
+        await probe.write.setAccountData([ACCT_B, fresh(2000, FEED_ID_B)]);
+
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], false]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+
+        const hash = await probe.write.refreshAll([[ACCT_A, ACCT_B], false]);
+        const receipt = await pc.waitForTransactionReceipt({ hash });
+        assert.equal(receipt.status, "success");
+        await probe.write.setAccountData([ACCT_A, fresh(3000)]); // restore
+    });
+
+    it("a faulted feed recovers automatically on the next valid update", async () => {
+        // ACCT_A was malformed in the previous test and is now valid again.
+        const { result } = await probe.simulate.refreshAll([[ACCT_A], false]);
+        assert.deepEqual(result, [1n, 0n, 0n]);
+    });
+
+    it("reverts ONLY when every attempted feed faulted", async () => {
+        const bad = buildPythPullAccount({
+            discriminator: 0xdeadbeefdeadbeefn,
+            price: 1n,
+            conf: 0n,
+            expo: -8,
+            publishTime: 4000,
+        });
+        const probe2 = await deployProbe();
+        await probe2.write.setAccountData([ACCT_A, bad]);
+        await probe2.write.setAccountData([ACCT_B, bad]);
+        await assert.rejects(
+            probe2.simulate.refreshAll([[ACCT_A, ACCT_B], false]),
+            /AllFeedsFaulted/,
+        );
+    });
+
+    it("faults a feed whose confidence exceeds the bound; batch survives", async () => {
+        const wide = buildPythPullAccount({
+            price: 100n,
+            conf: 3n, // 3% > MAX_CONF_BPS (2%)
+            expo: -8,
+            publishTime: 5000,
+            feedId: FEED_ID_A,
+        });
+        await probe.write.setAccountData([ACCT_A, wide]);
+        await probe.write.setAccountData([ACCT_B, fresh(5000, FEED_ID_B)]);
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], false]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+        await probe.write.setAccountData([ACCT_A, fresh(6000)]); // restore
+    });
+
+    it("faults a feed whose account carries a different feed_id than first bound", async () => {
+        // ACCT_A was bound to FEED_ID_A on its first commit; serve it B's id.
+        await probe.write.setAccountData([ACCT_A, fresh(7000, FEED_ID_B)]);
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+        await probe.write.setAccountData([ACCT_A, fresh(7000)]); // restore
+    });
+
+    it("faults a non-positive price; batch survives", async () => {
+        const zero = buildPythPullAccount({
+            price: 0n,
+            conf: 0n,
+            expo: -8,
+            publishTime: 8000,
+            feedId: FEED_ID_A,
+        });
+        await probe.write.setAccountData([ACCT_A, zero]);
+        const { result } = await probe.simulate.refreshAll([[ACCT_A, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+    });
+
+    it("empty feed list is a no-op", async () => {
+        const { result } = await probe.simulate.refreshAll([[], false]);
+        assert.deepEqual(result, [0n, 0n, 0n]);
+    });
+
+    it("refreshOne is self-callable only", async () => {
+        await assert.rejects(probe.simulate.refreshOne([ACCT_A, false]), /SelfOnly/);
+    });
+});

--- a/tests/oracle/PriceBookProbeFast.test.ts
+++ b/tests/oracle/PriceBookProbeFast.test.ts
@@ -1,0 +1,166 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * PriceBookProbeFast — the optimized-parse variant of the Phase-0 kernel.
+ *
+ * Two obligations:
+ *   1. DIFFERENTIAL: for every input vector, the fast path must land exactly
+ *      the same stored state and outcome (commit/skip/fault) as the legacy
+ *      PythPullParser-based probe.
+ *   2. SEMANTICS: the same write-path invariants as PriceBookProbe (fault
+ *      isolation, monotonic skip, all-skip healthy, all-faulted revert,
+ *      feed_id binding), plus fetch-failure handled as a per-feed fault
+ *      (no revert bubbling from the account read).
+ */
+
+const ACCT_A = ("0x" + "aa".repeat(32)) as `0x${string}`;
+const ACCT_B = ("0x" + "bb".repeat(32)) as `0x${string}`;
+const FEED_ID_A = ("0x" + "11".repeat(32)) as `0x${string}`;
+const FEED_ID_B = ("0x" + "22".repeat(32)) as `0x${string}`;
+
+const build = (p: Partial<Parameters<typeof buildPythPullAccount>[0]> & { publishTime: number }) =>
+    buildPythPullAccount({
+        price: 123_456_789n,
+        conf: 1_000n,
+        expo: -8,
+        feedId: FEED_ID_A,
+        ...p,
+    });
+
+describe("PriceBookProbeFast", () => {
+    let viem: any;
+    let fast: any;
+    let legacy: any;
+
+    before(async () => {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        fast = await viem.deployContract("PriceBookProbeFastHarness", []);
+        legacy = await viem.deployContract("PriceBookProbeHarness", []);
+    });
+
+    // ── differential: fast state == legacy state for every vector ──────
+    const vectors: Array<[string, any]> = [
+        ["plain expo -8", { publishTime: 1000 }],
+        ["expo -5 (scale up)", { publishTime: 1001, expo: -5, price: 7_385n, conf: 10n }],
+        ["expo -12 (scale down)", { publishTime: 1002, expo: -12, price: 191_342_712_530_123n }],
+        ["expo 0", { publishTime: 1003, expo: 0, price: 42n, conf: 0n }],
+        ["conf at exact bound", { publishTime: 1004, price: 10_000n, conf: 200n }],
+        ["large price (BTC-ish)", { publishTime: 1005, price: 6_489_936_000_000n }],
+        ["pt at u32 boundary", { publishTime: 4_294_967_295 }],
+    ];
+    for (const [name, params] of vectors) {
+        it(`differential: ${name}`, async () => {
+            const acct = ("0x" + Math.random().toString(16).slice(2).padEnd(8, "0").slice(0, 8) + "00".repeat(28)) as `0x${string}`;
+            const data = build(params);
+            await fast.write.setAccountData([acct, data]);
+            await legacy.write.setAccountData([acct, data]);
+            await fast.write.refreshAll([[acct], false]);
+            await legacy.write.refreshAll([[acct], false]);
+            const f = await fast.read.getEntry([acct]); // [answer, feedId, publishTime, status]
+            const l = await legacy.read.entries([acct]); // [answer, feedId, publishTime, cachedAt, status]
+            assert.equal(f[0], l[0], "answer");
+            assert.equal(f[1], l[1], "feedId");
+            assert.equal(f[2], l[2], "publishTime");
+            assert.equal(f[3], BigInt(l[4]), "status");
+        });
+    }
+
+    it("differential: outcome counts match legacy on a mixed batch", async () => {
+        const ACCT_C = ("0x" + "33".repeat(32)) as `0x${string}`;
+        const bad = build({ publishTime: 9000, discriminator: 0xdeadbeefdeadbeefn });
+        const wide = build({ publishTime: 9000, price: 100n, conf: 3n, feedId: FEED_ID_B });
+        const good = build({ publishTime: 9000, feedId: ("0x" + "44".repeat(32)) as `0x${string}` });
+        for (const p of [fast, legacy]) {
+            await p.write.setAccountData([ACCT_A, bad]);
+            await p.write.setAccountData([ACCT_B, wide]);
+            await p.write.setAccountData([ACCT_C, good]);
+        }
+        const { result: rf } = await fast.simulate.refreshAll([[ACCT_A, ACCT_B, ACCT_C], false]);
+        const { result: rl } = await legacy.simulate.refreshAll([[ACCT_A, ACCT_B, ACCT_C], false]);
+        assert.deepEqual(rf, rl); // committed/skipped/faulted identical
+        assert.deepEqual(rf, [1n, 0n, 2n]);
+    });
+
+    // ── semantics on the fast path ──────────────────────────────────────
+    it("commits, then all-skip is a healthy no-op, then force re-commits", async () => {
+        await fast.write.setAccountData([ACCT_A, build({ publishTime: 2000 })]);
+        await fast.write.setAccountData([ACCT_B, build({ publishTime: 2000, feedId: FEED_ID_B })]);
+        await fast.write.refreshAll([[ACCT_A, ACCT_B], false]);
+
+        const again = await fast.simulate.refreshAll([[ACCT_A, ACCT_B], false]);
+        assert.deepEqual(again.result, [0n, 2n, 0n]);
+
+        const forced = await fast.simulate.refreshAll([[ACCT_A, ACCT_B], true]);
+        assert.deepEqual(forced.result, [2n, 0n, 0n]);
+    });
+
+    it("older publishTime never rolls back", async () => {
+        await fast.write.setAccountData([ACCT_A, build({ publishTime: 100 })]);
+        const { result } = await fast.simulate.refreshAll([[ACCT_A], false]);
+        assert.deepEqual(result, [0n, 1n, 0n]);
+        const [, , publishTime] = await fast.read.getEntry([ACCT_A]);
+        assert.equal(publishTime, 2000n);
+        await fast.write.setAccountData([ACCT_A, build({ publishTime: 2000 })]);
+    });
+
+    it("feed_id mismatch faults after first bind; batch survives", async () => {
+        await fast.write.setAccountData([ACCT_A, build({ publishTime: 3000, feedId: FEED_ID_B })]);
+        const { result } = await fast.simulate.refreshAll([[ACCT_A, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+        await fast.write.setAccountData([ACCT_A, build({ publishTime: 3000 })]);
+    });
+
+    it("fetch failure is a per-feed fault, not a revert", async () => {
+        await fast.write.setFetchFail([ACCT_A, true]);
+        const { result } = await fast.simulate.refreshAll([[ACCT_A, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+        await fast.write.setFetchFail([ACCT_A, false]);
+    });
+
+    it("short account data is a per-feed fault", async () => {
+        const acct = ("0x" + "cc".repeat(32)) as `0x${string}`;
+        await fast.write.setAccountData([acct, "0x22f123639d7ef4cd"]);
+        const { result } = await fast.simulate.refreshAll([[acct, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+    });
+
+    it("partial verification variant is a per-feed fault", async () => {
+        const acct = ("0x" + "dd".repeat(32)) as `0x${string}`;
+        await fast.write.setAccountData([acct, build({ publishTime: 1, verificationVariant: 0x00 })]);
+        const { result } = await fast.simulate.refreshAll([[acct, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+    });
+
+    it("non-positive price is a per-feed fault", async () => {
+        const acct = ("0x" + "ee".repeat(32)) as `0x${string}`;
+        await fast.write.setAccountData([acct, build({ publishTime: 1, price: 0n })]);
+        const { result } = await fast.simulate.refreshAll([[acct, ACCT_B], true]);
+        assert.deepEqual(result, [1n, 0n, 1n]);
+    });
+
+    it("reverts ONLY when every attempted feed faulted", async () => {
+        const p2 = await viem.deployContract("PriceBookProbeFastHarness", []);
+        await p2.write.setFetchFail([ACCT_A, true]);
+        await p2.write.setFetchFail([ACCT_B, true]);
+        await assert.rejects(p2.simulate.refreshAll([[ACCT_A, ACCT_B], false]), /AllFeedsFaulted/);
+    });
+
+    it("empty feed list is a no-op", async () => {
+        const { result } = await fast.simulate.refreshAll([[], false]);
+        assert.deepEqual(result, [0n, 0n, 0n]);
+    });
+
+    // ── decomposition entrypoints exist and count correctly ────────────
+    it("fetchAll / parseAllFast / parseAllLegacy report ok-counts", async () => {
+        const { result: f } = await fast.simulate.fetchAll([[ACCT_A, ACCT_B]]);
+        assert.equal(f, 2n);
+        const { result: pf } = await fast.simulate.parseAllFast([[ACCT_A, ACCT_B]]);
+        assert.equal(pf, 2n);
+        const { result: pl } = await fast.simulate.parseAllLegacy([[ACCT_A, ACCT_B]]);
+        assert.equal(pl, 2n);
+    });
+});

--- a/tests/oracle/helpers/mockPythPull.ts
+++ b/tests/oracle/helpers/mockPythPull.ts
@@ -72,6 +72,15 @@ export function buildPythPullAccount(params: PythPullAccountParams): `0x${string
     // verification_level at offset 40 (default 0x01 = Full)
     buf[40] = params.verificationVariant ?? 0x01;
 
+    // feed_id at offset 41 ([u8;32])
+    if (params.feedId) {
+        const fid = params.feedId.replace(/^0x/, "");
+        if (fid.length !== 64) throw new Error("feedId must be 32 bytes of hex");
+        for (let i = 0; i < 32; i++) {
+            buf[41 + i] = parseInt(fid.slice(i * 2, i * 2 + 2), 16);
+        }
+    }
+
     // price at offset 73 (i64, LE)
     writeInt64LE(buf, 73, params.price);
 


### PR DESCRIPTION
Implements the PriceBook spec (rome-specs `active/technical/oracle-pricebook.md`): one `PriceBook` contract owns every registered feed's cache; per-feed `BookFeedAdapter` clones are stateless Chainlink-ABI view facades; the whole roster refreshes in measured-width `refreshAll` batches instead of one tx per pair.

**Contracts**
- `PriceBook.sol` — owner-gated registration (validates source owner + parsed feed id, deploys the adapter clone, ends with the feed's solo first refresh inline); permissionless `refreshAll` with per-feed branch isolation (commit / healthy-skip / fault; reverts `AllFeedsFaulted` only when every attempted feed faulted); monotonic publishTime with future-timestamp fault; conf/overflow bounds fault with no write; publish_time cheap-skip bypassed once entry age exceeds half the staleness window; assembly PriceUpdateV2 parse (differential-tested byte-equivalent to `PythPullParser`).
- `BookFeedAdapter.sol` — byte-compatible with `CachedPythAdapter` reads: same selectors and conditions for `UninitializedPriceFeed`/`StalePriceFeed` (clock = publishTime), `getRoundData`→`HistoricalRoundsNotSupported`, decimals/version/description/metadata; no pause check on reads (matches legacy — pause gates the write side as a skip).

**Tests** (all local: new suites green; full CI set 315/315)
- `PriceBook.test.ts` — the spec's A1 semantic matrix (registration validation, fault isolation, pause-skip never counts toward all-faulted, cheap-skip short-circuit + bypass, recovery, permissionless caller).
- `BookEquivalence.test.ts` — the spec's A2 ABI-equivalence matrix legacy-vs-book (uninitialized / fresh / stale / historical / decimals / version / description / metadata).
- `PriceBookProbe{,Fast}` + triage driver — the Phase-0 measurement rig the spec's numbers came from (kept as the A3 re-measurement harness).

**Measured on Hadrian (200010)** — book `0x619134d4d5e1e98ea10c9a6782957df24837fdda`, impl `0x080350ca88fdaaa1f0c35368a3758794c8583234`, 10 pyth feeds registered at a 300s window, entries cross-checked against the deployed raw adapters:

| run | outcome | execution | CU |
|---|---|---|---|
| W1 | 1 commit | 1 atomic inline (736B) | 224,216 |
| W2 | 2 commits | 1 atomic inline (934B) | 335,768 |
| W4 | 3 commits + 1 skip | 1 atomic inline (1229B — at the size cap) | 513,110 |
| W8 | 8 commits | **1 atomic execution** (41 keys, address-table compressed) | 1,029,834 |
| W10 | 3 commits + 7 skips | 1 atomic execution | 905,626 |
| W10 skip-round | 1 commit + 9 skips | 1 atomic execution | 787,234 |

Production marginal ≈ 111k CU/feed (fixed ≈ 113k) → all-commit atomic capacity ≈ 11 feeds; per the spec the keeper chunk width derives from this measurement. Width ≥ 5 currently rides the transparent dynamic address-table fallback (+setup txs + finality tax) — the persistent table over the book's account set (spec gate A3) removes that, making a 10-feed tick one Solana transaction flat.

Not in this PR (per spec rollout): keeper book-lane + chunking, persistent-table provisioning, consumer cutover, registry recording of book adapters.