### PR TITLE
feat(oracle): record Hadrian PriceBook deploy; emit book feeds to the registry

### DIFF
--- a/deployments/hadrian.json
+++ b/deployments/hadrian.json
@@ -211,6 +211,84 @@
       ]
     }
   },
+  "PriceBook": {
+    "address": "0x619134d4d5e1e98ea10c9a6782957df24837fdda",
+    "implementation": "0x080350ca88fdaaa1f0c35368a3758794c8583234",
+    "deployedAt": "2026-08-08",
+    "owner": "0x1f4946Be340F06c46A50E65084790968aBcc48F6",
+    "feeds": [
+      {
+        "pair": "SOL/USD",
+        "adapter": "0x2779176109cbEDD2fDdA63937E087518b309F4BE",
+        "pubkey": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+        "pubkeyBytes32": "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "BTC/USD",
+        "adapter": "0xF0aF167691D3Bcc49e17902930831AdD58C8cF97",
+        "pubkey": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+        "pubkeyBytes32": "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "ETH/USD",
+        "adapter": "0xDFC77D0Dd2a193C08200ECf9EF6fe5a4bF74E1a7",
+        "pubkey": "42amVS4KgzR9rA28tkVYqVXjq9Qa8dcZQMbH5EYFX6XC",
+        "pubkeyBytes32": "0x2cfad277afcaa867c7d7fe26e0d51dc899101335879ab63c2aa84876317135bb",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "USDC/USD",
+        "adapter": "0x0B1697E8f360271090D540Eaf3A16520C8651d12",
+        "pubkey": "Dpw1EAVrSB1ibxiDQyTAW6Zip3J4Btk2x4SgApQCeFbX",
+        "pubkeyBytes32": "0xbe939a8309f56407187fff30ac54b169498be99f6d8e1bfd4244680cd4f7d1e2",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "USDT/USD",
+        "adapter": "0x0E853850B3310bc5714FE9672e5e69d4A82C9F16",
+        "pubkey": "HT2PLQBcG5EiCcNSaMHAjSgd9F98ecpATbk4Sk5oYuM",
+        "pubkeyBytes32": "0x0436b7dea1e6d6556d85e7981663cccef16234d63541369a0bceaddb5a60e748",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "JUP/USD",
+        "adapter": "0x979d8F7b518b96d1a99Fa973Ec133F5705F3b5ae",
+        "pubkey": "7dbob1psH1iZBS7qPsm3Kwbf5DzSXK8Jyg31CTgTnxH5",
+        "pubkeyBytes32": "0x628661ff844a6d513411aa02952b8bf902e3b2fe282639f9c96d399e52d86468",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "JTO/USD",
+        "adapter": "0xfBb33E87b5Cf9563BB0a1638EbFEDAc230b8A2C2",
+        "pubkey": "7ajR2zA4MGMMTqRAVjghTKqPPn4kbrj3pYkAVRVwTGzP",
+        "pubkeyBytes32": "0x61ca3f110915af36104573608c75b56a0758cbef2cb34551cf02cad9a63ed00c",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "JITOSOL/USD",
+        "adapter": "0xC9afE27D4074d8f4Fe025360C6CFcB86F555d395",
+        "pubkey": "AxaxyeDT8JnWERSaTKvFXvPKkEdxnamKSqpWbsSjYg1g",
+        "pubkeyBytes32": "0x93f6880418b35aad10f98e24e374d087058430512df03245e0ada7647385b53b",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "MSOL/USD",
+        "adapter": "0x6dDcFF771f8E00D61086243f28e6B629b240c15b",
+        "pubkey": "5CKzb9j4ChgLUt8Gfm5CNGLN6khXKiqMbnGAW4cgXgxK",
+        "pubkeyBytes32": "0x3e559ca93e1bf119b0e7c20adf557067caca210c2e1778cef652a1dd4dc84644",
+        "maxStaleness": 300
+      },
+      {
+        "pair": "BONK/USD",
+        "adapter": "0xA5D6693323C58B7Da65578C46E041D975aaEb030",
+        "pubkey": "DBE3N8uNjhKPRHfANdwGvCZghWXyLPdqdSbEW2XFwBiX",
+        "pubkeyBytes32": "0xb4eacbe402ae9165c2ab7dfcdbe5044d27f284106f88a90bfddefa5fbff60ca0",
+        "maxStaleness": 300
+      }
+    ]
+  },
   "MeteoraDAMMv1Factory": {
     "address": "0x6ce0e90db2b54b9a433530cd5b3d31573a401c3e"
   },

--- a/scripts/oracle/lib/emit-registry-update.test.ts
+++ b/scripts/oracle/lib/emit-registry-update.test.ts
@@ -525,3 +525,74 @@ describe("emitRegistryUpdate — cached feeds", () => {
     expect(names).not.toContain("CachedFeedAdapterImpl");
   });
 });
+
+describe("emitRegistryUpdate — PriceBook feeds", () => {
+  const withBook: DeploymentsFile = {
+    ...HADRIAN_DEPLOYMENTS,
+    PriceBook: {
+      address: "0x1111100000000000000000000000000000000000",
+      implementation: "0x2222200000000000000000000000000000000000",
+      deployedAt: "2026-08-08",
+      owner: "0x3333300000000000000000000000000000000000",
+      feeds: [
+        {
+          pair: "SOL/USD",
+          adapter: "0x4444400000000000000000000000000000000000",
+          pubkey: "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+          pubkeyBytes32: "0x60314704340deddf371fd42472148f248e9d1a6d1a5eb2ac3acd8b7fd5d6b243",
+          maxStaleness: 300,
+        },
+        {
+          pair: "BTC/USD",
+          adapter: "0x5555500000000000000000000000000000000000",
+          pubkey: "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+          pubkeyBytes32: "0x35a70c11162fbf5a0e7f7d2f96e19f97b02246a15687ee672794897448e658de",
+          maxStaleness: 300,
+        },
+      ],
+    },
+  };
+
+  it("emits book feeds keyed <PAIR>-BOOK", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: withBook,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.feeds["SOL/USD-BOOK"]).toEqual({
+      address: "0x4444400000000000000000000000000000000000",
+      source: "book",
+      underlyingAccount: "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
+    });
+    expect(oracle.feeds["BTC/USD-BOOK"]).toEqual({
+      address: "0x5555500000000000000000000000000000000000",
+      source: "book",
+      underlyingAccount: "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
+    });
+  });
+
+  it("emits a top-level priceBook block with address + implementation", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: withBook,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.priceBook).toEqual({
+      address: "0x1111100000000000000000000000000000000000",
+      implementation: "0x2222200000000000000000000000000000000000",
+    });
+  });
+
+  it("does not emit priceBook or any -BOOK feed when PriceBook is absent (back-compat)", () => {
+    const { oracle } = emitRegistryUpdate({
+      deployments: HADRIAN_DEPLOYMENTS,
+      oracle: EMPTY_ORACLE,
+      contracts: EMPTY_CONTRACTS,
+      options: META,
+    });
+    expect(oracle.priceBook).toBeUndefined();
+    expect(Object.keys(oracle.feeds).some((k) => k.endsWith("-BOOK"))).toBe(false);
+  });
+});

--- a/scripts/oracle/lib/emit-registry-update.ts
+++ b/scripts/oracle/lib/emit-registry-update.ts
@@ -19,6 +19,14 @@ export interface DeploymentsFeed {
   pubkeyBytes32: `0x${string}`;
 }
 
+export interface PriceBookFeed {
+  pair: string; // "SOL/USD"
+  adapter: `0x${string}`; // BookFeedAdapter clone for this feed
+  pubkey: string; // Solana base58
+  pubkeyBytes32: `0x${string}`;
+  maxStaleness: number; // per-feed, set at registerFeed(...) time
+}
+
 export interface DeploymentsFile {
   OracleGatewayV2: {
     deployedAt: string;
@@ -38,15 +46,30 @@ export interface DeploymentsFile {
       cachedFeed?: DeploymentsFeed[];
     };
   };
+  // Optional — PriceBook is a standalone contract (one aggregated write,
+  // N per-feed BookFeedAdapter clones) deployed independently of the
+  // OracleGatewayV2 stack. Absent on deployments files that predate it.
+  PriceBook?: {
+    address: `0x${string}`;
+    implementation: `0x${string}`; // BookFeedAdapter implementation
+    deployedAt: string;
+    owner: `0x${string}`;
+    feeds: PriceBookFeed[];
+  };
 }
 
 export interface RegistryOracleFile {
   factory: string;
+  // Present only when the source deployments file has a PriceBook block.
+  priceBook?: {
+    address: string;
+    implementation: string;
+  };
   feeds: Record<
     string,
     {
       address: string;
-      source: "pyth" | "switchboard" | "cached-pyth" | "cached-feed";
+      source: "pyth" | "switchboard" | "cached-pyth" | "cached-feed" | "book";
       underlyingAccount?: string;
     }
   >;
@@ -148,9 +171,25 @@ function buildOracle({ deployments }: EmitInput): RegistryOracleFile {
       underlyingAccount: f.pubkey,
     };
   }
+  // PriceBook — one aggregated write, N per-feed BookFeedAdapter clones.
+  // Keyed "-BOOK" so it never collides with the raw/cached entries above.
+  // Additive: a deployments file without a PriceBook block emits nothing new.
+  for (const f of deployments.PriceBook?.feeds ?? []) {
+    feeds[`${f.pair}-BOOK`] = {
+      address: f.adapter,
+      source: "book",
+      underlyingAccount: f.pubkey,
+    };
+  }
 
   return {
     factory: og.OracleAdapterFactory,
+    ...(deployments.PriceBook && {
+      priceBook: {
+        address: deployments.PriceBook.address,
+        implementation: deployments.PriceBook.implementation,
+      },
+    }),
     feeds,
   };
 }


### PR DESCRIPTION
Records the deployed Hadrian PriceBook (PR #318's contracts, live at `0x619134d4…`, 10 feeds) in the deployments manifest and teaches the registry emitter about it, so the next oracle deploy's auto-emit carries the book instead of clobbering it:

- `deployments/hadrian.json` — top-level `PriceBook` block: book, BookFeedAdapter implementation, owner, per-feed {pair, adapter, pubkey, maxStaleness}.
- `emit-registry-update.ts` — projects `PriceBook.feeds` into `<PAIR>-BOOK` oracle.json entries (source `"book"`) plus a top-level `priceBook` block. Additive: files without a PriceBook block emit exactly what they do today (tested).
- Emitter faithfulness verified: running the CLI against the pre-PriceBook manifest reproduces the registry's current oracle.json byte-for-byte; with this manifest the diff is purely additive (10 entries + priceBook).

Tests 18/18 (TDD, red-first); the repo's CI test set (`hardhat test nodejs …`) 315 passing; compile clean. Registry-side schema + data land separately (registry PR).