### PR TITLE
chore(ci): gate discovery interfaces against their implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npx hardhat compile
+      - name: ABI parity — discovery interfaces vs implementations
+        # Solidity's `is IFoo` only enforces interface ⊆ impl. Nothing in the
+        # language catches a new contract function the interface omits, which is
+        # how IRomeBridgeWithdraw shipped without three live egress rails.
+        run: node scripts/check-abi-parity.js
       - name: Run CPI foundation + oracle + bridge tests
         run: |
           npx hardhat test nodejs \

--- a/scripts/check-abi-parity.js
+++ b/scripts/check-abi-parity.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * ABI parity gate — a discovery interface must not lie about its implementation.
+ *
+ * Two directions, because inheritance only enforces one:
+ *   SUBSET   every interface member exists in the implementation.
+ *            (Solidity's `is IFoo` already gives this.)
+ *   COVERAGE every externally callable state-mutating function in the
+ *            implementation appears in the interface.
+ *            (Nothing in the language enforces this — it is why
+ *            IRomeBridgeWithdraw shipped missing three live egress rails.)
+ *
+ * Reads compiled artifacts only. No RPC, no chain, no transaction.
+ * Run after `hardhat compile`:  node scripts/check-abi-parity.js
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// interface -> implementation. Add a pair when a new discovery interface lands.
+const PAIRS = [{ iface: 'IRomeBridgeWithdraw', impl: 'RomeBridgeWithdraw' }];
+
+// Views excluded from COVERAGE by the admission rule: per-chain config
+// addresses are registry data, not call surface. State-mutating functions are
+// never exemptible — that is the whole point of the gate.
+const ARTIFACTS = path.join(__dirname, '..', 'artifacts', 'contracts');
+
+function findArtifact(dir, name) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const hit = findArtifact(p, name);
+      if (hit) return hit;
+    } else if (entry.name === `${name}.json`) {
+      return p;
+    }
+  }
+  return null;
+}
+
+function abiOf(name) {
+  const file = findArtifact(ARTIFACTS, name);
+  if (!file) {
+    console.error(`FATAL: no compiled artifact for ${name}. Run \`npx hardhat compile\` first.`);
+    process.exit(2);
+  }
+  return JSON.parse(fs.readFileSync(file, 'utf8')).abi;
+}
+
+const sig = (e) => `${e.name}(${e.inputs.map((i) => i.type).join(',')})`;
+const members = (abi, type, filter = () => true) =>
+  new Set(abi.filter((e) => e.type === type && filter(e)).map(sig));
+const mutating = (e) => !['view', 'pure'].includes(e.stateMutability);
+
+let failures = 0;
+
+for (const { iface, impl } of PAIRS) {
+  const ifaceAbi = abiOf(iface);
+  const implAbi = abiOf(impl);
+  console.log(`\n${iface} vs ${impl}`);
+
+  for (const type of ['function', 'event', 'error']) {
+    const orphaned = [...members(ifaceAbi, type)].filter((m) => !members(implAbi, type).has(m));
+    if (orphaned.length) {
+      failures++;
+      console.log(`  SUBSET FAIL [${type}] — declared in ${iface}, absent from ${impl}:`);
+      orphaned.forEach((m) => console.log(`     + ${m}`));
+    }
+  }
+
+  const uncovered = [...members(implAbi, 'function', mutating)].filter(
+    (m) => !members(ifaceAbi, 'function').has(m),
+  );
+  if (uncovered.length) {
+    failures++;
+    console.log(`  COVERAGE FAIL — state-mutating in ${impl}, absent from ${iface}:`);
+    uncovered.forEach((m) => console.log(`     - ${m}`));
+    console.log(`  Add them to ${iface}, or narrow the admission rule in its header and say why.`);
+  }
+
+  if (!failures) console.log('  ok — subset and coverage both hold');
+}
+
+if (failures) {
+  console.log(`\nABI parity FAILED (${failures} check group(s)).`);
+  process.exit(1);
+}
+console.log('\nABI parity passed.');


### PR DESCRIPTION
## What
`scripts/check-abi-parity.js`, run in `build-and-test` after compile.

## Why
Solidity's `is IFoo` enforces only **interface ⊆ implementation**. Nothing in the language catches the other direction — a contract function the interface omits. That is exactly how `IRomeBridgeWithdraw` shipped covering 10 of 52 external functions, missing `burnToWormhole`, `transferNativeToWormhole` and `bridgeOutToSolana`, and offering the first half of two two-tx egress flows without their second half.

Inheritance would not have caught it. A comparison of the compiled ABIs does.

## What it checks
- **SUBSET** — every interface member (function, event, error) exists in the implementation.
- **COVERAGE** — every externally callable **state-mutating** function in the implementation appears in the interface. Per-chain config-address getters are excluded by the interface's own admission rule; state-mutating functions are never exemptible.

Reads compiled artifacts only — no RPC, no chain, no transaction. Runs in about a second.

## Evidence
- Green on `master` today.
- Verified it bites, both directions: removing `bridgeOutToSolana` from the interface fails COVERAGE; declaring a function the implementation lacks fails SUBSET.

## Scope
Adds one script and one CI step. No contract touched.

Extend `PAIRS` when a new discovery interface lands.