### PR TITLE
fix(deploy): rubicon — redeploy ERC20SPLFactory at the #326 fix

### DIFF
--- a/deployments/rubicon.json
+++ b/deployments/rubicon.json
@@ -1,6 +1,6 @@
 {
   "ERC20SPLFactory": {
-    "address": "0x888a485a8338b52f1d24742cb0d98a557f845409",
+    "address": "0xe0501c6c524fea785044a0d1730dec983e34f984",
     "cpiContractAddress": "0xFF00000000000000000000000000000000000008"
   },
   "SPL_ERC20_USDC": {
@@ -28,7 +28,7 @@
     "via": "ERC20SPLFactory.add_spl_token_no_metadata"
   },
   "ERC20Users": {
-    "address": "0x36AE2E5d76BB48E38c192A899C69c9A7525Dddb9",
+    "address": "0xD3649E5125D773a64B2359A636Bc0a74a22b9D50",
     "via": "ERC20SPLFactory.users()"
   },
   "RomeBridgeWithdraw": {


### PR DESCRIPTION
Records the rubicon (7531) redeploy of `ERC20SPLFactory` at the #326 mint-authority front-running fix.

- New factory: `0xe0501c6c524fea785044a0d1730dec983e34f984` (creation tx `0xde7c7596dcd66bc210a503a3db1e4f451e05b3052dd68e76f0a2145738791b3f`, block 438907082, 2026-08-12T23:35:06Z)
- `ERC20Users` follows `factory.users()` → `0xD3649E5125D773a64B2359A636Bc0a74a22b9D50`

Verification: on-chain runtime bytecode is byte-identical to the compiled `8123547` build modulo the four constructor immutables (each value checked: CPI precompile, users, hooked deployer, token-metadata program id); the `init_token_mint(bytes32)` probe reverts on the prior factory and returns cleanly (view) on this one; creation receipt status 1.

The prior factory `0x888a485a8338b52f1d24742cb0d98a557f845409` stays on-chain but is superseded (pre-#326 code). Canonical wrappers are unaffected — they are standalone contracts and keep their original users reference.