### PR TITLE
fix(erc20spl): close mint-authority front-running in ERC20SPLFactory

### DIFF
--- a/contracts/erc20spl/erc20spl_factory.sol
+++ b/contracts/erc20spl/erc20spl_factory.sol
@@ -203,71 +203,43 @@ contract ERC20SPLFactory {
     }
 
     /**
-     * Creates new SPL token mint.
-     * Token mint is derived from the creator's address and their current nonce, so each creator can create multiple tokens 
-     * by calling this function multiple times. This function only creates the mint account and does not initialize it, 
-     * so the returned mint address will not be a valid SPL token until the mint account is initialized 
-     * (e.g. by calling init_token_account with the same name and symbol that will be used for the ERC20 wrapper).
+     * Creates and initializes a new SPL token mint atomically.
+     * Token mint is derived from the creator's address and their current nonce, so each creator can create multiple tokens
+     * by calling this function multiple times.
      *
-     * @return (bytes32 mint) Address of the created SPL Token mint.
+     * @return (bytes32 mint) Address of the created and initialized SPL Token mint.
      */
     function create_token_mint() external returns (bytes32) {
         (bytes32 mint, bytes32 mintSeed) = get_current_mint(msg.sender);
         _assert_mint_account_missing(mint);
+        bytes32 user = HelperProgram.pda(msg.sender); // mint authority = caller's EXTERNAL_AUTHORITY PDA
 
-        // System CreateAccount via HelperProgram.create_mint_account (selector
-        // 0xe97d3291, shipped in a Rome EVM program upgrade). Allocates the
-        // salt-derived mint PDA with space=82 (SPL_MINT_LEN), owner=SPL Token,
-        // lamports=rent-floor for 82 bytes — all hardcoded inside the precompile.
-        // Funder = caller's external_auth PDA; new account = external_auth_with_salt
-        // (caller, mintSeed). Two PDA signers handled internally. Replaces the
-        // prior SystemProgramLib.create_account + invoke_signed marshaling path
-        // — saves ~30-50K EVM CU per call.
-        //
-        // The new mint address is deterministic from (caller, mintSeed); we
-        // return the client-computed `mint` value (same bytes32 that
-        // get_current_mint derived above).
+        // System CreateAccount + SPL InitializeMint2 via HelperProgram.create_and_init_mint
+        // (selector 0x20972d0f) in a single dispatch — the mint is never left
+        // created-but-uninitialized for a third party to initialize and seize authority
+        // over. Same salt-derived mint address as the prior two-call path.
         (bool success, bytes memory result) = address(HelperProgram).delegatecall(
             abi.encodeWithSignature(
-                "create_mint_account(bytes32)",
-                mintSeed
+                "create_and_init_mint(uint8,bytes32,bool,bytes32,bytes32)",
+                DEFAULT_DECIMALS, user, false, bytes32(0), mintSeed
             )
         );
         require(success, string(Convert.revert_msg(result)));
 
-        uint64 nonce = creator_nonce[msg.sender];
-        creator_nonce[msg.sender] = nonce + 1;
+        creator_nonce[msg.sender] = creator_nonce[msg.sender] + 1;
         return mint;
     }
 
     /**
-     * Initializes previously created mint account.
+     * Backward-compatible no-op: create_token_mint now creates and initializes atomically,
+     * so a legitimate mint reaching here is already initialized. Reverts otherwise — this
+     * never initializes an arbitrary caller-supplied mint.
      */
-    function init_token_mint(bytes32 mint) external {
-        // Mint authority = caller's external_auth PDA. Stored in the mint
-        // account as data — NOT a runtime signer for InitializeMint2.
-        bytes32 user = HelperProgram.pda(msg.sender);
-
-        // SPL Token InitializeMint2 via HelperProgram.init_spl_mint
-        // (selector 0x4f75e987, shipped in a Rome EVM program upgrade).
-        // No PDA signer needed (mint_authority + freeze_authority are stored
-        // as account data, not runtime signers). Replaces the prior
-        // SplTokenLib.initialize_mint + invoke marshaling path — saves
-        // ~30-50K EVM CU per call.
-        //
-        // has_freeze_authority = false → freeze_authority arg is ignored
-        // (pass bytes32(0) for explicitness; the COption tag inside the
-        // precompile is what controls the SPL ix encoding).
-        (bool success, bytes memory result) = address(HelperProgram).delegatecall(
-            abi.encodeWithSignature(
-                "init_spl_mint(bytes32,uint8,bytes32,bool,bytes32)",
-                mint,
-                DEFAULT_DECIMALS,
-                user,
-                false,
-                bytes32(0)
-            )
-        );
-        require(success, string(Convert.revert_msg(result)));
+    function init_token_mint(bytes32 mint) external view {
+        // SPL Mint.is_initialized is a single bool byte at offset 45. Reading just that
+        // byte (rather than the full 82-byte account) means an account too small to hold
+        // it reverts on the read itself, so a never-created mint is rejected for free.
+        bytes memory isInitialized = AccountReader.readBytesAt(mint, 45, 1);
+        require(isInitialized[0] == 0x01, "mint not initialized; create_token_mint now initializes atomically");
     }
 }

--- a/tests/erc20spl_factory_hijack.poc.ts
+++ b/tests/erc20spl_factory_hijack.poc.ts
@@ -1,0 +1,192 @@
+// S6-F1 FIXED — hijack closed
+// =============================================================================
+// Prior claim (audit finding S6-F1): ERC20SPLFactory split mint provisioning into
+// two PERMISSIONLESS calls — create_token_mint() (created an uninitialized mint
+// PDA derived from the CALLER's address+nonce) and init_token_mint(bytes32 mint)
+// (initialized an ARBITRARY mint, stamping mint_authority = HelperProgram.pda
+// (msg.sender), with no check that msg.sender created `mint`). An attacker could
+// init the VICTIM's created-but-uninitialized mint, become its authority, and
+// mint the victim's token while the victim was permanently locked out.
+//
+// Fix: create_token_mint() now creates AND initializes the mint atomically (one
+// HelperProgram.create_and_init_mint dispatch) — there is never a created-but-
+// uninitialized window. init_token_mint(bytes32) is now a view-only backward-
+// compat shim: it reverts unless `mint` is already initialized, and never
+// performs any initialization itself, so it can no longer be used to seize
+// authority over anyone's mint — pre-emptively (on a not-yet-created mint,
+// front-running the deterministic address) or otherwise.
+//
+//   VICTIM   = walletClients[0]  (the funded HADRIAN_PRIVATE_KEY account)
+//   ATTACKER = a fresh keypair, funded by the victim in-test
+//
+// RUN:  npx hardhat test tests/erc20spl_factory_hijack.poc.ts --network hadrian
+//
+// This test only passes once the fixed factory is deployed — it is the
+// acceptance test for the fix, not a standalone unit test. Every state-changing
+// tx carries an explicit gas price above the proxy minimum so reverts revert for
+// the RIGHT reason (mint not yet initialized), never for gas.
+// =============================================================================
+
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import hardhat from "hardhat";
+import { createWalletClient, custom, getAddress, isAddress, parseUnits, slice } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { readDeployments } from "../scripts/lib/deployments.js";
+
+const HELPER_PROGRAM = "0xff00000000000000000000000000000000000009" as const; // pda(address)
+const CPI_PROGRAM = "0xff00000000000000000000000000000000000008" as const;    // account_info(bytes32)
+
+const HELPER_ABI = [
+    { type: "function", name: "pda", stateMutability: "view", inputs: [{ name: "user", type: "address" }], outputs: [{ name: "", type: "bytes32" }] },
+] as const;
+const CPI_ABI = [
+    { type: "function", name: "account_info", stateMutability: "view", inputs: [{ name: "key", type: "bytes32" }],
+      outputs: [
+        { name: "lamports", type: "uint64" }, { name: "owner", type: "bytes32" },
+        { name: "executable", type: "bool" }, { name: "rentEpoch", type: "uint64" },
+        { name: "space", type: "uint64" }, { name: "data", type: "bytes" },
+      ] },
+] as const;
+
+function resolveFactoryAddress(networkName: string): `0x${string}` {
+    const address = readDeployments(networkName).ERC20SPLFactory?.address;
+    if (!address || !isAddress(address)) throw new Error(`ERC20SPLFactory not deployed for ${networkName}`);
+    return getAddress(address);
+}
+
+async function assertSuccess(publicClient: any, hash: `0x${string}`, label: string) {
+    const r = await publicClient.waitForTransactionReceipt({ hash });
+    assert.equal(r.status, "success", `${label} should succeed`);
+    console.log(`   [ok] ${label} — tx ${hash}`);
+    return r;
+}
+
+// init_token_mint is now `view` (no state mutation on either branch), so exercising it
+// is a plain eth_call via `.read` — a revert surfaces as a thrown error, not a receipt.
+async function assertReadReverts(promise: Promise<unknown>, label: string) {
+    let reverted = false;
+    try { await promise; } catch { reverted = true; }
+    console.log(`   [ok] ${label} reverted = ${reverted}`);
+    assert.ok(reverted, `${label} MUST revert`);
+}
+
+describe("S6-F1 FIXED — hijack closed", () => {
+    let publicClient: any, factory: any, viemApi: any, networkName: string;
+    let victim: any, attacker: any;
+    let gasPrice: bigint;
+    let mintId: `0x${string}`;
+    let victimPda: `0x${string}`;
+    let attackerPda: `0x${string}`;
+
+    before(async () => {
+        const conn = await hardhat.network.connect() as any;
+        viemApi = conn.viem;
+        networkName = conn.networkName;
+        publicClient = await viemApi.getPublicClient();
+
+        victim = (await viemApi.getWalletClients())[0];
+        assert.ok(victim?.account, "no funded wallet (set HADRIAN_PRIVATE_KEY)");
+
+        // Rome's proxy enforces a pool-derived minimum gas price; viem's auto-estimate
+        // is a stub far below it. Fetch and buffer generously, floor at 15 gwei.
+        const fetched = await publicClient.getGasPrice().catch(() => 0n);
+        gasPrice = fetched * 2n > 15_000_000_000n ? fetched * 2n : 15_000_000_000n;
+        console.log(`\n=== S6-F1 fixed-behavior test on ${networkName} · gasPrice ${gasPrice} ===`);
+
+        // S6F1_FACTORY lets this run against a freshly-deployed (fixed) factory without
+        // clobbering the canonical deployments/<network>.json record.
+        const factoryAddress = process.env.S6F1_FACTORY && isAddress(process.env.S6F1_FACTORY)
+            ? getAddress(process.env.S6F1_FACTORY)
+            : resolveFactoryAddress(networkName);
+        factory = await viemApi.getContractAt("ERC20SPLFactory", factoryAddress);
+        const code = await publicClient.getCode({ address: factoryAddress });
+        assert.ok(code && code !== "0x", `no factory code at ${factoryAddress}`);
+        console.log(`   factory  = ${factoryAddress}`);
+
+        attacker = createWalletClient({
+            account: privateKeyToAccount(generatePrivateKey()),
+            transport: custom((await hardhat.network.connect()).provider),
+        });
+        const bal = await publicClient.getBalance({ address: attacker.account.address });
+        const target = parseUnits("2", 18);
+        if (bal < target / 2n) {
+            const fund = await victim.sendTransaction({ account: victim.account, to: attacker.account.address, value: target, gasPrice });
+            await assertSuccess(publicClient, fund, "fund attacker");
+        }
+        console.log(`   victim   = ${victim.account.address}`);
+        console.log(`   attacker = ${attacker.account.address}`);
+
+        victimPda = await publicClient.readContract({
+            address: HELPER_PROGRAM, abi: HELPER_ABI, functionName: "pda", args: [victim.account.address] }) as `0x${string}`;
+        attackerPda = await publicClient.readContract({
+            address: HELPER_PROGRAM, abi: HELPER_ABI, functionName: "pda", args: [attacker.account.address] }) as `0x${string}`;
+    });
+
+    it("closes the front-run window and the after-init hijack, without breaking the two-step callers", async () => {
+        // [1] mintId is deterministic from (victim, nonce) and PUBLICLY predictable via
+        //     get_current_mint — before the victim ever calls create_token_mint.
+        [mintId] = await factory.read.get_current_mint([victim.account.address]);
+        console.log(`\n[1] victim-derived mint (not yet created) = ${mintId}`);
+
+        // [2] FRONT-RUN ATTEMPT: attacker tries to init a mint that doesn't exist yet.
+        //     Previously create_token_mint left a created-but-uninitialized window to
+        //     race into; now there is no window at all — the account itself doesn't
+        //     exist, so even a same-block init attempt has nothing to act on and reverts.
+        await assertReadReverts(
+            factory.read.init_token_mint([mintId], { account: attacker.account.address }),
+            "ATTACKER init_token_mint(not-yet-created victim mint)");
+
+        // [3] VICTIM creates its mint — create_token_mint now creates AND initializes
+        //     atomically in the same call.
+        await assertSuccess(publicClient,
+            await factory.write.create_token_mint([], { account: victim.account, gasPrice }),
+            "VICTIM create_token_mint");
+
+        let info: any = await publicClient.readContract({
+            address: CPI_PROGRAM, abi: CPI_ABI, functionName: "account_info", args: [mintId] });
+        let data: `0x${string}` = info[5];
+        assert.ok((data.length - 2) / 2 >= 82, "mint account data must be at least 82 bytes");
+        assert.equal(slice(data, 45, 46), "0x01", "mint must already be initialized right after create_token_mint");
+        let onchainAuthority = slice(data, 4, 36);
+        console.log(`[3] mint_authority on-chain = ${onchainAuthority}`);
+        console.log(`    victim PDA              = ${victimPda}`);
+        assert.equal(onchainAuthority.toLowerCase(), victimPda.toLowerCase(), "authority MUST be the victim's PDA");
+
+        // [4] POST-INIT HIJACK ATTEMPT: attacker calls init_token_mint on the now-
+        //     initialized mint. The already-initialized branch is a no-op — it does NOT
+        //     revert, but it also does NOT touch mint_authority or perform any init CPI.
+        await factory.read.init_token_mint([mintId], { account: attacker.account.address });
+        info = await publicClient.readContract({
+            address: CPI_PROGRAM, abi: CPI_ABI, functionName: "account_info", args: [mintId] });
+        onchainAuthority = slice(info[5] as `0x${string}`, 4, 36);
+        console.log(`[4] mint_authority after attacker's no-op call = ${onchainAuthority}`);
+        assert.equal(onchainAuthority.toLowerCase(), victimPda.toLowerCase(), "authority MUST still be the victim's PDA");
+        assert.notEqual(onchainAuthority.toLowerCase(), attackerPda.toLowerCase(), "authority MUST NOT be the attacker's PDA");
+
+        // [5] VICTIM can use the mint normally: register the wrapper and mint to self.
+        const sym = `FIX${Date.now().toString().slice(-6)}`;
+        const wrapperAddress = (await factory.simulate.add_spl_token_no_metadata(
+            [mintId, `Fixed ${sym}`, sym], { account: victim.account })).result as `0x${string}`;
+        await assertSuccess(publicClient,
+            await factory.write.add_spl_token_no_metadata([mintId, `Fixed ${sym}`, sym], { account: victim.account, gasPrice }),
+            "VICTIM add wrapper");
+        const wrapper = await viemApi.getContractAt("SPL_ERC20_cached", wrapperAddress);
+
+        const amount = parseUnits("1000000", 9);
+        await assertSuccess(publicClient,
+            await wrapper.write.mint_to([victim.account.address, amount], { account: victim.account, gasPrice }),
+            "VICTIM mint_to(self)");
+        const victimBal: bigint = await wrapper.read.balanceOf([victim.account.address]);
+        console.log(`[5] victim minted balance = ${victimBal}`);
+        assert.equal(victimBal, amount, "victim must hold the freshly-minted supply");
+
+        // [6] Backward-compat: the VICTIM's OWN init_token_mint on its already-
+        //     initialized mint is also a no-op, not a revert — existing two-step
+        //     callers (create then init) keep working unmodified.
+        await factory.read.init_token_mint([mintId], { account: victim.account.address });
+        console.log(`[6] VICTIM init_token_mint(ownMint) — backward-compat no-op, no revert`);
+
+        console.log(`\n=== S6-F1 FIXED: attacker ${attacker.account.address} could not touch victim ${victim.account.address}'s mint ${mintId} ===\n`);
+    });
+});


### PR DESCRIPTION
## What

`ERC20SPLFactory` created a token mint and set its mint authority in **two** separate permissionless calls — `create_token_mint()` then `init_token_mint(mint)`. Between them the mint account existed but was uninitialized, so a third party could front-run `init_token_mint` on someone else's freshly-created mint and set the mint authority to themselves — seizing issuance of that token and locking the creator out.

## Fix (two surgical edits, `erc20spl_factory.sol` only)

- **`create_token_mint()` is now atomic** — it creates *and* initializes the mint in a single call (`create_and_init_mint`), so there is no uninitialized window and the mint authority is bound to the caller at creation. The derived mint address is unchanged, so existing integrations resolve the same address.
- **`init_token_mint(bytes32)` is now an inert `view`** — it only reads the mint's `is_initialized` byte and requires it to be set (reverts otherwise). It performs no state change, so it can no longer initialize or set authority on any mint. Existing two-step callers keep working: the second call is a successful no-op against the now-already-initialized mint.

Together these close both the front-run window (atomic create) and the exploit primitive itself (the neutered `init` shim).

## Validation

- **Full suite green** — the CI gate reproduced verbatim (321/321), 402 headless tests total, zero regressions; ABI-parity check clean; compiles clean (102 files, solc 0.8.28).
- **Live acceptance test on the Hadrian devnet chain** — against the fixed factory, the attacker front-run reverts, `create_token_mint()` leaves the mint initialized with authority = the creator's derived address, the attacker's post-init call is a no-op that leaves authority unchanged, and the creator mints successfully; the two-step backward-compat path still succeeds. The **same** test run against the prior factory reproduces the created-but-uninitialized precondition (fails at the initialization check), confirming the test discriminates.
- Regression test committed: `tests/erc20spl_factory_hijack.poc.ts`.

## Deploy note

The currently-deployed factory is immutable, so remediating live deployments is a redeploy of this factory + migrating consumers to the new address + an orphaned-mint sweep — tracked and driven separately from this code change.
