### PR TITLE
oracle: PriceBook/BookFeedAdapter — pause fail-closed on the read path

### DIFF
--- a/contracts/oracle/BookFeedAdapter.sol
+++ b/contracts/oracle/BookFeedAdapter.sol
@@ -19,10 +19,10 @@ interface IPriceBookRead {
 ///         its source account and applies the same staleness math as
 ///         CachedPythAdapter (clock = publishTime; same error selectors).
 ///
-///         There is deliberately NO pause check on the read path — matching
-///         CachedPythAdapter, where `_checkPaused` gates only `refresh()`.
-///         Pausing this adapter in the book stops the book from refreshing the
-///         entry, which then ages out and reads revert `StalePriceFeed`.
+///         The read path fails closed on pause: a paused entry's status byte
+///         is 2, and `latestRoundData` reverts `AdapterPaused` immediately —
+///         unlike CachedPythAdapter, where `_checkPaused` gates only
+///         `refresh()` and a paused read just ages out to `StalePriceFeed`.
 ///
 ///         Deployed as EIP-1167 clone by the book at feed registration.
 contract BookFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
@@ -35,6 +35,7 @@ contract BookFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
 
     error StalePriceFeed();
     error UninitializedPriceFeed();
+    error AdapterPaused();
     error HistoricalRoundsNotSupported();
     error AlreadyInitialized();
     error StalenessOutOfRange(uint256 staleness);
@@ -82,9 +83,10 @@ contract BookFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
     }
 
     /// @notice Book entry as a Chainlink round. Pure SLOADs (via the book).
-    ///         Reverts `UninitializedPriceFeed` before the entry's first commit
-    ///         and `StalePriceFeed` past `maxStaleness` — same conditions and
-    ///         selectors as CachedPythAdapter.
+    ///         Reverts `AdapterPaused` while the book has paused this feed,
+    ///         `UninitializedPriceFeed` before the entry's first commit, and
+    ///         `StalePriceFeed` past `maxStaleness` — the latter two match
+    ///         CachedPythAdapter's conditions and selectors.
     function latestRoundData()
         external
         view
@@ -92,6 +94,7 @@ contract BookFeedAdapter is IAggregatorV3Interface, IAdapterMetadata {
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         (int256 a, uint64 publishTime,, uint8 status) = IPriceBookRead(book).entryOf(sourceAccount);
+        if (status == 2) revert AdapterPaused();
         if (status == 0) revert UninitializedPriceFeed();
         if (publishTime > block.timestamp || block.timestamp - publishTime > maxStaleness) {
             revert StalePriceFeed();

--- a/contracts/oracle/PriceBook.sol
+++ b/contracts/oracle/PriceBook.sol
@@ -208,13 +208,16 @@ contract PriceBook {
     }
 
     /// @notice Unpause and re-validate against the live source in one step.
-    ///         Reverts (rolling back `_paused` and the entry together) unless
-    ///         the source is strictly newer than the retained entry AND fresh
-    ///         within `maxStaleness` — pause/unpause never resurrects a stale
-    ///         or non-newer price.
+    ///         A no-op if the adapter isn't currently paused — safe to
+    ///         include in a bulk/blind unpause without checking state first.
+    ///         Otherwise reverts (rolling back `_paused` and the entry
+    ///         together) unless the source is strictly newer than the
+    ///         retained entry AND fresh within `maxStaleness` — pause/unpause
+    ///         never resurrects a stale or non-newer price.
     function unpauseAdapter(address adapter) external onlyOwner {
         bytes32 acct = accountOfAdapter[adapter];
         if (acct == bytes32(0)) revert NotARegisteredAdapter();
+        if (!_paused[adapter]) return;
         _paused[adapter] = false;
         (uint256 outcome, bytes4 reason) = _refreshOne(acct, false);
         if (outcome == OUTCOME_SKIP) revert UnpauseSourceNotNewer();

--- a/contracts/oracle/PriceBook.sol
+++ b/contracts/oracle/PriceBook.sol
@@ -24,7 +24,12 @@ import {CpiProgram} from "../interface.sol";
 ///         publishTime → fault (a committed future timestamp would wedge the
 ///         feed against monotonicity), value bounds → fault with no write
 ///         (prior entry keeps serving until it ages out), pause → healthy
-///         write-side skip (reads are never pause-gated; the entry ages out).
+///         write-side skip AND a fail-closed read: the served entry's status
+///         flips to paused (answer/publishTime/cachedAt retained) so reads
+///         revert immediately instead of aging out; unpause re-refreshes and
+///         only resumes serving when the source is strictly newer than the
+///         retained entry and fresh within maxStaleness — any failure rolls
+///         back atomically, leaving the feed paused.
 ///
 ///         Cheap-skip: a bound feed on the fast path pre-reads publish_time
 ///         (one u64) and skips before the full fetch + parse. The pre-read
@@ -37,6 +42,7 @@ contract PriceBook {
         address adapter; // the feed's BookFeedAdapter clone
         uint16 maxConfBps; // conf/price bound, bps
         uint32 halfWindowSec; // cheap-skip bypass threshold (maxStaleness/2)
+        uint32 maxStaleness; // exact bound (halfWindowSec halves it, losing the odd second) — unpause freshness gate matches BookFeedAdapter's read gate to the second
     }
 
     address public owner;
@@ -51,6 +57,7 @@ contract PriceBook {
     mapping(address => bool) internal _paused;
 
     uint16 public constant DEFAULT_MAX_CONF_BPS = 200; // legacy adapters' constant
+    uint8 private constant STATUS_PAUSED = 2; // entry status byte: 0 = never written, 1 = live, 2 = paused
     uint256 private constant OUTCOME_COMMIT = 0;
     uint256 private constant OUTCOME_SKIP = 1;
     uint256 private constant OUTCOME_FAULT = 2;
@@ -69,6 +76,9 @@ contract PriceBook {
     error StalenessOutOfRange(uint256 staleness);
     error ConfBpsOutOfRange(uint256 bps);
     error NotARegisteredAdapter();
+    error UnpauseSourceNotNewer();
+    error UnpauseStalePrice();
+    error UnpauseRefreshFailed(bytes4 reason);
     error RegistrationRefreshFailed(bytes4 reason);
     error AllFeedsFaulted();
     // per-feed fault reasons (also surfaced via FeedRefreshFailed)
@@ -117,7 +127,8 @@ contract PriceBook {
             expectedFeedId: expectedFeedId,
             adapter: adapter,
             maxConfBps: maxConfBps == 0 ? DEFAULT_MAX_CONF_BPS : uint16(maxConfBps),
-            halfWindowSec: uint32(maxStaleness / 2)
+            halfWindowSec: uint32(maxStaleness / 2),
+            maxStaleness: uint32(maxStaleness)
         });
         _accounts.push(sourceAccount);
         accountOfAdapter[adapter] = sourceAccount;
@@ -189,14 +200,27 @@ contract PriceBook {
     // ── admin ───────────────────────────────────────────────────────────
 
     function pauseAdapter(address adapter) external onlyOwner {
-        if (accountOfAdapter[adapter] == bytes32(0)) revert NotARegisteredAdapter();
+        bytes32 acct = accountOfAdapter[adapter];
+        if (acct == bytes32(0)) revert NotARegisteredAdapter();
         _paused[adapter] = true;
+        _entries[acct] = (_entries[acct] & ((uint256(1) << 192) - 1)) | (uint256(STATUS_PAUSED) << 192);
         emit AdapterPauseSet(adapter, true);
     }
 
+    /// @notice Unpause and re-validate against the live source in one step.
+    ///         Reverts (rolling back `_paused` and the entry together) unless
+    ///         the source is strictly newer than the retained entry AND fresh
+    ///         within `maxStaleness` — pause/unpause never resurrects a stale
+    ///         or non-newer price.
     function unpauseAdapter(address adapter) external onlyOwner {
-        if (accountOfAdapter[adapter] == bytes32(0)) revert NotARegisteredAdapter();
+        bytes32 acct = accountOfAdapter[adapter];
+        if (acct == bytes32(0)) revert NotARegisteredAdapter();
         _paused[adapter] = false;
+        (uint256 outcome, bytes4 reason) = _refreshOne(acct, false);
+        if (outcome == OUTCOME_SKIP) revert UnpauseSourceNotNewer();
+        if (outcome != OUTCOME_COMMIT) revert UnpauseRefreshFailed(reason);
+        uint64 publishTime = uint64(_entries[acct] >> 64);
+        if (block.timestamp - publishTime > _regs[acct].maxStaleness) revert UnpauseStalePrice();
         emit AdapterPauseSet(adapter, false);
     }
 

--- a/tests/oracle/BookEquivalence.test.ts
+++ b/tests/oracle/BookEquivalence.test.ts
@@ -10,9 +10,10 @@ import { buildPythPullAccount } from "./helpers/mockPythPull.js";
  *
  * Matrix: uninitialized / fresh / stale / getRoundData / decimals / version /
  * description / metadata shape. Pause is intentionally NOT in the read
- * matrix — the legacy read path has no pause check (verified: _checkPaused
- * gates only refresh()); write-side pause behavior is covered in
- * PriceBook.test.ts.
+ * matrix — it's a deliberate divergence (S5-F3): legacy's read path has no
+ * pause check (verified: _checkPaused gates only refresh()), while the
+ * book's read path now fails closed on pause. See BookPauseFailClosed.test.ts
+ * for the book's own pause/unpause matrix.
  */
 
 const RECEIVER = ("0x" + "de".repeat(32)) as `0x${string}`;

--- a/tests/oracle/BookPauseFailClosed.test.ts
+++ b/tests/oracle/BookPauseFailClosed.test.ts
@@ -90,10 +90,12 @@ describe("PriceBook / BookFeedAdapter — pause fails closed", () => {
         await assert.rejects(adapter.read.latestRoundData(), /AdapterPaused/, "reads still gated");
     });
 
-    it("unpause reverts UnpauseStalePrice when the newer source price is itself stale", async () => {
+    it("unpause reverts UnpauseStalePrice when the newer source price is itself stale, and rolls back the commit", async () => {
         const b = await deployBook();
-        const { adapterAddr, pt0 } = await registerFresh(b);
+        const { adapterAddr, adapter, pt0 } = await registerFresh(b);
         await b.write.pauseAdapter([adapterAddr]);
+        const entryPaused = await b.read.entryOf([ACCT_A]);
+        assert.equal(entryPaused[3], 2, "paused marker set before the doomed unpause attempt");
 
         // Strictly newer than pt0, but by the time unpause runs the chain
         // clock has moved well past maxStaleness relative to this publishTime.
@@ -103,7 +105,18 @@ describe("PriceBook / BookFeedAdapter — pause fails closed", () => {
         await test.mine({ blocks: 1 });
 
         await assert.rejects(b.write.unpauseAdapter([adapterAddr]), /UnpauseStalePrice/);
+
+        // _refreshOne committed the newer-but-stale price mid-call; the
+        // revert must unwind that commit too — the entry has to land back on
+        // exactly the paused-P0 marker, not the reverted P1 commit.
         assert.equal(await b.read.isPaused([adapterAddr]), true, "stays paused");
+        const entryAfter = await b.read.entryOf([ACCT_A]);
+        assert.deepEqual(
+            [...entryAfter],
+            [...entryPaused],
+            "entry rolled back to the paused marker, not left at the reverted commit",
+        );
+        await assert.rejects(adapter.read.latestRoundData(), /AdapterPaused/, "reads still gated");
     });
 
     it("unpause succeeds when the source is strictly newer AND fresh: emits FeedRefreshed, serves P1", async () => {
@@ -138,5 +151,26 @@ describe("PriceBook / BookFeedAdapter — pause fails closed", () => {
 
         const live = (await adapter.read.latestRoundData()) as readonly bigint[];
         assert.equal(live[1], p1Price, "adapter now serves P1");
+    });
+
+    it("unpause on a never-paused feed is a harmless no-op", async () => {
+        const b = await deployBook();
+        const { adapterAddr, adapter } = await registerFresh(b);
+        assert.equal(await b.read.isPaused([adapterAddr]), false);
+        const entryBefore = await b.read.entryOf([ACCT_A]);
+
+        // Live, never-paused feed: must NOT revert (the bulk/blind-unpause
+        // footgun — without the guard this hits UnpauseSourceNotNewer since
+        // the source hasn't moved).
+        const hash = await b.write.unpauseAdapter([adapterAddr]);
+        const receipt = await pc.waitForTransactionReceipt({ hash });
+        assert.equal(receipt.status, "success");
+
+        assert.equal(await b.read.isPaused([adapterAddr]), false);
+        const entryAfter = await b.read.entryOf([ACCT_A]);
+        assert.deepEqual([...entryAfter], [...entryBefore], "entry untouched by the no-op");
+
+        const live = (await adapter.read.latestRoundData()) as readonly bigint[];
+        assert.equal(live[1], P0, "adapter still serves P0");
     });
 });

--- a/tests/oracle/BookPauseFailClosed.test.ts
+++ b/tests/oracle/BookPauseFailClosed.test.ts
@@ -1,0 +1,142 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { decodeEventLog } from "viem";
+import { buildPythPullAccount } from "./helpers/mockPythPull.js";
+
+/**
+ * S5-F3 — the book's pause must fail closed on the read path.
+ *
+ * Before this fix, BookFeedAdapter.latestRoundData() had no pause check: a
+ * paused feed kept serving its last cached answer until it aged out on its
+ * own. This matrix locks in the fix: pause flips the served entry's status
+ * byte (answer/publishTime/cachedAt retained) so reads revert AdapterPaused
+ * immediately; unpause re-validates against the live source — strictly newer
+ * than the retained entry AND fresh within maxStaleness — before it can
+ * resume serving, and any failure rolls back atomically (pause/unpause never
+ * substitutes for a real source read).
+ */
+
+const RECEIVER = ("0x" + "de".repeat(32)) as `0x${string}`;
+const ACCT_A = ("0x" + "aa".repeat(32)) as `0x${string}`;
+const FEED_A = ("0x" + "11".repeat(32)) as `0x${string}`;
+const WINDOW = 3600n; // maxStaleness, seconds
+const P0 = 300_000_000_000n;
+
+const priceAt = (publishTime: number, price: bigint = P0) =>
+    buildPythPullAccount({ price, conf: 0n, expo: -8, publishTime, feedId: FEED_A });
+
+describe("PriceBook / BookFeedAdapter — pause fails closed", () => {
+    let viem: any;
+    let pc: any;
+    let impl: any;
+
+    const nowTs = async () => Number((await pc.getBlock()).timestamp);
+
+    async function deployBook() {
+        impl = await viem.deployContract("BookFeedAdapter", []);
+        return viem.deployContract("PriceBookHarness", [RECEIVER, impl.address]);
+    }
+
+    /** Register ACCT_A with a fresh P0 and return the book + its adapter. */
+    async function registerFresh(b: any) {
+        const pt0 = (await nowTs()) - 30;
+        await b.write.setAccountData([ACCT_A, priceAt(pt0)]);
+        await b.write.registerFeed([ACCT_A, FEED_A, 200n, "X / USD", WINDOW]);
+        const adapterAddr = (await b.read.adapterOf([ACCT_A])) as `0x${string}`;
+        const adapter = await viem.getContractAt("BookFeedAdapter", adapterAddr);
+        return { adapterAddr, adapter, pt0 };
+    }
+
+    before(async () => {
+        const conn = await hardhat.network.connect();
+        viem = conn.viem;
+        pc = await viem.getPublicClient();
+    });
+
+    it("pause reverts AdapterPaused on read and overwrites ONLY the status byte", async () => {
+        const b = await deployBook();
+        const { adapterAddr, adapter } = await registerFresh(b);
+
+        const live = (await adapter.read.latestRoundData()) as readonly bigint[];
+        assert.equal(live[1], P0, "adapter serves P0 before pause");
+
+        const entry0 = await b.read.entryOf([ACCT_A]);
+        assert.equal(entry0[3], 1, "status is live before pause");
+
+        await b.write.pauseAdapter([adapterAddr]);
+        await assert.rejects(adapter.read.latestRoundData(), /AdapterPaused/);
+
+        const entry1 = await b.read.entryOf([ACCT_A]);
+        assert.equal(entry1[0], entry0[0], "answer retained");
+        assert.equal(entry1[1], entry0[1], "publishTime retained");
+        assert.equal(entry1[2], entry0[2], "cachedAt retained");
+        assert.equal(entry1[3], 2, "status flips to paused, and ONLY the status byte changed");
+    });
+
+    it("unpause reverts UnpauseSourceNotNewer when the source hasn't advanced; stays paused", async () => {
+        const b = await deployBook();
+        const { adapterAddr, adapter } = await registerFresh(b);
+        await b.write.pauseAdapter([adapterAddr]);
+        assert.equal(await b.read.isPaused([adapterAddr]), true);
+        const entryBefore = await b.read.entryOf([ACCT_A]);
+
+        // Source account data is untouched — same publishTime as P0.
+        await assert.rejects(b.write.unpauseAdapter([adapterAddr]), /UnpauseSourceNotNewer/);
+
+        assert.equal(await b.read.isPaused([adapterAddr]), true, "_paused rolled back to true");
+        const entryAfter = await b.read.entryOf([ACCT_A]);
+        assert.deepEqual([...entryAfter], [...entryBefore], "entry unchanged");
+        await assert.rejects(adapter.read.latestRoundData(), /AdapterPaused/, "reads still gated");
+    });
+
+    it("unpause reverts UnpauseStalePrice when the newer source price is itself stale", async () => {
+        const b = await deployBook();
+        const { adapterAddr, pt0 } = await registerFresh(b);
+        await b.write.pauseAdapter([adapterAddr]);
+
+        // Strictly newer than pt0, but by the time unpause runs the chain
+        // clock has moved well past maxStaleness relative to this publishTime.
+        await b.write.setAccountData([ACCT_A, priceAt(pt0 + 10)]);
+        const test = await viem.getTestClient();
+        await test.increaseTime({ seconds: Number(WINDOW) + 100 });
+        await test.mine({ blocks: 1 });
+
+        await assert.rejects(b.write.unpauseAdapter([adapterAddr]), /UnpauseStalePrice/);
+        assert.equal(await b.read.isPaused([adapterAddr]), true, "stays paused");
+    });
+
+    it("unpause succeeds when the source is strictly newer AND fresh: emits FeedRefreshed, serves P1", async () => {
+        const b = await deployBook();
+        const { adapterAddr, adapter, pt0 } = await registerFresh(b);
+        await b.write.pauseAdapter([adapterAddr]);
+
+        const p1Pt = pt0 + 10;
+        const p1Price = 305_000_000_000n;
+        await b.write.setAccountData([ACCT_A, priceAt(p1Pt, p1Price)]);
+
+        const hash = await b.write.unpauseAdapter([adapterAddr]);
+        const receipt = await pc.waitForTransactionReceipt({ hash });
+        assert.equal(receipt.status, "success");
+
+        const refreshed = receipt.logs
+            .map((log: any) => {
+                try {
+                    return decodeEventLog({ abi: b.abi, data: log.data, topics: log.topics });
+                } catch {
+                    return null;
+                }
+            })
+            .find((e: any) => e?.eventName === "FeedRefreshed");
+        assert.ok(refreshed, "FeedRefreshed emitted");
+        assert.equal((refreshed as any).args.answer, p1Price);
+        assert.equal((refreshed as any).args.publishTime, BigInt(p1Pt));
+
+        assert.equal(await b.read.isPaused([adapterAddr]), false);
+        const entry = await b.read.entryOf([ACCT_A]);
+        assert.equal(entry[3], 1, "status back to live");
+
+        const live = (await adapter.read.latestRoundData()) as readonly bigint[];
+        assert.equal(live[1], p1Price, "adapter now serves P1");
+    });
+});

--- a/tests/oracle/BookPauseFailClosed.test.ts
+++ b/tests/oracle/BookPauseFailClosed.test.ts
@@ -173,4 +173,33 @@ describe("PriceBook / BookFeedAdapter — pause fails closed", () => {
         const live = (await adapter.read.latestRoundData()) as readonly bigint[];
         assert.equal(live[1], P0, "adapter still serves P0");
     });
+
+    it("unpause reverts UnpauseRefreshFailed on a genuine per-feed fault, and rolls back", async () => {
+        const b = await deployBook();
+        const { adapterAddr, adapter, pt0 } = await registerFresh(b);
+        await b.write.pauseAdapter([adapterAddr]);
+        const entryPaused = await b.read.entryOf([ACCT_A]);
+        assert.equal(entryPaused[3], 2, "paused marker set before the doomed unpause attempt");
+
+        // Strictly newer than pt0 — so the cheap-skip peek sees a newer
+        // publishTime and does NOT short-circuit to SKIP, and the full
+        // monotonic guard doesn't SKIP either — but a non-positive price
+        // faults the full validated read. OUTCOME_FAULT, not SKIP, not a
+        // staleness gate: this is the UnpauseRefreshFailed leg.
+        await b.write.setAccountData([ACCT_A, priceAt(pt0 + 10, 0n)]);
+
+        await assert.rejects(b.write.unpauseAdapter([adapterAddr]), /UnpauseRefreshFailed/);
+
+        // Full rollback: the fault happens before _refreshOne ever writes
+        // _entries, and _paused must land back on true — entry must be
+        // exactly the paused-P0 marker, with no mid-call state leaked.
+        assert.equal(await b.read.isPaused([adapterAddr]), true, "stays paused");
+        const entryAfter = await b.read.entryOf([ACCT_A]);
+        assert.deepEqual(
+            [...entryAfter],
+            [...entryPaused],
+            "entry rolled back to the paused marker — no mid-call state leaked",
+        );
+        await assert.rejects(adapter.read.latestRoundData(), /AdapterPaused/, "reads still gated");
+    });
 });

--- a/tests/oracle/PriceBook.test.ts
+++ b/tests/oracle/PriceBook.test.ts
@@ -11,7 +11,9 @@ import { buildPythPullAccount } from "./helpers/mockPythPull.js";
  *   fault, value-bound faults, feed-id binding, unregistered fault,
  *   pause = healthy write-side skip, all-faulted-only revert (per call),
  *   empty no-op, automatic fault recovery, cheap-skip with the
- *   age > window/2 bypass.
+ *   age > window/2 bypass. Unpause re-validates against the live source
+ *   before resuming service (fail-closed read + strictly-newer-and-fresh
+ *   unpause gate: see BookPauseFailClosed.test.ts for the full matrix).
  *
  * Harness overrides the account reads (precompile unavailable on the
  * simulated network): per-account full bytes, an independent peek value
@@ -171,6 +173,11 @@ describe("PriceBook", () => {
         const { result } = await b.simulate.refreshAll([[ACCT_A]]);
         assert.deepEqual(result, [0n, 1n, 0n], "paused → skip, no revert despite zero commits");
 
+        // Fail-closed unpause (S5-F3): the book re-validates against the live
+        // source before resuming service, so unpauseAdapter only succeeds once
+        // the source is strictly newer than the retained entry.
+        const [, pt0] = await b.read.entryOf([ACCT_A]);
+        await b.write.setAccountData([ACCT_A, await fresh({ publishTime: Number(pt0) + 10 })]);
         await b.write.unpauseAdapter([adapter]);
         assert.equal(await b.read.isPaused([adapter]), false);
     });


### PR DESCRIPTION
> **Status: implemented + independently reviewed (verdict: holds); review items N1/N2 folded in; draft pending sign-off to flip-to-ready.** The `rome-specs` R5/status-enum update is a coordinated companion (separate repo). On-chain rollout (new book deploy + re-register + comet re-cutover on Hadrian → Rubicon greenfield) follows after merge.

## Implementation & verification

- Written **test-first**: 4 acceptance tests (below) + the one pre-existing test that encoded the old "unpause always succeeds" behaviour updated to the new contract. `_refreshOne` logic **unchanged** — the retained publish time + its existing cheap-skip/monotonic guards already enforce strictly-newer.
- **Independent adversarial cold-review — verdict: holds.** All four guarantees (fail-closed read, strictly-newer unpause, fresh unpause, atomic rollback) verified against the diff; **5 mutations run, all killed**, including one that removes *both* the not-newer and fault gates (the genuinely dangerous mutant — unpause would resurrect the retained price) — caught by test 2.
- **Full oracle suite: 134 passing** (128 baseline + 6 new: 4 pause/unpause + 1 idempotent-unpause + 1 fault-path rollback); `hardhat compile` and the ABI-parity gate clean.
- **Read-path CU unchanged — measured.** `latestRoundData` on a live feed is **+22 gas** vs pre-fix (36,712 vs 36,690) — the single `status == 2` comparison on already-returned data, no new SLOAD or external call (an SLOAD alone is 100–2,100; a staticcall thousands). Keeper write path and per-tick tx count untouched; N1's guard is one SLOAD in the admin-only unpause; `maxStaleness` packs into the existing `Registration` slot.
- Diff is confined to `contracts/oracle/{PriceBook,BookFeedAdapter}.sol` + `tests/oracle/` (`BookPauseFailClosed.test.ts` new; one assertion added to `PriceBook.test.ts`; one comment reworded in `BookEquivalence.test.ts`).

## Review items (resolved)

- **N1 — applied.** `unpauseAdapter` now no-ops if the adapter isn't paused (`if (!_paused[adapter]) return;`), so a bulk/blind unpause won't trip `UnpauseSourceNotNewer` on live feeds. One SLOAD in the admin path, never on reads. Covered by a new test (unpause a never-paused feed → no-op, still serves).
- **N2 — added.** Test 3 (`UnpauseStalePrice`) now also asserts the entry rolled back to the paused marker (the commit-then-revert path) and reads still revert `AdapterPaused`.
- **N3 — known.** `PriceBook` is not upgradeable, so shipping means a new book deploy + re-registering feeds + re-pointing consumers (adapter clone addresses change). Same for any option.

---

## Problem

`BookFeedAdapter.latestRoundData` serves the `PriceBook`'s cached entry but never checks whether the adapter is paused. `PriceBook.pauseAdapter` sets a `_paused` flag and `_refreshOne` skips paused feeds — but the flag never affects reads, and the cached entry is left frozen. So pausing an adapter does **not** stop it serving: it keeps returning the last cached price until that price ages past `maxStaleness` (up to 24h). Pause is meant to be the emergency lever that stops a bad price from being served; today it isn't.

## Goal

- Pausing an adapter must **fail its reads closed immediately**.
- Unpausing must resume service **only with data that is strictly newer than the value live at pause AND fresh (within `maxStaleness`)** — otherwise the adapter stays paused. The pre-pause value can never be re-served, and unpause never "succeeds" into a non-serving (stale-reverting) state.

## Design — materialize pause into the entry's `status`, with a strictly-newer + fresh unpause

The entry's `status` byte already encodes servability (`0 = never written`, `1 = live`). Add **`2 = paused`** as a first-class value:

1. **`pauseAdapter(adapter)`** — set `_paused[adapter]` and overwrite **only the status byte** of the served entry to `2`, **retaining** answer/publishTime/cachedAt. The prior publish time is the monotonic anchor for recovery; the retained answer is never served (reads revert while paused), kept only for on-chain forensics via `entryOf`.
2. **`BookFeedAdapter.latestRoundData`** — revert `AdapterPaused` when `status == 2`, before the `status==0`/staleness checks, so the revert reason is *paused*, not *stale*.
3. **`_refreshOne`** — **unchanged.** With the publish time retained, the existing cheap-skip and monotonic guard already enforce strictly-newer on the unpause refresh.
4. **`unpauseAdapter(adapter)`** — clear `_paused`, then `_refreshOne(acct, false)`, then enforce **both** or revert (which atomically rolls back `_paused` *and* the entry, leaving the adapter paused):
   - `OUTCOME_SKIP` (source not strictly newer) → revert `UnpauseSourceNotNewer`.
   - `OUTCOME_FAULT` (invalid/unreadable source) → revert `UnpauseRefreshFailed(reason)`.
   - committed but `now − publishTime > maxStaleness` (strictly-newer yet stale) → revert `UnpauseStalePrice`.
   Only a strictly-newer **and** fresh validated commit clears the pause; it emits `FeedRefreshed` on the unpause receipt.

Status machine: `0 →(register, forced) 1 →(pause; publishTime retained) 2 →(unpause; only on strictly-newer + fresh validated source) 1`; any failed unpause reverts and stays `2`.

**Guarantee:** `unpauseAdapter` succeeds ⟺ the feed is now serving a strictly-newer, validated, fresh price. Otherwise it stays paused. The sequence "pause bad price → source hasn't produced a newer/fresh update → unpause → bad or stale price served" is impossible — every non-serving case reverts.

**Impl note:** the unpause staleness gate uses the *exact* `maxStaleness` (stored on `Registration`, not the floor-halved `halfWindowSec`) so it matches `BookFeedAdapter`'s read gate to the second.

## Why this shape (vs the alternatives considered)

- **Per-read pause check** (add an `isPaused()` call to `latestRoundData`): rejected. (a) It leaves the entry frozen during pause, so unpause re-serves the pre-pause value until the next refresh — it can't express the strictly-newer/fresh recovery rule. (b) It adds a second cross-contract call + storage read to **every consumer read, forever**, for a pause that is rare; the read path is the hot path (every borrow/liquidate/quote).
- **Zero the entry on pause** (`_entries[acct] = 0`): identical read cost, but it discards the publish time, so unpause has no anchor to require *strictly newer* against — it re-serves whatever the source holds, including the pre-pause value. Retaining the entry + `2 = paused` yields the honest `AdapterPaused` selector (the reason the raw adapters already surface, consistent with `priceStatus()`'s "2 = paused"), keeps the paused state observable on-chain, and — because the adapters are unpatchable minimal-proxy clones — makes even an un-updated clone fail closed. Safety is enforced at the single write point, not in N immutable read facades.

Hot read-path CU is unchanged from today (one call; a paused feed is a local branch on data already read); the keeper's write path and per-tick transaction count are unchanged (pause/unpause are rare owner-only actions). The only real cost vs the zero-entry variant is operational: unpause is *conditional* on a healthy source (fresh + strictly-newer) rather than unconditional — which is the safety guarantee.

## Recovery liveness (accepted trade-off)

Unpause is blocked until the source publishes a price strictly newer than the one live at pause *and* fresh. Intended: if a source is stuck at the bad value, the feed should stay paused. Near-instant on a sponsored-push mainnet source, ≤ a refresh tick or two on a best-effort source; the block is explicit and diagnosable (`UnpauseSourceNotNewer` / `UnpauseStalePrice`), never a silent re-serve.

## Collateral (coordinated)

- `BookFeedAdapter` + `PriceBook` header comments — updated in this PR (they previously asserted "deliberately no pause check" / "reads are never pause-gated").
- The spec's status enum + read-freshness / pause-parity requirement + its parity test case — a `rome-specs` companion (the book's pause semantics now intentionally diverge from the legacy cached adapter; the legacy behaviour was the defect).

## Deploy boundary

`PriceBook` and its adapter clones are not upgradeable (the adapter implementation is a constructor immutable), so this fix exists only on a newly deployed book + implementation pair. A live book keeps the old pause semantics until its consumers re-point at a redeployed book's adapters.

## Acceptance tests (implemented — all passing)

1. register → refresh (P0) → `latestRoundData` returns P0 → `pauseAdapter` → reverts `AdapterPaused`; **and** the pause write preserved answer/publishTime/cachedAt and flipped only the status byte to 2.
2. unpause, source still at P0 (not strictly newer) → reverts `UnpauseSourceNotNewer`; `_paused` and the packed entry unchanged (rolled back); reads still `AdapterPaused`.
3. unpause, source strictly newer than P0 but **stale** → reverts `UnpauseStalePrice`; stays paused. *(N2: add the rollback/reads-gated assertions.)*
4. unpause, source strictly newer **and** fresh (P1) → succeeds, emits `FeedRefreshed(P1)`, `latestRoundData` serves P1.
5. unpause on a never-paused (live) feed → no-op: no revert, stays live, still serves P0 (N1).
6. unpause when the source faults validation (strictly-newer but non-positive price) → reverts `UnpauseRefreshFailed`, entry rolled back to the paused marker.

Mutations confirmed killed: removing the pause status write (1); dropping the strictly-newer enforcement (2); dropping the unpause staleness gate (3).
